### PR TITLE
Add Interest Group Request Management System

### DIFF
--- a/api/dashboard/ig/dash_ig_serializer.py
+++ b/api/dashboard/ig/dash_ig_serializer.py
@@ -12,6 +12,9 @@ class InterestGroupSerializer(serializers.ModelSerializer):
     category = serializers.ChoiceField(
         choices=["maker", "coder", "creative", "manager", "others"]
     )
+    status = serializers.ChoiceField(
+        choices=["active", "requested", "cancelled", "rejected"]
+    )
 
     class Meta:
         model = InterestGroup
@@ -31,6 +34,7 @@ class InterestGroupSerializer(serializers.ModelSerializer):
             "icon",
             "code",
             "category",
+            "status",
             "members",
             "updated_by",
             "updated_at",
@@ -74,6 +78,7 @@ class InterestGroupCreateUpdateSerializer(serializers.ModelSerializer):
             "name",
             "code",
             "category",
+            "status",
             "icon",
             "about",
             "prerequisites",
@@ -88,3 +93,32 @@ class InterestGroupCreateUpdateSerializer(serializers.ModelSerializer):
             "created_by",
             "updated_by",
         ]
+
+
+class InterestGroupRequestSerializer(serializers.ModelSerializer):
+    """Serializer for user-submitted IG creation requests."""
+    
+    class Meta:
+        model = InterestGroup
+        fields = [
+            "name",
+            "code",
+            "category",
+            "icon",
+            "about",
+            "prerequisites",
+            "career_opportunities",
+            "resource",
+            "top_blogs",
+            "people_to_follow",
+            "leads",
+            "mentors",
+            "thinktank",
+            "office_hours",
+        ]
+        extra_kwargs = {
+            "name": {"required": True},
+            "code": {"required": True},
+            "category": {"required": True},
+            "icon": {"required": True},
+        }

--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -10,6 +10,7 @@ from utils.utils import CommonUtils, DiscordWebhooks
 from .dash_ig_serializer import (
     InterestGroupSerializer,
     InterestGroupCreateUpdateSerializer,
+    InterestGroupRequestSerializer,
 )
 import json
 from django.utils.decorators import method_decorator
@@ -324,6 +325,159 @@ class InterestGroupGetAPI(APIView):
             return CustomResponse(response={"interestGroup": serializer.data}).get_success_response()
 
         return CustomResponse(message=serializer.errors).get_failure_response()
+
+
+class InterestGroupRequestAPI(APIView):
+    """API endpoint for users to submit and retrieve IG creation requests."""
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value, RoleType.COMPANY.value])
+    def get(self, request):
+        """Retrieve Interest Group requests created by a company user.
+        
+        Query Parameters:
+            - user_id (optional): Filter by specific company user ID. 
+              If not provided, defaults to the authenticated user's ID.
+              Only admins can query other users' requests.
+            - status (optional): Filter by IG status (requested, active, rejected, cancelled)
+        """
+        user_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+        target_user_id = request.query_params.get('user_id')
+        status_filter = request.query_params.get('status')
+        is_admin = RoleType.ADMIN.value in roles
+
+        ig_queryset = InterestGroup.objects.select_related(
+            "created_by", "updated_by"
+        ).prefetch_related(
+            "user_ig_link_ig"
+        )
+        
+        if target_user_id:
+            if target_user_id != user_id and not is_admin:
+                return CustomResponse(
+                    general_message="You can only view your own IG requests"
+                ).get_failure_response()
+            ig_queryset = ig_queryset.filter(created_by_id=target_user_id)
+        else:
+            if not is_admin:
+                ig_queryset = ig_queryset.filter(created_by_id=user_id)
+
+        if status_filter:
+            valid_statuses = ['active', 'requested', 'cancelled', 'rejected']
+            if status_filter not in valid_statuses:
+                return CustomResponse(
+                    general_message=f"Invalid status. Must be one of: {', '.join(valid_statuses)}"
+                ).get_failure_response()
+            ig_queryset = ig_queryset.filter(status=status_filter)
+
+        paginated_queryset = CommonUtils.get_paginated_queryset(
+            ig_queryset,
+            request,
+            ["name", "code", "category"],
+            {
+                "name": "name",
+                "status": "status",
+                "created_on": "created_at",
+                "updated_on": "updated_at",
+            },
+        )
+
+        ig_serializer_data = InterestGroupSerializer(
+            paginated_queryset.get("queryset"), many=True
+        ).data
+        
+        return CustomResponse().paginated_response(
+            data=ig_serializer_data, 
+            pagination=paginated_queryset.get("pagination")
+        )
+
+    @role_required([RoleType.ADMIN.value, RoleType.COMPANY.value])
+    def post(self, request):
+        """Submit a new Interest Group creation request."""
+        user_id = JWTUtils.fetch_user_id(request)
+
+        request_data = request.data.copy()
+
+        for fld in [
+            "prerequisites",
+            "career_opportunities",
+            "top_blogs",
+            "people_to_follow",
+            "leads",
+            "mentors",
+        ]:
+            if fld in request_data and not isinstance(request_data.get(fld), str):
+                try:
+                    request_data[fld] = json.dumps(request_data.get(fld))
+                except Exception:
+                    pass
+
+        request_data["created_by"] = request_data["updated_by"] = user_id
+        request_data["status"] = "requested"
+
+        serializer = InterestGroupRequestSerializer(data=request_data)
+
+        if serializer.is_valid():
+            ig_instance = serializer.save(
+                created_by_id=user_id,
+                updated_by_id=user_id,
+                status="requested"
+            )
+            response_serializer = InterestGroupSerializer(ig_instance)
+            
+            return CustomResponse(
+                response={"interestGroup": response_serializer.data},
+                general_message="Interest Group request submitted successfully. It will be reviewed by admins."
+            ).get_success_response()
+
+        return CustomResponse(
+            general_message=serializer.errors
+        ).get_failure_response()
+
+    @role_required([RoleType.ADMIN.value])
+    def patch(self, request, pk):
+        """Update Interest Group request status (Admin only).
+        
+        Allowed status transitions:
+            - requested → active
+            - requested → rejected
+            - requested → cancelled
+            - any status → any status (admin override)
+        """
+        user_id = JWTUtils.fetch_user_id(request)
+        
+        try:
+            ig = InterestGroup.objects.get(id=pk)
+        except InterestGroup.DoesNotExist:
+            return CustomResponse(
+                general_message="Interest Group not found"
+            ).get_failure_response()
+
+        new_status = request.data.get('status')
+
+        valid_statuses = ['active', 'requested', 'cancelled', 'rejected']
+        if not new_status:
+            return CustomResponse(
+                general_message="Status field is required"
+            ).get_failure_response()
+        
+        if new_status not in valid_statuses:
+            return CustomResponse(
+                general_message=f"Invalid status. Must be one of: {', '.join(valid_statuses)}"
+            ).get_failure_response()
+
+        ig.status = new_status
+        ig.updated_by_id = user_id
+        ig.save()
+
+        response_serializer = InterestGroupSerializer(ig)
+        
+        return CustomResponse(
+            response={"interestGroup": response_serializer.data},
+            general_message=f"Interest Group status updated to '{new_status}'"
+        ).get_success_response()
+
 
 
 class InterestGroupListApi(APIView):

