### PR TITLE
feat(dashboard): added endpoints for managing Events and Categories

### DIFF
--- a/api/dashboard/category/category_serializer.py
+++ b/api/dashboard/category/category_serializer.py
@@ -14,11 +14,7 @@ class CategoryListSerializer(serializers.ModelSerializer):
 class CategoryCUDSerializer(serializers.ModelSerializer):
     class Meta:
         model= Category
-        fields= '__all__'
-        extra_kwargs = {
-            'created_by': {'required': False},
-            'updated_by': {'required': False},
-        }
+        fields= ['name', 'description', 'entity_id', 'entity_type']
 
     def create(self, validated_data):
         user_id = self.context.get("user_id")

--- a/api/dashboard/category/category_serializer.py
+++ b/api/dashboard/category/category_serializer.py
@@ -13,8 +13,9 @@ class CategoryListSerializer(serializers.ModelSerializer):
 
 class CategoryCUDSerializer(serializers.ModelSerializer):
     class Meta:
-        model= Category
-        fields= ['name', 'description', 'entity_id', 'entity_type']
+        model = Category
+        fields = ["name", "description", "entity_id", "entity_type"]
+        read_only_fields = ["id", "created_by", "updated_by", "created_at", "updated_at"]
 
     def create(self, validated_data):
         user_id = self.context.get("user_id")

--- a/api/dashboard/category/category_serializer.py
+++ b/api/dashboard/category/category_serializer.py
@@ -1,0 +1,35 @@
+from rest_framework import serializers
+from db.task import Category
+
+
+class CategoryListSerializer(serializers.ModelSerializer):
+    created_by = serializers.CharField(source="created_by.full_name", read_only=True)
+    updated_by = serializers.CharField(source="updated_by.full_name", read_only=True)
+
+
+    class Meta:
+        model= Category
+        fields= '__all__'
+
+class CategoryCUDSerializer(serializers.ModelSerializer):
+    class Meta:
+        model= Category
+        fields= '__all__'
+        extra_kwargs = {
+            'created_by': {'required': False},
+            'updated_by': {'required': False},
+        }
+
+    def create(self, validated_data):
+        user_id = self.context.get("user_id")
+        validated_data['created_by_id'] = user_id
+        validated_data['updated_by_id'] = user_id
+        return Category.objects.create(**validated_data)
+
+    def update(self, instance, validated_data):
+        user_id = self.context.get("user_id")
+        instance.updated_by_id = user_id
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+        return instance

--- a/api/dashboard/category/category_views.py
+++ b/api/dashboard/category/category_views.py
@@ -1,10 +1,13 @@
 from db.task import Category
 from rest_framework.views import APIView
-from utils.permission import JWTUtils
+from utils.permission import JWTUtils, CustomizePermission
 from utils.response import CustomResponse
 from .category_serializer import CategoryListSerializer, CategoryCUDSerializer
+from utils.types import RoleType
+from utils.permission import role_required
 
 class CategoryAPI(APIView):
+    authentication_classes = [CustomizePermission]
     def get(self, request, category_id=None):
         if category_id:
             category = Category.objects.filter(id=category_id).first()
@@ -19,6 +22,11 @@ class CategoryAPI(APIView):
         serializer = CategoryListSerializer(category, many=True)
         return CustomResponse(response=serializer.data).get_success_response()
 
+    @role_required(
+        [
+            RoleType.ADMIN.value,
+        ]
+    )
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         serializer = CategoryCUDSerializer(
@@ -35,6 +43,11 @@ class CategoryAPI(APIView):
             general_message=serializer.errors,
         ).get_failure_response()
 
+    @role_required(
+        [
+            RoleType.ADMIN.value,
+        ]
+    )
     def put(self, request, category_id):
         user_id = JWTUtils.fetch_user_id(request)
         category = Category.objects.filter(id=category_id).first()
@@ -57,6 +70,11 @@ class CategoryAPI(APIView):
             general_message=serializer.errors,
         ).get_failure_response()
 
