### PR TITLE
Add learner filters to dashboard user API

### DIFF
--- a/api/dashboard/user/dash_user_views.py
+++ b/api/dashboard/user/dash_user_views.py
@@ -95,7 +95,20 @@ class UserGetPatchDeleteAPI(APIView):
 class UserAPI(APIView):
     authentication_classes = [CustomizePermission]
 
+    def normalize_list_param(self, values):
+        """
+        Supports:
+        - repeated params: ?x=a&x=b
+        - csv params: ?x=a,b
+        - mixed: ?x=a&x=b,c
+        """
+        result = []
+        for value in values:
+            if value:
+                result.extend(v.strip() for v in value.split(",") if v.strip())
+        return result
     @role_required([RoleType.ADMIN.value])
+
     def get(self, request):
         user_queryset = User.objects.select_related(
             "wallet_user", "user_lvl_link_user", "user_lvl_link_user__level"
@@ -104,44 +117,42 @@ class UserAPI(APIView):
         # New Filters
 
         # karma filter
-        minimum_karma = request.GET.get("minKarma")
-        if minimum_karma is not None:
+        minimum_karma = request.query_params.get("minKarma")
+        if minimum_karma:
+            try:
+                minimum_karma = int(minimum_karma)
+            except ValueError:
+                return CustomResponse(
+                    general_message="Invalid minKarma. It must be an integer."
+                ).get_failure_response()
+
             user_queryset = user_queryset.filter(
-                wallet_user__karma__gte=int(minimum_karma)
+                wallet_user__karma__gte=minimum_karma
             )
 
         # level filter
-        level = request.GET.get("level")
+        level = request.query_params.get("level")
         if level:
             user_queryset = user_queryset.filter(
                 user_lvl_link_user__level__name=level
             )
 
         # skill filter
-        skills = request.GET.getlist("skillIds")
-        if len(skills) == 1 and "," in skills[0]:
-            skills = skills[0].split(",")
-
+        skills = self.normalize_list_param(request.query_params.getlist("skillIds"))
         if skills:
             user_queryset = user_queryset.filter(
                 skill_progress__skill_id__in=skills
             ).distinct()
         
         # interest group filter
-        interest_group_ids = request.GET.getlist("interestGroupIds")
-        if len(interest_group_ids) == 1 and "," in interest_group_ids[0]:
-            interest_group_ids = interest_group_ids[0].split(",")
-
+        interest_group_ids = self.normalize_list_param(request.query_params.getlist("interestGroupIds"))
         if interest_group_ids:
             user_queryset = user_queryset.filter(
                 user_ig_link_user__ig_id__in=interest_group_ids
             ).distinct()
 
         # achievement filter
-        achievement_ids = request.GET.getlist("achievementIds")
-        if len(achievement_ids) == 1 and "," in achievement_ids[0]:
-            achievement_ids = achievement_ids[0].split(",")
-
+        achievement_ids = self.normalize_list_param(request.query_params.getlist("achievementIds"))
         if achievement_ids:
             user_queryset = user_queryset.filter(
                 achievements__achievement_id__in=achievement_ids

--- a/api/dashboard/user/dash_user_views.py
+++ b/api/dashboard/user/dash_user_views.py
@@ -160,6 +160,7 @@ class UserAPI(APIView):
             {
                 "full_name": "full_name",
                 "karma": "wallet_user__karma",
+                "level": "user_lvl_link_user__level__name", 
                 "created_at": "created_at",
             },
         )

--- a/api/dashboard/user/dash_user_views.py
+++ b/api/dashboard/user/dash_user_views.py
@@ -101,6 +101,52 @@ class UserAPI(APIView):
             "wallet_user", "user_lvl_link_user", "user_lvl_link_user__level"
         ).all()
 
+        # New Filters
+
+        # karma filter
+        minimum_karma = request.GET.get("minKarma")
+        if minimum_karma is not None:
+            user_queryset = user_queryset.filter(
+                wallet_user__karma__gte=int(minimum_karma)
+            )
+
+        # level filter
+        level = request.GET.get("level")
+        if level:
+            user_queryset = user_queryset.filter(
+                user_lvl_link_user__level__name=level
+            )
+
+        # skill filter
+        skills = request.GET.getlist("skillIds")
+        if len(skills) == 1 and "," in skills[0]:
+            skills = skills[0].split(",")
+
+        if skills:
+            user_queryset = user_queryset.filter(
+                skill_progress__skill_id__in=skills
+            ).distinct()
+        
+        # interest group filter
+        interest_group_ids = request.GET.getlist("interestGroupIds")
+        if len(interest_group_ids) == 1 and "," in interest_group_ids[0]:
+            interest_group_ids = interest_group_ids[0].split(",")
+
+        if interest_group_ids:
+            user_queryset = user_queryset.filter(
+                user_ig_link_user__ig_id__in=interest_group_ids
+            ).distinct()
+
+        # achievement filter
+        achievement_ids = request.GET.getlist("achievementIds")
+        if len(achievement_ids) == 1 and "," in achievement_ids[0]:
+            achievement_ids = achievement_ids[0].split(",")
+
+        if achievement_ids:
+            user_queryset = user_queryset.filter(
+                achievements__achievement_id__in=achievement_ids
+            ).distinct()
+
         queryset = CommonUtils.get_paginated_queryset(
             user_queryset,
             request,


### PR DESCRIPTION
## Description

This PR adds **optional filters** to the existing
`GET /api/v1/dashboard/user` endpoint.

### Supported filters

* `minKarma` – minimum karma threshold
* `level` – learner level
* `skillIds` – learners with any of the given skills
* `interestGroupIds` – learners in any of the given interest groups
* `achievementIds` – learners with any of the given achievements

### Notes

* Filters are **composable** and work with existing pagination & sorting
* Supports both repeated params and comma-separated values
* No new endpoints added
* No breaking changes to existing consumers

### Example

```
/api/v1/dashboard/user?minKarma=300&skillIds=id1,id2&interestGroupIds=id3
```