### PR TITLE
Updated leader board details

### DIFF
--- a/api/launchpad/launchpad_views.py
+++ b/api/launchpad/launchpad_views.py
@@ -33,7 +33,7 @@ class Leaderboard(APIView):
                 Prefetch(
                     "user_organization_link_user",
                     queryset=UserOrganizationLink.objects.filter(
-                        org__org_type__in=["College", "School", "Company", "Community"]
+                        org__org_type__in=["College", "School", "Company"]
                     ),
                 )
             ).annotate(


### PR DESCRIPTION
In this commit the data retrieved from the user table has been changed from 

**before**
```python
        Prefetch(
                    "user_organization_link_user",
                    queryset=UserOrganizationLink.objects.filter(
                        org__org_type__in=["College", "School", "Company", "Community"]
                    ),
                )
```

**after**
```python
       Prefetch(
                    "user_organization_link_user",
                    queryset=UserOrganizationLink.objects.filter(
                        org__org_type__in=["College", "School", "Company"]
                    ),
                )
                
```

This commit is for  resolving the duplicates being show in the leader board