### PR TITLE
feat: Campus Events Feed and Execom Management APIs (ALTER 1.93)

### DIFF
--- a/api/dashboard/campus/dash_campus_helper.py
+++ b/api/dashboard/campus/dash_campus_helper.py
@@ -15,7 +15,7 @@ def validate_campus_member(user_id, org):
         org=org,
         org__org_type=OrganizationType.COLLEGE.value,
         is_alumni=False,
-    ).first()
+    ).exists()
 
 
 def get_campus_events_qs(org):

--- a/api/dashboard/campus/dash_campus_helper.py
+++ b/api/dashboard/campus/dash_campus_helper.py
@@ -1,4 +1,4 @@
-from db.organization import UserOrganizationLink, Organization
+from db.organization import UserOrganizationLink
 from utils.types import OrganizationType
 
 
@@ -7,3 +7,22 @@ def get_user_college_link(user_id):
         user_id=user_id,
         org__org_type=OrganizationType.COLLEGE.value
     ).first()
+
+
+def validate_campus_member(user_id, org):
+    return UserOrganizationLink.objects.filter(
+        user_id=user_id,
+        org=org,
+        org__org_type=OrganizationType.COLLEGE.value,
+        is_alumni=False,
+    ).first()
+
+
+def get_campus_events_qs(org):
+    from api.dashboard.events.serializers import get_live_events
+    from db.events import Event
+    base = get_live_events()
+    return (
+        base.filter(scope=Event.Scope.CAMPUS, scope_org=org)
+        | base.filter(scope=Event.Scope.CAMPUS_IG, scope_org=org)
+    ).distinct()

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -1,0 +1,282 @@
+from collections import Counter
+
+from django.db.models import Q
+from rest_framework.views import APIView
+
+from db.events import Event
+from db.organization import UserOrganizationLink
+from db.user import User, Role, UserRoleLink
+from utils.permission import CustomizePermission, JWTUtils, role_required
+from utils.response import CustomResponse
+from utils.types import OrganizationType, RoleType
+from utils.utils import CommonUtils
+from . import serializers as campus_serializers
+from .dash_campus_helper import (
+    get_user_college_link,
+    get_campus_events_qs,
+    validate_campus_member,
+)
+
+
+class CampusEventsAPI(APIView):
+    """
+    GET  campus/events/
+    Returns paginated campus-scoped and campus-IG-scoped events
+    for the authenticated campus lead's campus.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value])
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        if not (user_org_link := get_user_college_link(user_id)):
+            return CustomResponse(
+                general_message="User has no organization"
+            ).get_failure_response()
+
+        if user_org_link.org is None:
+            return CustomResponse(
+                general_message="Campus lead has no college"
+            ).get_failure_response()
+
+        org = user_org_link.org
+        events = get_campus_events_qs(org)
+
+        params = request.query_params
+
+        if status := params.get("status"):
+            events = events.filter(status=status)
+
+        if scope := params.get("scope"):
+            events = events.filter(scope=scope)
+
+        if event_type := params.get("event_type"):
+            events = events.filter(organiser_type=event_type)
+
+        if date_from := params.get("date_from"):
+            events = events.filter(start_datetime__date__gte=date_from)
+
+        if date_to := params.get("date_to"):
+            events = events.filter(start_datetime__date__lte=date_to)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            events,
+            request,
+            search_fields=["title"],
+            sort_fields={
+                "start_datetime": "start_datetime",
+                "interest_count": "interest_count",
+            },
+        )
+
+        serializer = campus_serializers.CampusEventListSerializer(
+            paginated["queryset"], many=True
+        )
+        return CustomResponse(
+            response={
+                "data": serializer.data,
+                "pagination": paginated["pagination"],
+            }
+        ).get_success_response()
+
+
+class CampusEventDistributionAPI(APIView):
+    """
+    GET  campus/events/distribution/
+    Returns ranked tag distribution for all campus events.
+    Aggregates from Event.tags JSONField using Counter.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value])
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        if not (user_org_link := get_user_college_link(user_id)):
+            return CustomResponse(
+                general_message="User has no organization"
+            ).get_failure_response()
+
+        if user_org_link.org is None:
+            return CustomResponse(
+                general_message="Campus lead has no college"
+            ).get_failure_response()
+
+        org = user_org_link.org
+        tags_qs = get_campus_events_qs(org).values_list("tags", flat=True)
+
+        counter = Counter()
+        for tags in tags_qs:
+            if tags:  # tags is a JSONField, can be null
+                counter.update(tags)
+
+        data = [
+            {"tag": tag, "event_count": count}
+            for tag, count in counter.most_common()
+        ]
+
+        return CustomResponse(
+            response={"data": data}
+        ).get_success_response()
+
+
+class CampusExecomAPI(APIView):
+    """
+    GET     campus/execom/              — list all execom role holders
+    POST    campus/execom/              — appoint a member to a role
+    DELETE  campus/execom/<member_id>/  — remove a role link
+    """
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value])
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        if not (user_org_link := get_user_college_link(user_id)):
+            return CustomResponse(
+                general_message="User has no organization"
+            ).get_failure_response()
+
+        if user_org_link.org is None:
+            return CustomResponse(
+                general_message="Campus lead has no college"
+            ).get_failure_response()
+
+        org = user_org_link.org
+
+        campus_user_ids = UserOrganizationLink.objects.filter(
+            org=org,
+            org__org_type=OrganizationType.COLLEGE.value,
+        ).values_list("user_id", flat=True)
+
+        execom_links = UserRoleLink.objects.filter(
+            user_id__in=campus_user_ids
+        ).filter(
+            Q(role__title=RoleType.CAMPUS_LEAD.value)
+            | Q(role__title=RoleType.LEAD_ENABLER.value)
+            | Q(role__title=RoleType.ENABLER.value)
+            | Q(role__title__endswith="CampusLead")  # IG roles — no space
+        ).select_related("user", "role")
+
+        serializer = campus_serializers.ExecomMemberSerializer(
+            execom_links, many=True
+        )
+        return CustomResponse(
+            response={"data": serializer.data}
+        ).get_success_response()
+
+    @role_required([RoleType.CAMPUS_LEAD.value])
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        muid = request.data.get("muid")
+        role_title = request.data.get("role_title")
+
+        if not muid or not role_title:
+            return CustomResponse(
+                general_message="muid and role_title are required"
+            ).get_failure_response()
+
+        # Fetch user by muid
+        new_user = User.objects.filter(muid=muid).first()
+        if new_user is None:
+            return CustomResponse(
+                general_message="User not found"
+            ).get_failure_response()
+
+        # Get requester's campus
+        if not (user_org_link := get_user_college_link(user_id)):
+            return CustomResponse(
+                general_message="User has no organization"
+            ).get_failure_response()
+
+        org = user_org_link.org
+
+        # Validate new user is a non-alumni campus member
+        if not validate_campus_member(new_user.id, org):
+            return CustomResponse(
+                general_message="User is not a member of your campus"
+            ).get_failure_response()
+
+        # Fetch role by title
+        role = Role.objects.filter(title=role_title).first()
+        if role is None:
+            return CustomResponse(
+                general_message="Role not found"
+            ).get_failure_response()
+
+        # Remove existing holder of this role in the campus
+        campus_user_ids = UserOrganizationLink.objects.filter(
+            org=org,
+            org__org_type=OrganizationType.COLLEGE.value,
+        ).values_list("user_id", flat=True)
+
+        UserRoleLink.objects.filter(
+            user_id__in=campus_user_ids,
+            role=role,
+        ).delete()
+
+        # Assign new role — follows UserRoleLinkSerializer pattern
+        serializer = campus_serializers.UserRoleLinkSerializer(
+            data={"user": new_user.id, "role": role.id},
+            context={"user_id": user_id},
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message="Role assigned successfully"
+            ).get_success_response()
+
+        return CustomResponse(message=serializer.errors).get_failure_response()
+
+    @role_required([RoleType.CAMPUS_LEAD.value])
+    def delete(self, request, member_id=None):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        if not member_id:
+            return CustomResponse(
+                general_message="member_id is required"
+            ).get_failure_response()
+
+        if not (user_org_link := get_user_college_link(user_id)):
+            return CustomResponse(
+                general_message="User has no organization"
+            ).get_failure_response()
+
+        org = user_org_link.org
+
+        # Fetch the role link
+        role_link = UserRoleLink.objects.filter(
+            id=member_id
+        ).select_related("role").first()
+
+        if role_link is None:
+            return CustomResponse(
+                general_message="Role link not found"
+            ).get_failure_response()
+
+        # Guard: must belong to this campus
+        campus_user_ids = UserOrganizationLink.objects.filter(
+            org=org,
+            org__org_type=OrganizationType.COLLEGE.value,
+        ).values_list("user_id", flat=True)
+
+        if role_link.user_id not in campus_user_ids:
+            return CustomResponse(
+                general_message="Role link not found or not part of this campus"
+            ).get_failure_response()
+
+        # Guard: campus lead cannot remove their own lead role
+        if (
+            role_link.user_id == user_id
+            and role_link.role.title == RoleType.CAMPUS_LEAD.value
+        ):
+            return CustomResponse(
+                general_message="Cannot remove your own Campus Lead role. Use transfer-lead-role instead."
+            ).get_failure_response()
+
+        role_link.delete()
+        return CustomResponse(
+            general_message="Role removed successfully"
+        ).get_success_response()

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -191,6 +191,10 @@ class CampusExecomAPI(APIView):
             ).get_failure_response()
 
         org = user_org_link.org