+    @role_required(
+        [
+            RoleType.ADMIN.value,
+        ]
+    )
     def patch(self, request, category_id):
         user_id = JWTUtils.fetch_user_id(request)
         category = Category.objects.filter(id=category_id).first()
@@ -80,6 +98,11 @@ class CategoryAPI(APIView):
             general_message=serializer.errors,
         ).get_failure_response()
 
+    @role_required(
+        [
+            RoleType.ADMIN.value,
+        ]
+    )
     def delete(self, request, category_id):
         category = Category.objects.filter(id=category_id).first()
         if not category:

--- a/api/dashboard/category/category_views.py
+++ b/api/dashboard/category/category_views.py
@@ -1,0 +1,92 @@
+from db.task import Category
+from rest_framework.views import APIView
+from utils.permission import JWTUtils
+from utils.response import CustomResponse
+from .category_serializer import CategoryListSerializer, CategoryCUDSerializer
+
+class CategoryAPI(APIView):
+    def get(self, request, category_id=None):
+        if category_id:
+            category = Category.objects.filter(id=category_id).first()
+            if not category:
+                return CustomResponse(
+                    general_message='Invalid Category id'
+                ).get_failure_response()
+            serializer = CategoryListSerializer(category)
+            return CustomResponse(response=serializer.data).get_success_response()
+        
+        category = Category.objects.all()
+        serializer = CategoryListSerializer(category, many=True)
+        return CustomResponse(response=serializer.data).get_success_response()
+
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        serializer = CategoryCUDSerializer(
+            data=request.data,
+            context={'user_id': user_id}
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message='Category created successfully',
+                response=serializer.data
+            ).get_success_response()
+        return CustomResponse(
+            general_message=serializer.errors,
+        ).get_failure_response()
+
+    def put(self, request, category_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        category = Category.objects.filter(id=category_id).first()
+        if not category:
+            return CustomResponse(
+                general_message='Invalid Category id'
+            ).get_failure_response()
+        serializer = CategoryCUDSerializer(
+            category,
+            data=request.data,
+            context={'user_id': user_id}
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message='Category updated successfully',
+                response=serializer.data
+            ).get_success_response()
+        return CustomResponse(
+            general_message=serializer.errors,
+        ).get_failure_response()
+
+    def patch(self, request, category_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        category = Category.objects.filter(id=category_id).first()
+        if not category:
+            return CustomResponse(
+                general_message='Invalid Category id'
+            ).get_failure_response()
+        serializer = CategoryCUDSerializer(
+            category,
+            data=request.data,
+            context={'user_id': user_id},
+            partial=True
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message='Category updated successfully',
+                response=serializer.data
+            ).get_success_response()
+        return CustomResponse(
+            general_message=serializer.errors,
+        ).get_failure_response()
+
+    def delete(self, request, category_id):
+        category = Category.objects.filter(id=category_id).first()
+        if not category:
+            return CustomResponse(
+                general_message='Invalid Category id'
+            ).get_failure_response()
+        category.delete()
+        return CustomResponse(
+            general_message='Category deleted successfully'
+        ).get_success_response()

--- a/api/dashboard/category/category_views.py
+++ b/api/dashboard/category/category_views.py
@@ -5,6 +5,7 @@ from utils.response import CustomResponse
 from .category_serializer import CategoryListSerializer, CategoryCUDSerializer
 from utils.types import RoleType
 from utils.permission import role_required
+from utils.utils import CommonUtils
 
 class CategoryAPI(APIView):
     authentication_classes = [CustomizePermission]
@@ -19,8 +20,16 @@ class CategoryAPI(APIView):
             return CustomResponse(response=serializer.data).get_success_response()
         
         category = Category.objects.all()
-        serializer = CategoryListSerializer(category, many=True)
-        return CustomResponse(response=serializer.data).get_success_response()
+        paginated_queryset = CommonUtils.get_paginated_queryset(
+            category,
+            request,
+            ['name']
+        )
+        serializer = CategoryListSerializer(paginated_queryset.get("queryset"), many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated_queryset.get("pagination")
+        )
 
     @role_required(
         [

--- a/api/dashboard/category/urls.py
+++ b/api/dashboard/category/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from . import category_views
+
+urlpatterns = [
+    path('', category_views.CategoryAPI.as_view()),
+    path('<str:category_id>/', category_views.CategoryAPI.as_view()),
+]

--- a/api/dashboard/events/events_serializer.py
+++ b/api/dashboard/events/events_serializer.py
@@ -31,6 +31,9 @@ class EventsCUDSerializer(serializers.ModelSerializer):
             'link': {'required': False, 'allow_null': True},
             'category': {'required': False, 'allow_null': True},
         }
+        read_only_fields = [
+            'id', 'slug', 'created_by', 'updated_by', 'created_at', 'updated_at'
+        ]
 
     def create(self, validated_data):
         user_id = self.context.get("user_id")

--- a/api/dashboard/events/events_serializer.py
+++ b/api/dashboard/events/events_serializer.py
@@ -1,12 +1,12 @@
 import uuid
 from rest_framework import serializers
+from django.utils.text import slugify
 from db.task import Events
 from utils.utils import DateTimeUtils
 
-
 class EventsListSerializer(serializers.ModelSerializer):
-    created_by = serializers.CharField(source="created_by.full_name")
-    updated_by = serializers.CharField(source="updated_by.full_name")
+    created_by = serializers.CharField(source="created_by.full_name", read_only=True)
+    updated_by = serializers.CharField(source="updated_by.full_name", read_only=True)
 
     class Meta:
         model = Events
@@ -14,26 +14,46 @@ class EventsListSerializer(serializers.ModelSerializer):
 
 
 class EventsCUDSerializer(serializers.ModelSerializer):
+
+    tag = serializers.JSONField(source='tags', required=False, allow_null=True)
+
     class Meta:
         model = Events
-        fields = ['name', 'description']
+        fields = [
+            'name', 'description', 'registration_start_date', 'registration_end_date',
+            'event_start_date', 'event_end_date', 'event_start_time', 'event_end_time',
+            'user_limit', 'event_type', 'ticket_type', 'cover_image',
+            'location_name', 'location_address', 'ticket_value', 'link', 'tag',
+            'category'
+        ]
+        extra_kwargs = {
+            'ticket_value': {'required': False},
+            'link': {'required': False, 'allow_null': True},
+            'category': {'required': False, 'allow_null': True},
+        }
 
     def create(self, validated_data):
         user_id = self.context.get("user_id")
-
+        
+        validated_data["id"] = str(uuid.uuid4())
         validated_data["created_by_id"] = user_id
         validated_data["updated_by_id"] = user_id
-        validated_data["id"] = uuid.uuid4()
+        validated_data['slug'] = slugify(validated_data.get('name'))
+        validated_data['status'] = 'request'
+        
         return Events.objects.create(**validated_data)
 
     def update(self, instance, validated_data):
         user_id = self.context.get("user_id")
 
-        instance.name = validated_data.get("name", instance.name)
-        instance.description = validated_data.get(
-            "description", instance.description)
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+
+        if 'name' in validated_data:
+            instance.slug = slugify(validated_data['name'])
+        
         instance.updated_by_id = user_id
         instance.updated_at = DateTimeUtils.get_current_utc_time()
+        
         instance.save()
-
         return instance

--- a/api/dashboard/events/events_serializer.py
+++ b/api/dashboard/events/events_serializer.py
@@ -39,7 +39,7 @@ class EventsCUDSerializer(serializers.ModelSerializer):
         validated_data["created_by_id"] = user_id
         validated_data["updated_by_id"] = user_id
         validated_data['slug'] = slugify(validated_data.get('name'))
-        validated_data['status'] = 'request'
+        validated_data['status'] = Events.Status.REQUEST.value
         
         return Events.objects.create(**validated_data)
 

--- a/api/dashboard/events/events_views.py
+++ b/api/dashboard/events/events_views.py
@@ -21,7 +21,7 @@ class EventAPI(APIView):
             serializer = EventsListSerializer(events)
             return CustomResponse(response=serializer.data).get_success_response()
         
-        events = Events.objects.all()
+        events = Events.objects.exclude(status=Events.Status.CANCELLED.value)
         paginated_queryset = CommonUtils.get_paginated_queryset(
             events,
             request,
@@ -147,7 +147,7 @@ class EventAPI(APIView):
                 general_message="Invalid event id"
             ).get_failure_response()
 
-        events.status = 'cancelled'
+        events.status = Events.Status.CANCELLED.value
         events.save()
 
         return CustomResponse(

--- a/api/dashboard/events/events_views.py
+++ b/api/dashboard/events/events_views.py
@@ -5,7 +5,8 @@ from utils.permission import CustomizePermission, JWTUtils
 from utils.response import CustomResponse
 from utils.utils import CommonUtils
 from .events_serializer import EventsCUDSerializer, EventsListSerializer
-
+from utils.types import RoleType
+from utils.permission import role_required
 
 class EventAPI(APIView):
     authentication_classes = [CustomizePermission]
@@ -38,6 +39,12 @@ class EventAPI(APIView):
                 "pagination"
             )
         )
+    
+    @role_required(
+        [
+            RoleType.ADMIN.value,
+        ]
+    )
 
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
@@ -61,6 +68,11 @@ class EventAPI(APIView):
             general_message=serializer.errors,
         ).get_failure_response()
 
+    @role_required(
+        [
+            RoleType.ADMIN.value,
+        ]
+    )
     def put(self, request, event_id):
         user_id = JWTUtils.fetch_user_id(request)
 
@@ -88,6 +100,11 @@ class EventAPI(APIView):
             message=serializer.errors
         ).get_failure_response()
 
