### PR TITLE
[Enhancement] Adding active field in /get-user-levels api response

### DIFF
--- a/api/dashboard/profile/profile_serializer.py
+++ b/api/dashboard/profile/profile_serializer.py
@@ -235,6 +235,7 @@ class UserLevelSerializer(serializers.ModelSerializer):
                 "task_name": task.title,
                 "discord_link": task.discord_link,
                 "hashtag": task.hashtag,
+                "active": task.active,
                 "completed": is_completed,
                 "karma": task.karma,
                 "task_description": task.description


### PR DESCRIPTION
This pull request enhances the /get-user-levels API by including an active field in its response.

- The new active field allows clients to determine the active status of user levels directly from the API response.
- No changes are made to the request payload or logic, only the response structure is updated.