+        if org is None:
+            return CustomResponse(
+                general_message="User has no organization"
+            ).get_failure_response()
 
         # Validate new user is a non-alumni campus member
         if not validate_campus_member(new_user.id, org):

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -173,6 +173,15 @@ class CampusExecomAPI(APIView):
         muid = request.data.get("muid")
         role_title = request.data.get("role_title")
 
+        ALLOWED_ROLES = [
+        RoleType.CAMPUS_LEAD.value,
+        RoleType.LEAD_ENABLER.value,
+        ]
+        if role_title not in ALLOWED_ROLES and not role_title.endswith("CampusLead"):
+            return CustomResponse(
+                general_message="Invalid role"
+            ).get_failure_response()
+
         if not muid or not role_title:
             return CustomResponse(
                 general_message="muid and role_title are required"

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -264,12 +264,13 @@ class CampusExecomAPI(APIView):
             ).get_failure_response()
 
         # Guard: must belong to this campus
-        campus_user_ids = UserOrganizationLink.objects.filter(
+        is_campus_member = UserOrganizationLink.objects.filter(
             org=org,
             org__org_type=OrganizationType.COLLEGE.value,
-        ).values_list("user_id", flat=True)
+            user_id=role_link.user_id,
+        ).exists()
 
-        if role_link.user_id not in campus_user_ids:
+        if not is_campus_member:
             return CustomResponse(
                 general_message="Role link not found or not part of this campus"
             ).get_failure_response()

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -3,7 +3,6 @@ from collections import Counter
 from django.db.models import Q
 from rest_framework.views import APIView
 