+    @role_required(
+        [
+            RoleType.ADMIN.value,
+        ]
+    )
     def patch(self,request, event_id):
         user_id = JWTUtils.fetch_user_id(request)
 
@@ -116,6 +133,11 @@ class EventAPI(APIView):
             message=serializer.errors
         ).get_failure_response()
 
+    @role_required(
+        [
+            RoleType.ADMIN.value,
+        ]
+    )
     def delete(self, request, event_id):
 
         events = Events.objects.filter(id=event_id).first()

--- a/api/dashboard/events/events_views.py
+++ b/api/dashboard/events/events_views.py
@@ -10,7 +10,16 @@ from .events_serializer import EventsCUDSerializer, EventsListSerializer
 class EventAPI(APIView):
     authentication_classes = [CustomizePermission]
 
-    def get(self, request):
+    def get(self, request, event_id=None):
+        if event_id:
+            events = Events.objects.filter(id=event_id).first()
+            if not events:
+                return CustomResponse(
+                    general_message="Invalid Event id"
+                ).get_failure_response()
+            serializer = EventsListSerializer(events)
+            return CustomResponse(response=serializer.data).get_success_response()
+        
         events = Events.objects.all()
         paginated_queryset = CommonUtils.get_paginated_queryset(
             events,
@@ -79,6 +88,34 @@ class EventAPI(APIView):
             message=serializer.errors
         ).get_failure_response()
 
