### PR TITLE
[Enhancement] Increase max_length of description field in TaskList model to 65535 characters

### DIFF
--- a/db/task.py
+++ b/db/task.py
@@ -106,7 +106,7 @@ class TaskList(models.Model):
     hashtag = models.CharField(max_length=75)
     discord_link = models.CharField(max_length=200, blank=True, null=True)
     title = models.CharField(max_length=75)
-    description = models.CharField(max_length=200, null=True)
+    description = models.CharField(max_length=65535, null=True)
     karma = models.IntegerField(null=True)
     channel = models.ForeignKey(Channel, on_delete=models.CASCADE, null=True)
     type = models.ForeignKey(TaskType, on_delete=models.CASCADE)


### PR DESCRIPTION
This pull request updates the TaskList Django model by increasing the max_length of the description field from 200 to 65535 characters.

- The change allows much longer descriptions for tasks in the task_list table.
- No changes were made to other fields or business logic.