### PR TITLE
[BUG] Ensure μID generation checks include suspended users

### DIFF
--- a/api/register/register_helper.py
+++ b/api/register/register_helper.py
@@ -13,7 +13,8 @@ def generate_muid(full_name):
     muid = f"{full_name}@mulearn"
 
     counter = 0
-    while User.objects.filter(muid=muid).exists():
+
+    while User.every.filter(muid=muid).exists():
         counter += 1
         muid = f"{full_name}-{counter}@mulearn"
 


### PR DESCRIPTION
Summary

Fix μID collision during registration by checking the model's non-filtering manager [User.every] when detecting existing μIDs. This prevents generating a μID that already exists on suspended/soft-deleted users.
Problem

The app previously used User.objects.filter(muid=...) inside μID generation. User.objects is an ActiveUserManager that filters out suspended or soft-deleted users. That allowed generating μIDs that already exist for suspended users, which led to collisions / unexpected IntegrityErrors at save time.