-from db.events import Event
 from db.organization import UserOrganizationLink
 from db.user import User, Role, UserRoleLink
 from utils.permission import CustomizePermission, JWTUtils, role_required

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -249,6 +249,10 @@ class CampusExecomAPI(APIView):
 
         org = user_org_link.org
 
+        if org is None:
+            return CustomResponse(
+                general_message="Campus lead has no college"
+            ).get_failure_response()
         # Fetch the role link
         role_link = UserRoleLink.objects.filter(
             id=member_id

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -380,11 +380,12 @@ class ExecomMemberSerializer(serializers.ModelSerializer):
 
     def get_ig_name(self, obj):
         title = obj.role.title
-        # IG campus lead roles end with 'CampusLead' (no space)
-        # e.g. 'pythonCampusLead' → ig_name = 'python'
+        # IG campus lead roles end with 'CampusLead'
+        # Handles both 'pythonCampusLead' and 'WEBDEV CampusLead'
         if title not in (
             RoleType.CAMPUS_LEAD.value,
             RoleType.LEAD_ENABLER.value,
         ) and title.endswith("CampusLead"):
-            return title.replace("CampusLead", "")
+            ig_name = title.replace("CampusLead", "").strip()
+            return ig_name or None
         return None

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -10,7 +10,7 @@ from db.user import User, UserRoleLink
 from utils.types import OrganizationType
 from utils.types import RoleType
 from utils.utils import DateTimeUtils
-
+from db.events import Event
 
 class CampusDetailsPublicSerializer(serializers.ModelSerializer):
     college_name = serializers.ReadOnlyField(source="title")
@@ -335,38 +335,56 @@ class UserRoleLinkSerializer(serializers.ModelSerializer):
         return user_role_link
 
 
+class CampusEventListSerializer(serializers.ModelSerializer):
+    tags = serializers.JSONField()
+
+    class Meta:
+        model = Event
+        fields = [
+            "id",
+            "title",
+            "status",
+            "scope",
+            "organiser_type",
+            "start_datetime",
+            "end_datetime",
+            "venue_type",
+            "venue_city",
+            "interest_count",
+            "cover_image",
+            "tags",
+        ]
 
 
-class CampusLeaderboardSerializer(CampusStudentDetailsSerializer):
-    # ── override fields (email & mobile removed — public endpoint) ──────────
-    email           = None
-    mobile          = None
+class ExecomMemberSerializer(serializers.ModelSerializer):
+    user_id = serializers.CharField(source="user.id")
+    full_name = serializers.CharField(source="user.full_name")
+    muid = serializers.CharField(source="user.muid")
+    profile_pic = serializers.SerializerMethodField()
+    role_title = serializers.CharField(source="role.title")
+    ig_name = serializers.SerializerMethodField()
 
-    # ── NEW fields not in CampusStudentDetailsSerializer ────────────────────
-    profile_pic     = serializers.SerializerMethodField()
-    ig_count        = serializers.IntegerField(default=0)
-
-    class Meta(CampusStudentDetailsSerializer.Meta):
-        # inherit parent Meta and extend fields
-        fields = (
-            "rank",
+    class Meta:
+        model = UserRoleLink
+        fields = [
             "user_id",
             "full_name",
             "muid",
-            "profile_pic",       
-            "karma",
-            "level",
-            "join_date",
-            "last_karma_gained",
-            "graduation_year",
-            "department",
-            "is_alumni",
-            "ig_count",          
-          
-        )
+            "profile_pic",
+            "role_title",
+            "ig_name",
+        ]
 
     def get_profile_pic(self, obj):
-        return str(obj.profile_pic) if obj.profile_pic else None
+        return obj.user.profile_pic
 
-    # get_rank and get_full_name are inherited from CampusStudentDetailsSerializer
-   
+    def get_ig_name(self, obj):
+        title = obj.role.title
+        # IG campus lead roles end with 'CampusLead' (no space)
+        # e.g. 'pythonCampusLead' → ig_name = 'python'
+        if title not in (
+            RoleType.CAMPUS_LEAD.value,
+            RoleType.LEAD_ENABLER.value,
+        ) and title.endswith("CampusLead"):
+            return title.replace("CampusLead", "")
+        return None

--- a/api/dashboard/campus/urls.py
+++ b/api/dashboard/campus/urls.py
@@ -60,9 +60,9 @@ urlpatterns = [
         name="transfer-ig-role",
     ),
     path(
-    "events/",
-    events_views.CampusEventsAPI.as_view(),
-    name="campus-events",
+        "events/",
+        events_views.CampusEventsAPI.as_view(),
+        name="campus-events",
     ),
     path(
         "events/distribution/",

--- a/api/dashboard/campus/urls.py
+++ b/api/dashboard/campus/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from . import campus_views
+from . import events_views
 
 urlpatterns = [
     path(
@@ -56,7 +57,27 @@ urlpatterns = [
     path(
         "transfer-ig-role/",
         campus_views.TransferIGRoleAPI.as_view(),
-        name="transfer-lead-role",
+        name="transfer-ig-role",
+    ),
+    path(
+    "events/",
+    events_views.CampusEventsAPI.as_view(),
+    name="campus-events",
+    ),
+    path(
+        "events/distribution/",
+        events_views.CampusEventDistributionAPI.as_view(),
+        name="campus-event-distribution",
+    ),
+    path(
+        "execom/",
+        events_views.CampusExecomAPI.as_view(),
+        name="campus-execom",
+    ),
+    path(
+        "execom/<str:member_id>/",
+        events_views.CampusExecomAPI.as_view(),
+        name="campus-execom-delete",
     ),
     path(
         "<str:org_id>/",

--- a/db/events.py
+++ b/db/events.py
@@ -235,3 +235,29 @@ class EventLog(models.Model):
     class Meta:
         managed = False
         db_table = 'events_log'
+
+class EventTag(models.Model):
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    title = models.CharField(max_length=100, unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        managed = False
+        db_table = 'event_tag'
+
+
+class EventTagLink(models.Model):
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    event = models.ForeignKey(
+        Event, on_delete=models.CASCADE,
+        db_column='event_id', related_name='tag_links'
+    )
+    tag = models.ForeignKey(
+        EventTag, on_delete=models.CASCADE,
+        db_column='tag_id', related_name='event_links'
+    )
+
+    class Meta:
+        managed = False
+        db_table = 'event_tag_link'
+        unique_together = [('event', 'tag')]


### PR DESCRIPTION
feat: Campus Events Feed and Execom Management APIs (ALTER 1.93)
## Changes
- Added campus events feed API with filters (status, scope, date range, event type)
- Added event tag distribution API for chart display
- Added execom list, appoint, and delete APIs
- Added EventTag and EventTagLink models to db/events.py
- Updated dash_campus_helper.py with validate_campus_member and get_campus_events_qs helpers

## Endpoints
- GET  /api/v1/dashboard/campus/events/
- GET  /api/v1/dashboard/campus/events/distribution/
- GET  /api/v1/dashboard/campus/execom/
- POST /api/v1/dashboard/campus/execom/
- DELETE /api/v1/dashboard/campus/execom/<member_id>/

## Task
ALTER 1.93 — Campus Dashboard