### PR TITLE
Add Wadhwani College and Zonal Leaderboard API Endpoints

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -15,5 +15,6 @@ urlpatterns = [
     path('top100/', include('api.top100_coders.urls')),
     path('launchpad/', include('api.launchpad.urls')),
     path('donate/', include('api.donate.urls')),
+    path('wadhwani/', include('api.wadhwani.urls')),
     path("__debug__/", include(debug_toolbar.urls)),
 ]

--- a/api/wadhwani/serializers.py
+++ b/api/wadhwani/serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+
+class WadhwaniCollegeLeaderboardSerializer(serializers.Serializer):
+    code = serializers.CharField()
+    title = serializers.CharField()
+    total_karma = serializers.IntegerField()
+    students = serializers.IntegerField()
+
+class WadhwaniZoneLeaderboardSerializer(serializers.Serializer):
+    zone_name = serializers.CharField()
+    total_karma = serializers.IntegerField()
+    students = serializers.IntegerField()

--- a/api/wadhwani/urls.py
+++ b/api/wadhwani/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import wadhwani_views
+
+urlpatterns = [
+    path('college/', wadhwani_views.WadhwaniCollegeLeaderboard.as_view()),
+    path('zonal/', wadhwani_views.WadhwaniZonalLeaderboard.as_view()),
+    
+]

--- a/api/wadhwani/wadhwani_views.py
+++ b/api/wadhwani/wadhwani_views.py
@@ -1,0 +1,108 @@
+from django.db.models import Sum, Count, Q, Value, F
+from django.db.models.functions import Coalesce
+from rest_framework.views import APIView
+
+from db.organization import Organization
+from db.task import TaskList
+from db.user import User
+from utils.response import CustomResponse
+from utils.types import OrganizationType, RoleType
+from .serializers import WadhwaniCollegeLeaderboardSerializer, WadhwaniZoneLeaderboardSerializer
+
+class WadhwaniCollegeLeaderboard(APIView):
+    def get(self, request):
+        wadhwani_hashtags = [
+            "#lp24-interpersonalskills",
+            "#lp24-professional",
+            "#lp24-obtainanappropriatejob",
+            "#ge-speaking-listening",
+            "#ge-problemsolving",
+            "#cl-entrp-customer",
+            "#cl-entrp-mindset",
+            "#cl-entrp-intro",
+        ]
+
+        wadhwani_task_ids = list(TaskList.objects.filter(
+            hashtag__in=wadhwani_hashtags
+        ).values_list("id", flat=True))
+
+
+        college_leaderboard = (
+            Organization.objects.filter(
+                org_type=OrganizationType.COLLEGE.value,
+                user_organization_link_org__user__user_role_link_user__role__title=RoleType.STUDENT.value,
+                user_organization_link_org__user__exist_in_guild=True,
+                user_organization_link_org__user__karma_activity_log_user__task__in=wadhwani_task_ids,
+                user_organization_link_org__user__karma_activity_log_user__appraiser_approved=True,
+            )
+            .annotate(
+                total_karma=Coalesce(
+                    Sum(
+                        "user_organization_link_org__user__karma_activity_log_user__karma",
+                        filter=Q(
+                            user_organization_link_org__user__karma_activity_log_user__task__in=wadhwani_task_ids
+                        ),
+                    ),
+                    Value(0),
+                ),
+                students=Count("user_organization_link_org__user", distinct=True),
+                institution=F("title"),
+            )
+            .values("code", "title", "total_karma", "students")
+            .order_by("-total_karma")[:12]
+        )
+
+        leaderboard_data = WadhwaniCollegeLeaderboardSerializer(college_leaderboard, many=True).data
+        return CustomResponse(response=leaderboard_data).get_success_response()
+
+
+
+class WadhwaniZonalLeaderboard(APIView):
+    def get(self, request):
+        wadhwani_hashtags = [
+            "#lp24-interpersonalskills",
+            "#lp24-professional",
+            "#lp24-obtainanappropriatejob",
+            "#ge-speaking-listening",
+            "#ge-problemsolving",
+            "#cl-entrp-customer",
+            "#cl-entrp-mindset",
+            "#cl-entrp-intro",
+        ]
+
+        wadhwani_task_ids = list(
+            TaskList.objects.filter(hashtag__in=wadhwani_hashtags).values_list("id", flat=True)
+        )
+
+        zone_leaderboard = (
+            Organization.objects.filter(
+                org_type=OrganizationType.COLLEGE.value,
+                user_organization_link_org__user__user_role_link_user__role__title=RoleType.STUDENT.value,
+                user_organization_link_org__user__exist_in_guild=True,
+                user_organization_link_org__user__karma_activity_log_user__task__in=wadhwani_task_ids,
+                user_organization_link_org__user__karma_activity_log_user__appraiser_approved=True,
+            )
+            .annotate(
+                zone_name=F("district__zone__name"),
+                total_karma=Coalesce(
+                    Sum(
+                        "user_organization_link_org__user__karma_activity_log_user__karma",
+                        filter=Q(
+                            user_organization_link_org__user__karma_activity_log_user__task__in=wadhwani_task_ids
+                        ),
+                    ),
+                    Value(0),
+                ),
+                students=Count("user_organization_link_org__user", distinct=True),
+            )
+            .values("zone_name")
+            .annotate(
+                total_karma=F("total_karma"),
+                students=F("students"),
+            )
+            .order_by("-total_karma")
+        )
+
+        response_data = WadhwaniZoneLeaderboardSerializer(zone_leaderboard, many=True).data
+        return CustomResponse(response=response_data).get_success_response()
+


### PR DESCRIPTION
###  Wadhwani Leaderboard APIs

This PR adds two new API endpoints:

- **`/api/v1/wadhwani/college/`** – Returns the top colleges based on total karma and student participation for Wadhwani course tasks.

- **`/api/v1/wadhwani/zonal/`** – Returns a zonal leaderboard aggregating total karma and student count across zones (North, Central, South) for the same hashtag.

Both endpoints filter by:
- ✅ Approved karma logs  
- 🎓 Student role  
- 🟢 Active users in the guild
