### PR TITLE
feat(launchpad_companies): add endpoint for company verification

### DIFF
--- a/api/launchpad/launchpad_views.py
+++ b/api/launchpad/launchpad_views.py
@@ -409,6 +409,26 @@ class RefreshTokenAPI(APIView):
             "refreshToken": new_refresh_token
         }).get_success_response()
 
+class CompanyVerifyAPI(APIView):
+    def post(self, request):
+        company_id = request.data.get('id')
+
+        if not company_id:
+            return CustomResponse(general_message="Company ID is required.").get_failure_response()
+
+        try:
+            company = LaunchpadCompanies.objects.get(id=company_id)
+            company.is_verified = True
+            company.save()
+
+            return CustomResponse(response={
+                "company_name": company.name,
+                "message": f"Company '{company.name}' verified successfully."
+            }).get_success_response()
+
+        except LaunchpadCompanies.DoesNotExist:
+            return CustomResponse(general_message="Company not found.").get_failure_response()
+
 
 #<--------------------------------------------------- old launchpad ------------------------------------------------->
 class Leaderboard(APIView):

--- a/api/launchpad/serializers.py
+++ b/api/launchpad/serializers.py
@@ -15,7 +15,7 @@ class LaunchpadCompaniesSerializer(serializers.ModelSerializer):
         model = LaunchpadCompanies
         fields = [
             'id', 'name', 'poc_name', 'poc_role', 'poc_email', 
-            'poc_phone', 'username', 'password', 'created_at', 'updated_at'
+            'poc_phone', 'username', 'password','is_verified', 'created_at', 'updated_at'
         ]
 
 class LaunchpadRecruiterSerializer(serializers.ModelSerializer):

--- a/api/launchpad/urls.py
+++ b/api/launchpad/urls.py
@@ -3,7 +3,7 @@ from . import launchpad_views
 from .launchpad_views import (
     RegisterCompanyAPI, RegisterRecruiterAPI, CompanyListAPI, AddJobAPI, 
     LoginCompanyAPI, LoginRecruiterAPI, GetCompanyInfoAPI, GetRecruiterInfoAPI,
-    RefreshTokenAPI
+    RefreshTokenAPI, CompanyVerifyAPI
 )
 
 urlpatterns = [
@@ -16,6 +16,7 @@ urlpatterns = [
     path('add-job/', AddJobAPI.as_view()),
     path('company-info/', GetCompanyInfoAPI.as_view()),
     path('recruiter-info/', GetRecruiterInfoAPI.as_view()),
+    path('company-verify/', CompanyVerifyAPI.as_view()),
 
     #<----------------------- old launchpad -------------------------->
     path("leaderboard/", launchpad_views.Leaderboard.as_view()),

--- a/db/launchpad.py
+++ b/db/launchpad.py
@@ -12,6 +12,7 @@ class LaunchpadCompanies(models.Model):
     poc_phone = models.CharField(max_length=20)
     username = models.CharField(max_length=50, unique=True)
     password = models.CharField(max_length=255)
+    is_verified = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
###  New Endpoint: Company Verification API

####  Endpoint
`POST /api/v1/launchpad/company-verify/`

####  Summary
Introduces a new API endpoint to verify companies by setting the `is_verified` flag to `true` in the `launchpad_companies` table.

####  Functionality
- Accepts a JSON payload with the company `id`.
- Updates the corresponding company's `is_verified` status to `true`.
- Returns a success response with the verified company's name.
- Handles errors such as missing ID or company not found.

####  Request Example
```json
POST /api/v1/launchpad/company-verify/
Content-Type: application/json

{
  "id": "company-uuid-1234"
}
