### PR TITLE
Fixed leaderboard data duplicate issue

### DIFF
--- a/api/launchpad/launchpad_views.py
+++ b/api/launchpad/launchpad_views.py
@@ -9,6 +9,7 @@ from db.user import User
 from db.organization import UserOrganizationLink
 from db.task import KarmaActivityLog
 
+
 class Leaderboard(APIView):
     def get(self, request):
         total_karma_subquery = KarmaActivityLog.objects.filter(
@@ -26,34 +27,32 @@ class Leaderboard(APIView):
         ).values('user')
 
         allowed_org_types = ["College", "School", "Company"]
-        
+
         users = User.objects.filter(
-                karma_activity_log_user__task__event="launchpad",
-                karma_activity_log_user__appraiser_approved=True,
-                id__in=intro_task_completed_users
-            ).prefetch_related(
-                Prefetch(
-                    "user_organization_link_user",
-                    queryset=UserOrganizationLink.objects.filter(
-                        org__org_type__in=allowed_org_types
-                    ),
-                )
-            ).filter(
-                id__in=UserOrganizationLink.objects.filter(
-                    org__org_type__in=allowed_org_types
-                ).values("user")
-            ).annotate(
-                karma=Subquery(total_karma_subquery, output_field=IntegerField()),
-                org=F("user_organization_link_user__org__title"),
-                district_name=F("user_organization_link_user__org__district__name"),
-                state=F("user_organization_link_user__org__district__zone__state__name"),
-                time_=Max("karma_activity_log_user__created_at"),
-            ).order_by("-karma")
-        
+            karma_activity_log_user__task__event="launchpad",
+            karma_activity_log_user__appraiser_approved=True,
+            id__in=intro_task_completed_users
+        ).prefetch_related(
+            Prefetch(
+                "user_organization_link_user",
+                queryset=UserOrganizationLink.objects.filter(org__org_type__in=allowed_org_types),
+            )
+        ).filter(
+            user_organization_link_user__id__in=UserOrganizationLink.objects.filter(
+                org__org_type__in=allowed_org_types
+            ).values("id")
+        ).annotate(
+            karma=Subquery(total_karma_subquery, output_field=IntegerField()),
+            org=F("user_organization_link_user__org__title"),
+            district_name=F("user_organization_link_user__org__district__name"),
+            state=F("user_organization_link_user__org__district__zone__state__name"),
+            time_=Max("karma_activity_log_user__created_at"),
+        ).order_by("-karma")
+
         paginated_queryset = CommonUtils.get_paginated_queryset(
             users,
             request,
-            ["full_name","karma", "org", "district_name", "state"],
+            ["full_name", "karma", "org", "district_name", "state"],
             sort_fields={
                 "karma": "karma",
                 "time_": "time_",

--- a/api/launchpad/launchpad_views.py
+++ b/api/launchpad/launchpad_views.py
@@ -25,15 +25,23 @@ class Leaderboard(APIView):
             task__hashtag='#lp24-introduction',
         ).values('user')
 
-        allowed_org_types = UserOrganizationLink.objects.filter(
-                        org__org_type__in=["College", "School", "Company"])
-                    
-
+        allowed_org_types = ["College", "School", "Company"]
+        
         users = User.objects.filter(
                 karma_activity_log_user__task__event="launchpad",
                 karma_activity_log_user__appraiser_approved=True,
-                id__in=intro_task_completed_users,
-                user_organization_link_org__in=allowed_org_types,
+                id__in=intro_task_completed_users
+            ).prefetch_related(
+                Prefetch(
+                    "user_organization_link_user",
+                    queryset=UserOrganizationLink.objects.filter(
+                        org__org_type__in=allowed_org_types
+                    ),
+                )
+            ).filter(
+                id__in=UserOrganizationLink.objects.filter(
+                    org__org_type__in=allowed_org_types
+                ).values("user")
             ).annotate(
                 karma=Subquery(total_karma_subquery, output_field=IntegerField()),
                 org=F("user_organization_link_user__org__title"),


### PR DESCRIPTION
Fixed issue with duplicate entries in case of multiple organization linked to a user like Community.

Added the following filter to launchpad query
```python
filter(
    user_organization_link_user__id__in=UserOrganizationLink.objects.filter(
        org__org_type__in=allowed_org_types
    ).values("id")
)
```