+    def patch(self,request, event_id):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        events = Events.objects.filter(id=event_id).first()
+
+        if events is None:
+            return CustomResponse(
+                general_message="Invalid Event id"
+            ).get_failure_response()
+
+        serializer = EventsCUDSerializer(
+            events,
+            data=request.data,
+            partial=True,
+            context={"user_id": user_id}
+        )
+
+        if serializer.is_valid():
+            serializer.save()
+
+            return CustomResponse(
+                general_message=f"{events.name} Edited Successfully"
+            ).get_success_response()
+
+        return CustomResponse(
+            message=serializer.errors
+        ).get_failure_response()
+
     def delete(self, request, event_id):
 
         events = Events.objects.filter(id=event_id).first()
@@ -88,8 +125,9 @@ class EventAPI(APIView):
                 general_message="Invalid event id"
             ).get_failure_response()
 
-        events.delete()
+        events.status = 'cancelled'
+        events.save()
 
         return CustomResponse(
-            general_message=f"{events.name} Deleted Successfully"
+            general_message=f"{events.name} Status changed to Cancelled"
         ).get_success_response()

--- a/api/dashboard/events/urls.py
+++ b/api/dashboard/events/urls.py
@@ -5,5 +5,4 @@ from . import events_views
 urlpatterns = [
     path('', events_views.EventAPI.as_view()),
     path('<str:event_id>/', events_views.EventAPI.as_view()),
-    
 ]