--- a/api/dashboard/ig/urls.py
+++ b/api/dashboard/ig/urls.py
@@ -4,6 +4,8 @@ from . import dash_ig_view
 
 urlpatterns = [
     path('', dash_ig_view.InterestGroupAPI.as_view()),  # for get data and create new interest groups
+    path('request/', dash_ig_view.InterestGroupRequestAPI.as_view()),  # for submitting IG creation requests
+    path('request/<str:pk>/', dash_ig_view.InterestGroupRequestAPI.as_view()),  # for updating IG request status
     path('list/', dash_ig_view.InterestGroupListApi.as_view()),  # for public listing without admin permission
     path('csv/', dash_ig_view.InterestGroupCSV.as_view()),  # for IG data CSV download
     path('<str:pk>/', dash_ig_view.InterestGroupAPI.as_view()),  # for edit and delete

--- a/db/task.py
+++ b/db/task.py
@@ -41,6 +41,18 @@ class InterestGroup(models.Model):
     code = models.CharField(max_length=10, unique=True)
     icon = models.CharField(max_length=10)
     category =models.CharField(max_length=20,default="others",blank=False,null=False)
+    status = models.CharField(
+        max_length=20,
+        choices=[
+            ('active', 'Active'),
+            ('requested', 'Requested'),
+            ('cancelled', 'Cancelled'),
+            ('rejected', 'Rejected'),
+        ],
+        default='requested',
+        blank=False,
+        null=False
+    )
     about = models.TextField(blank=True, null=True)
     prerequisites = models.TextField(blank=True, null=True)
     career_opportunities = models.TextField(blank=True, null=True)

--- a/utils/types.py
+++ b/utils/types.py
@@ -44,6 +44,7 @@ class RoleType(Enum):
     IG_LEAD = "IG Lead"
     CAMPUS_ACTIVATION_TEAM = "Campus Activation Team"
     LEAD_ENABLER = "Lead Enabler"
+    COMPANY = "Company"
 
     @classmethod
     def IG_CAMPUS_LEAD_ROLE(cls, ig_code: str):


### PR DESCRIPTION
## 📋 Summary

This PR implements a comprehensive **Interest Group (IG) request management system** that enables company users to submit IG creation requests and allows admins to review, approve, or reject them through RESTful API endpoints.

---

## 🔗 Related Issue

Closes **#2610**

---

## ✨ Changes Made

### 🆕 New API Endpoints

#### 1️⃣ `POST /api/v1/dashboard/ig/request/`

* Allows **company users** to submit IG creation requests
* All requests default to **`requested`** status
* Validates required fields:

  * `name`
  * `code`
  * `category`
  * `icon`
* **Roles:** Admin, Company

---

#### 2️⃣ `GET /api/v1/dashboard/ig/request/`

* Retrieve IG requests with **role-based filtering**
* **Company users** see only their own requests
* **Admins** can:

  * View all requests
  * Filter by user ID
* Supports:

  * Pagination
  * Search
  * Sorting
  * Status filtering
* **Roles:** Admin, Company

---

#### 3️⃣ `PATCH /api/v1/dashboard/ig/request/<ig_id>/`

* Update IG request status (**approve / reject**)
* **Admin-only** access with strict status validation
* Allowed statuses:

  * `active`
  * `requested`
  * `rejected`
  * `cancelled`
* **Roles:** Admin only
