### PR TITLE
refractor(api): add task description to profile/get-user-levels/ endpoint

### DIFF
--- a/api/dashboard/profile/profile_serializer.py
+++ b/api/dashboard/profile/profile_serializer.py
@@ -237,6 +237,7 @@ class UserLevelSerializer(serializers.ModelSerializer):
                 "hashtag": task.hashtag,
                 "completed": is_completed,
                 "karma": task.karma,
+                "task_description": task.description
             }
             for task in tasks
             if (is_completed := (task.id in completed_tasks)) or task.active


### PR DESCRIPTION
### Summary
Added the `description` field from the `Task` table to the existing API response.