--- a/api/dashboard/task/dash_task_serializer.py
+++ b/api/dashboard/task/dash_task_serializer.py
@@ -106,6 +106,7 @@ class TaskModifySerializer(serializers.ModelSerializer):
             "created_by",
             "bonus_karma",
             "bonus_time",
+            "event_id",
         )
 
 

--- a/api/dashboard/task/dash_task_serializer.py
+++ b/api/dashboard/task/dash_task_serializer.py
@@ -29,6 +29,7 @@ class TaskListPublicSerializer(serializers.ModelSerializer):
             "level",
             "ig",
             "event",
+            "event_id",
         ]
 
 
@@ -62,6 +63,7 @@ class TaskListSerializer(serializers.ModelSerializer):
             "org",
             "ig",
             "event",
+            "event_id",
             "updated_at",
             "updated_by",
             "created_by",

--- a/api/dashboard/urls.py
+++ b/api/dashboard/urls.py
@@ -27,5 +27,5 @@ urlpatterns = [
     path("projects/", include("api.dashboard.projects.urls")),
     path("achievement/", include("api.dashboard.achievement.urls")),
     path("skill/", include("api.dashboard.skill.urls")),
-    path('category/', include('api.dashboard.category.urls'))
+    path("category/", include("api.dashboard.category.urls"))
 ]

--- a/api/dashboard/urls.py
+++ b/api/dashboard/urls.py
@@ -27,4 +27,5 @@ urlpatterns = [
     path("projects/", include("api.dashboard.projects.urls")),
     path("achievement/", include("api.dashboard.achievement.urls")),
     path("skill/", include("api.dashboard.skill.urls")),
+    path('category/', include('api.dashboard.category.urls'))
 ]

--- a/db/task.py
+++ b/db/task.py
@@ -300,14 +300,9 @@ class Category(models.Model):
     class Meta:
         managed = False
         db_table = "categories"
-
         indexes = [
             models.Index(fields=['entity_id', 'entity_type'], name='idx_categories_entity'),
         ]
-
-    class Meta:
-        managed = False
-        db_table = "categories"
 
 
         

--- a/db/task.py
+++ b/db/task.py
@@ -133,6 +133,7 @@ class TaskList(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     created_by = models.ForeignKey(User, models.DO_NOTHING, db_column="created_by", related_name="task_list_created_by")
     created_at = models.DateTimeField(auto_now_add=True)
+    event_id = models.CharField(max_length=36, null=True)
 
     class Meta:
         managed = False

--- a/db/task.py
+++ b/db/task.py
@@ -282,11 +282,82 @@ class VoucherLog(models.Model):
         managed = False
         db_table = "voucher_log"
 
+class Category(models.Model):
 
+    class EntityType(models.TextChoices):
+        EVENT = 'event', 'Event'
+
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    name = models.CharField(max_length=255)
+    description = models.TextField(null=True, blank=True)
+    entity_id = models.CharField(max_length=36)
+    entity_type = models.CharField(max_length=20, choices=EntityType.choices)
+    created_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="created_by", related_name="category_created_by")
+    updated_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="updated_by", related_name="category_updated_by")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    class Meta:
+        managed = False
+        db_table = "categories"
+
+        indexes = [
+            models.Index(fields=['entity_id', 'entity_type'], name='idx_categories_entity'),
+        ]
+
+    class Meta:
+        managed = False
+        db_table = "categories"
+
+
+        
 class Events(models.Model):
-    id          = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
-    name        = models.CharField(max_length=75)
-    description = models.CharField(max_length=200, null=True)
+
+    class Status(models.TextChoices):
+        UPCOMING = 'upcoming', 'Upcoming'
+        ONGOING = 'ongoing', 'Ongoing'
+        COMPLETED = 'completed', 'Completed'
+        CANCELLED = 'cancelled', 'Cancelled'
+        REQUEST = 'request', 'Request'
+
+    class EventType(models.TextChoices):
+        ONLINE = 'online', 'Online'
+        OFFLINE = 'offline', 'Offline'
+        HYBRID = 'hybrid', 'Hybrid'
+
+    class TicketType(models.TextChoices):
+        KARMA = 'karma', 'Karma'
+        PAID = 'paid', 'Paid'
+        FREE = 'free', 'Free'
+
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    name = models.CharField(max_length=75)
+    description = models.CharField(max_length=200, null=True, blank=True)
+    slug = models.CharField(max_length=255)
+    registration_start_date = models.DateTimeField()
+    registration_end_date = models.DateTimeField()
+    event_start_date = models.DateField()
+    event_end_date = models.DateField()
+    event_start_time = models.TimeField()
+    event_end_time = models.TimeField()
+    user_limit = models.IntegerField(default=0)
+    status = models.CharField(max_length=20, choices=Status.choices)
+    event_type = models.CharField(max_length=20, choices=EventType.choices)
+    ticket_type = models.CharField(max_length=20, choices=TicketType.choices)   
+    cover_image = models.CharField(max_length=512, null=True, blank=True)   
+    location_name = models.CharField(max_length=255, null=True, blank=True)
+    location_address = models.TextField(null=True, blank=True)
+    ticket_value = models.DecimalField(max_digits=10, decimal_places=2, default=0.00)
+    link = models.CharField(max_length=255, null=True, blank=True)
+    tags = models.JSONField(null=True, blank=True)
+    
+    category = models.ForeignKey(
+        'Category', 
+        on_delete=models.SET_NULL, 
+        null=True, 
+        db_column='category_id',
+        related_name='events'
+    )
+
     updated_by  = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="updated_by", related_name="event_updated_by")
     updated_at  = models.DateTimeField(auto_now=True)
     created_by  = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="created_by", related_name="event_created_by")
@@ -295,7 +366,6 @@ class Events(models.Model):
     class Meta:
         managed = False
         db_table = "events"
-
 
 class TaskReport(models.Model):
     id = models.CharField(primary_key=True, max_length=36)


### PR DESCRIPTION
This code adds full **CRUD (Create, Read, Update, Delete)** management for **Events** and **Categories** in the dashboard. It also introduces **`event_id` support** in the Task management APIs.

---

## New API Endpoints

### Category Management

* **GET** `/api/dashboard/category/` – List all categories
* **GET** `/api/dashboard/category/<category_id>/` – Retrieve category details
* **POST** `/api/dashboard/category/` – Create a new category
* **PUT** `/api/dashboard/category/<category_id>/` – Update a category
* **PATCH** `/api/dashboard/category/<category_id>/` – Partially update a category
* **DELETE** `/api/dashboard/category/<category_id>/` – Delete a category

---

### Event Management

* **GET** `/api/dashboard/events/` – List all events
* **GET** `/api/dashboard/events/<event_id>/` – Retrieve event details
* **POST** `/api/dashboard/events/` – Create a new event
* **PUT** `/api/dashboard/events/<event_id>/` – Update an event
* **PATCH** `/api/dashboard/events/<event_id>/` – Partially update an event
* **DELETE** `/api/dashboard/events/<event_id>/` – Delete an event (soft delete)

---

## Updated Task Endpoints

* **POST** `/api/dashboard/task/` – Accepts `event_id` in the request body
* **PUT** `/api/dashboard/task/<task_id>/` – Accepts `event_id` for task updates
* **GET** `/api/dashboard/task/<task_id>/` – Returns associated `event_id`
