### PR TITLE
Add active IG counts and leaderboard features in Campus API

### DIFF
--- a/api/dashboard/campus/campus_views.py
+++ b/api/dashboard/campus/campus_views.py
@@ -629,3 +629,134 @@ class TransferIGRoleAPI(APIView):
                 general_message="Assigned new Ig lead successfully"
             ).get_success_response()
         return CustomResponse(message=serializer.errors).get_failure_response()
+
+# ...existing code...
+
+class CampusStudentLeaderboardAPI(APIView):
+
+    authentication_classes = [CustomizePermission]
+    def get(self, request, org_id=None):
+
+        if not org_id:
+            return CustomResponse(
+                general_message="College not found"
+            ).get_failure_response()
+                                        
+  
+        org = Organization.objects.filter(
+            id=org_id,
+            org_type=OrganizationType.COLLEGE.value
+        ).first()
+  
+        if org is None:
+            return CustomResponse(
+                general_message="Campus not found"
+            ).get_failure_response()
+
+       
+        # 1. Compute Campus rank BEFORE filters/pagination                    #
+
+        rank_qs = (
+            Wallet.objects.filter(
+                user__user_organization_link_user__org=org,
+                user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            )
+            .distinct()
+            .order_by("-karma","-created_at")
+            .values("user_id")
+        )
+        ranks = {r["user_id"]: i + 1 for i, r in enumerate(rank_qs)}
+
+     
+        # 2. Base queryset - all students with annotations                    #
+
+        qs = (
+            User.objects.filter(
+                user_organization_link_user__org=org,
+                user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            )
+            .distinct()
+            .annotate(
+                user_id=F("id"),  
+                # existing fields from CampusStudentDetailsAPI
+                karma=F("wallet_user__karma"),
+                level=F("user_lvl_link_user__level__name"),
+                join_date=F("created_at"),
+             # org join date (fixed from created_at)
+                last_karma_gained=F("wallet_user__karma_last_updated_at"),
+                department=F("user_organization_link_user__department__title"),
+                graduation_year=F("user_organization_link_user__graduation_year"),
+                is_alumni=F("user_organization_link_user__is_alumni"),
+
+                # new fields not in existing API
+                ig_count=Count(
+                    "user_ig_link_user",
+                    distinct=True
+                ),
+            )
+            .order_by("-wallet_user__karma", "-wallet_user__created_at")  # ← rank 1 appears on page 1
+        )
+
+      
+        # 3. Apply optional filters from query params                         #
+      
+        params = request.query_params
+
+        pass_out_year   = params.get("pass_out_year")
+        ig_id           = params.get("ig_id")
+        cluster         = params.get("cluster")
+        is_alumni_param = params.get("is_alumni")
+        search          = params.get("search")
+
+        if pass_out_year:
+            qs = qs.filter(
+                user_organization_link_user__graduation_year=pass_out_year
+            )
+        if ig_id:
+            qs = qs.filter(user_ig_link_user__ig_id=ig_id)
+
+        if cluster:
+            qs = qs.filter(user_ig_link_user__ig__cluster=cluster)
+
+        if is_alumni_param is not None and is_alumni_param != "":
+            is_alumni_bool = is_alumni_param.lower() == "true"
+            qs = qs.filter(
+                user_organization_link_user__is_alumni=is_alumni_bool
+            )
+        if search:
+            qs = qs.filter(
+                Q(full_name__icontains=search) | Q(mu_id__icontains=search)
+            )
+
+     
+        # 4. Paginate using CommonUtils (handles pageIndex, perPage, sortBy)  #
+   
+        paginated_queryset = CommonUtils.get_paginated_queryset(
+            qs,
+            request,
+            search_fields=["full_name", "mu_id"],
+            sort_fields={
+                "full_name":       "full_name",
+                "muid":            "mu_id",
+                "karma":           "wallet_user__karma",
+                "level":           "user_lvl_link_user__level__level_order",
+                "join_date":       "user_organization_link_user__created_at",
+                "graduation_year": "user_organization_link_user__graduation_year",
+                "is_alumni":       "user_organization_link_user__is_alumni",
+            },
+        )
+
+        # 5. Serialize and return                                              #
+       
+        serializer = serializers.CampusLeaderboardSerializer(
+            paginated_queryset.get("queryset"),
+            many=True,
+            context={"ranks": ranks},
+        )
+
+        return CustomResponse(
+            response={
+                "data":       serializer.data,
+                "pagination": paginated_queryset.get("pagination"),
+            }
+        ).get_success_response()

--- a/api/dashboard/campus/campus_views.py
+++ b/api/dashboard/campus/campus_views.py
@@ -1,7 +1,7 @@
-from django.db.models import Count, F,Sum
+from django.db.models import Count, F,Sum, Subquery, OuterRef
 from django.db.models import Q
 from rest_framework.views import APIView
-
+from collections import defaultdict
 from db.organization import Organization, UserOrganizationLink
 from db.task import Level, Wallet, InterestGroup
 from db.user import User, Role, UserRoleLink
@@ -652,7 +652,8 @@ class CampusStudentLeaderboardAPI(APIView):
             return CustomResponse(
                 general_message="Campus not found"
             ).get_failure_response()
-
+        
+       
        
         # 1. Compute Campus rank BEFORE filters/pagination                    #
 
@@ -704,7 +705,7 @@ class CampusStudentLeaderboardAPI(APIView):
 
         pass_out_year   = params.get("pass_out_year")
         ig_id           = params.get("ig_id")
-        cluster         = params.get("cluster")
+        category         = params.get("category")
         is_alumni_param = params.get("is_alumni")
         search          = params.get("search")
 
@@ -715,8 +716,8 @@ class CampusStudentLeaderboardAPI(APIView):
         if ig_id:
             qs = qs.filter(user_ig_link_user__ig_id=ig_id)
 
-        if cluster:
-            qs = qs.filter(user_ig_link_user__ig__cluster=cluster)
+        if category:
+            qs = qs.filter(user_ig_link_user__ig__category=category)
 
         if is_alumni_param is not None and is_alumni_param != "":
             is_alumni_bool = is_alumni_param.lower() == "true"
@@ -725,7 +726,7 @@ class CampusStudentLeaderboardAPI(APIView):
             )
         if search:
             qs = qs.filter(
-                Q(full_name__icontains=search) | Q(mu_id__icontains=search)
+                Q(full_name__icontains=search) | Q(muid__icontains=search)
             )
 
      
@@ -734,10 +735,10 @@ class CampusStudentLeaderboardAPI(APIView):
         paginated_queryset = CommonUtils.get_paginated_queryset(
             qs,
             request,
-            search_fields=["full_name", "mu_id"],
+            search_fields=["full_name", "muid"],
             sort_fields={
                 "full_name":       "full_name",
-                "muid":            "mu_id",
+                "muid":            "muid",
                 "karma":           "wallet_user__karma",
                 "level":           "user_lvl_link_user__level__level_order",
                 "join_date":       "created_at",
@@ -761,7 +762,6 @@ class CampusStudentLeaderboardAPI(APIView):
             }
         ).get_success_response()
 
-# ...existing code...
 
 class CampusKarmaByClusterAPI(APIView):
 
@@ -784,53 +784,50 @@ class CampusKarmaByClusterAPI(APIView):
                 general_message="Campus not found"
             ).get_failure_response()
 
-        # Aggregate karma and member count by IG cluster
-        cluster_data = (
+        # Subquery: fetch each user's karma once — no JOIN fan-out
+        wallet_karma_sq = Wallet.objects.filter(
+            user=OuterRef("pk")
+        ).values("karma")[:1]
+
+        # Single query — LEFT JOIN via isnull=False removed
+        # users with NO IG will have category=None → goes to "unclustered"
+        all_rows = (
             User.objects.filter(
                 user_organization_link_user__org=org,
                 user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                user_ig_link_user__isnull=False,
             )
-            .values("user_ig_link_user__ig__category")
-            .annotate(
-                total_karma=Sum("wallet_user__karma"),
-                member_count=Count("id", distinct=True),
-            )
+            .annotate(user_karma=Subquery(wallet_karma_sq))
+            .values("id", "user_ig_link_user__ig__category", "user_karma")
+            .distinct()   # 1 row per (user_id, category) — kills IG fan-out
         )
 
-        # Users with NO IG membership (unclustered)
-        unclustered = (
-            User.objects.filter(
-                user_organization_link_user__org=org,
-                user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                user_ig_link_user__isnull=True,  # no IG at all
-            )
-            .distinct()
-            .aggregate(
-                total_karma=Sum("wallet_user__karma"),
-                member_count=Count("id", distinct=True),
-            )
-        )
+        # Aggregate in Python
+        category_map = defaultdict(lambda: {"total_karma": 0, "member_count": 0, "seen_users": set()})
 
-        # Build response dict
-        response = {}
+        for row in all_rows:  # streams from DB — no list() memory spike
+            category = row["user_ig_link_user__ig__category"] or "unclustered"
+            user_id  = row["id"]
+            karma    = row["user_karma"] or 0
 
-        for row in cluster_data:
-            cluster_name = row["user_ig_link_user__ig__category"] or "unclustered"
-            response[cluster_name] = {
-                "total_karma":  row["total_karma"] or 0,
-                "member_count": row["member_count"] or 0,
+            # seen_users guards against edge case where
+            # a user has NO IG (category=None) but still appears multiple times
+            # due to multiple org links
+            if user_id not in category_map[category]["seen_users"]:
+                category_map[category]["seen_users"].add(user_id)
+                category_map[category]["total_karma"]  += karma
+                category_map[category]["member_count"] += 1
+
+        # Build final response — strip seen_users from output
+        response = {
+            category: {
+                "total_karma":  data["total_karma"],
+                "member_count": data["member_count"],
             }
-
-        # Merge unclustered users (those with no IG at all)
-        if unclustered["member_count"]:
-            existing = response.get("unclustered", {"total_karma": 0, "member_count": 0})
-            response["unclustered"] = {
-                "total_karma":  (existing["total_karma"] or 0) + (unclustered["total_karma"] or 0),
-                "member_count": (existing["member_count"] or 0) + (unclustered["member_count"] or 0),
-            }
+            for category, data in category_map.items()
+        }
 
         return CustomResponse(
             response=response
         ).get_success_response()
 
+# ...existing code...

--- a/api/dashboard/campus/campus_views.py
+++ b/api/dashboard/campus/campus_views.py
@@ -1,4 +1,4 @@
-from django.db.models import Count, F
+from django.db.models import Count, F,Sum
 from django.db.models import Q
 from rest_framework.views import APIView
 
@@ -740,7 +740,7 @@ class CampusStudentLeaderboardAPI(APIView):
                 "muid":            "mu_id",
                 "karma":           "wallet_user__karma",
                 "level":           "user_lvl_link_user__level__level_order",
-                "join_date":       "user_organization_link_user__created_at",
+                "join_date":       "created_at",
                 "graduation_year": "user_organization_link_user__graduation_year",
                 "is_alumni":       "user_organization_link_user__is_alumni",
             },
@@ -760,3 +760,77 @@ class CampusStudentLeaderboardAPI(APIView):
                 "pagination": paginated_queryset.get("pagination"),
             }
         ).get_success_response()
+
+# ...existing code...
+
+class CampusKarmaByClusterAPI(APIView):
+
+    authentication_classes = [CustomizePermission]
+
+    def get(self, request, org_id=None):
+
+        if not org_id:
+            return CustomResponse(
+                general_message="College not found"
+            ).get_failure_response()
+
+        org = Organization.objects.filter(
+            id=org_id,
+            org_type=OrganizationType.COLLEGE.value
+        ).first()
+
+        if org is None:
+            return CustomResponse(
+                general_message="Campus not found"
+            ).get_failure_response()
+
+        # Aggregate karma and member count by IG cluster
+        cluster_data = (
+            User.objects.filter(
+                user_organization_link_user__org=org,
+                user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                user_ig_link_user__isnull=False,
+            )
+            .values("user_ig_link_user__ig__category")
+            .annotate(
+                total_karma=Sum("wallet_user__karma"),
+                member_count=Count("id", distinct=True),
+            )
+        )
+
+        # Users with NO IG membership (unclustered)
+        unclustered = (
+            User.objects.filter(
+                user_organization_link_user__org=org,
+                user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                user_ig_link_user__isnull=True,  # no IG at all
+            )
+            .distinct()
+            .aggregate(
+                total_karma=Sum("wallet_user__karma"),
+                member_count=Count("id", distinct=True),
+            )
+        )
+
+        # Build response dict
+        response = {}
+
+        for row in cluster_data:
+            cluster_name = row["user_ig_link_user__ig__category"] or "unclustered"
+            response[cluster_name] = {
+                "total_karma":  row["total_karma"] or 0,
+                "member_count": row["member_count"] or 0,
+            }
+
+        # Merge unclustered users (those with no IG at all)
+        if unclustered["member_count"]:
+            existing = response.get("unclustered", {"total_karma": 0, "member_count": 0})
+            response["unclustered"] = {
+                "total_karma":  (existing["total_karma"] or 0) + (unclustered["total_karma"] or 0),
+                "member_count": (existing["member_count"] or 0) + (unclustered["member_count"] or 0),
+            }
+
+        return CustomResponse(
+            response=response
+        ).get_success_response()
+

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -5,7 +5,7 @@ from django.db.models import Sum
 from rest_framework import serializers
 
 from db.organization import Organization, UserOrganizationLink, College
-from db.task import KarmaActivityLog
+from db.task import KarmaActivityLog,InterestGroup
 from db.user import User, UserRoleLink
 from utils.types import OrganizationType
 from utils.types import RoleType
@@ -23,6 +23,10 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
     rank = serializers.SerializerMethodField()
     karma_last_7_days = serializers.SerializerMethodField()
     karma_last_30_days = serializers.SerializerMethodField()
+    active_ig_count = serializers.SerializerMethodField()
+    active_igs = serializers.SerializerMethodField()  # add this field
+
+    
   
 
     class Meta:
@@ -38,6 +42,8 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
             "rank",
             "karma_last_7_days",
             "karma_last_30_days",
+            "active_ig_count",
+            "active_igs",
         ]
 
     def get_campus_level(self, obj):
@@ -108,6 +114,29 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
                 created_at__gte=thirty_days_ago,
             ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
         )
+    def get_active_ig_count(self, obj):
+        return (
+            InterestGroup.objects.filter(
+                user_ig_link_ig__user__user_organization_link_user__org=obj,
+                user_ig_link_ig__user__user_organization_link_user__verified=True,
+                status="Active",
+            )
+            .distinct()
+            .count()
+        )
+    def get_active_igs(self, obj):
+        igs = (
+            InterestGroup.objects.filter(
+                user_ig_link_ig__user__user_organization_link_user__org=obj,
+                user_ig_link_ig__user__user_organization_link_user__verified=True,
+                # status="Active",
+            )
+            .distinct()
+            .values("id", "name")
+        )
+        return list(igs)
+    
+
 
 
 class CampusDetailsSerializer(serializers.ModelSerializer):

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -24,8 +24,7 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
     karma_last_7_days = serializers.SerializerMethodField()
     karma_last_30_days = serializers.SerializerMethodField()
     active_ig_count = serializers.SerializerMethodField()
-    active_igs = serializers.SerializerMethodField()  # add this field
-
+ 
     
   
 
@@ -43,7 +42,7 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
             "karma_last_7_days",
             "karma_last_30_days",
             "active_ig_count",
-            "active_igs",
+           
         ]
 
     def get_campus_level(self, obj):
@@ -124,17 +123,7 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
             .distinct()
             .count()
         )
-    def get_active_igs(self, obj):
-        igs = (
-            InterestGroup.objects.filter(
-                user_ig_link_ig__user__user_organization_link_user__org=obj,
-                user_ig_link_ig__user__user_organization_link_user__verified=True,
-                # status="Active",
-            )
-            .distinct()
-            .values("id", "name")
-        )
-        return list(igs)
+ 
     
 
 
@@ -152,6 +141,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
     lead = serializers.SerializerMethodField()
     karma_last_7_days = serializers.SerializerMethodField()
     karma_last_30_days = serializers.SerializerMethodField()
+    active_ig_count = serializers.SerializerMethodField()
     class Meta:
         model = UserOrganizationLink
         fields = [
@@ -166,6 +156,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
             "lead",
             "karma_last_7_days",
             "karma_last_30_days",
+            "active_ig_count",
         ]
 
     def get_lead(self, obj):
@@ -257,6 +248,16 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
                 user__user_organization_link_user__org=obj.org,
                 created_at__gte=thirty_days_ago,
             ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
+        )
+    def get_active_ig_count(self, obj):
+        return (
+            InterestGroup.objects.filter(
+                user_ig_link_ig__user__user_organization_link_user__org=obj.org,
+                user_ig_link_ig__user__user_organization_link_user__verified=True,
+                status="Active",
+            )
+            .distinct()
+            .count()
         )
 
 

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -21,10 +21,8 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
     total_members = serializers.SerializerMethodField()
     active_members = serializers.SerializerMethodField()
     rank = serializers.SerializerMethodField()
-    karma_last_7_days = serializers.SerializerMethodField()
-    karma_last_30_days = serializers.SerializerMethodField()
-    active_ig_count = serializers.SerializerMethodField()
- 
+   
+    
     
   
 
@@ -95,35 +93,7 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
             keys_list = list(sorted_rank_dict.keys())
             position = keys_list.index(obj.id)
             return position + 1
-    
-    def get_karma_last_7_days(self, obj):
-        seven_days_ago = DateTimeUtils.get_current_utc_time() - timedelta(days=7)
-        return (
-            KarmaActivityLog.objects.filter(
-                user__user_organization_link_user__org=obj,
-                created_at__gte=seven_days_ago,
-            ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
-        )
 
-    def get_karma_last_30_days(self, obj):
-        thirty_days_ago = DateTimeUtils.get_current_utc_time() - timedelta(days=30)
-        return (
-            KarmaActivityLog.objects.filter(
-                user__user_organization_link_user__org=obj,
-                created_at__gte=thirty_days_ago,
-            ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
-        )
-    def get_active_ig_count(self, obj):
-        return (
-            InterestGroup.objects.filter(
-                user_ig_link_ig__user__user_organization_link_user__org=obj,
-                user_ig_link_ig__user__user_organization_link_user__verified=True,
-                status="Active",
-            )
-            .distinct()
-            .count()
-        )
- 
     
 
 
@@ -369,3 +339,40 @@ class UserRoleLinkSerializer(serializers.ModelSerializer):
 
         user_role_link = UserRoleLink.objects.create(**validated_data)
         return user_role_link
+
+
+
+
+class CampusLeaderboardSerializer(CampusStudentDetailsSerializer):
+    # ── override fields (email & mobile removed — public endpoint) ──────────
+    email           = None
+    mobile          = None
+
+    # ── NEW fields not in CampusStudentDetailsSerializer ────────────────────
+    profile_pic     = serializers.SerializerMethodField()
+    ig_count        = serializers.IntegerField(default=0)
+
+    class Meta(CampusStudentDetailsSerializer.Meta):
+        # inherit parent Meta and extend fields
+        fields = (
+            "rank",
+            "user_id",
+            "full_name",
+            "muid",
+            "profile_pic",       
+            "karma",
+            "level",
+            "join_date",
+            "last_karma_gained",
+            "graduation_year",
+            "department",
+            "is_alumni",
+            "ig_count",          
+          
+        )
+
+    def get_profile_pic(self, obj):
+        return str(obj.profile_pic) if obj.profile_pic else None
+
+    # get_rank and get_full_name are inherited from CampusStudentDetailsSerializer
+   

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -23,8 +23,6 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
     rank = serializers.SerializerMethodField()
    
     
-    
-  
 
     class Meta:
         model = Organization
@@ -37,10 +35,6 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
             "total_members",
             "active_members",
             "rank",
-            "karma_last_7_days",
-            "karma_last_30_days",
-            "active_ig_count",
-           
         ]
 
     def get_campus_level(self, obj):
@@ -224,7 +218,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
             InterestGroup.objects.filter(
                 user_ig_link_ig__user__user_organization_link_user__org=obj.org,
                 user_ig_link_ig__user__user_organization_link_user__verified=True,
-                status="Active",
+                status="active",
             )
             .distinct()
             .count()

--- a/api/dashboard/campus/urls.py
+++ b/api/dashboard/campus/urls.py
@@ -70,9 +70,9 @@ urlpatterns = [
         name="campus-student-leaderboard",
     ),
     path(
-    "<str:org_id>/karma-by-cluster/",
-    campus_views.CampusKarmaByClusterAPI.as_view(),
-    name="campus-karma-by-cluster",
+        "<str:org_id>/karma-by-cluster/",
+        campus_views.CampusKarmaByClusterAPI.as_view(),
+        name="campus-karma-by-cluster",
 ),
 
 ]

--- a/api/dashboard/campus/urls.py
+++ b/api/dashboard/campus/urls.py
@@ -69,4 +69,10 @@ urlpatterns = [
         campus_views.CampusStudentLeaderboardAPI.as_view(),
         name="campus-student-leaderboard",
     ),
+    path(
+    "<str:org_id>/karma-by-cluster/",
+    campus_views.CampusKarmaByClusterAPI.as_view(),
+    name="campus-karma-by-cluster",
+),
+
 ]

--- a/api/dashboard/campus/urls.py
+++ b/api/dashboard/campus/urls.py
@@ -63,4 +63,10 @@ urlpatterns = [
         campus_views.CampusDetailsPublicAPI.as_view(),
         name="campus-details-individual",
     ),
+
+    path(
+        "<str:org_id>/leaderboard/",
+        campus_views.CampusStudentLeaderboardAPI.as_view(),
+        name="campus-student-leaderboard",
+    ),
 ]

--- a/db/task.py
+++ b/db/task.py
@@ -188,7 +188,7 @@ class KarmaActivityLog(models.Model):
                                          null=True, related_name="karma_activity_log_peer_approved_by")
     appraiser_approved = models.BooleanField(blank=True, null=True)
     appraiser_approved_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="appraiser_approved_by",
-                                              blank=True, null=True,
+                                                  blank=True, null=True,
                                               related_name="karma_activity_log_appraiser_approved_by")
     updated_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="updated_by",
                                    related_name="karma_activity_log_updated_by")


### PR DESCRIPTION
This pull request introduces two new APIs for campus dashboards: a student leaderboard and campus karma aggregation by interest group cluster. It also adds new serializer fields to support these endpoints and makes minor adjustments to existing serializers for clarity and performance.

**New Campus Dashboard APIs:**

* Added `CampusStudentLeaderboardAPI` to provide a paginated, filterable leaderboard of students for a campus, including rank, karma, level, and IG count.
* Added `CampusKarmaByClusterAPI` to aggregate total karma and member count for each IG category ("cluster") within a campus.
* Registered new endpoints in `api/dashboard/campus/urls.py` for leaderboard and karma-by-cluster APIs.

**Serializer Enhancements:**

* Created `CampusLeaderboardSerializer` with new fields (`profile_pic`, `ig_count`) and removed sensitive fields for public leaderboard exposure.
* Added `active_ig_count` field to `CampusDetailsSerializer` to show number of active IGs for a campus. [[1]](diffhunk://#diff-fdc3381ddadaeaa71644baec628d779cd101a7cabb901724bddf88afbe3d159dR108) [[2]](diffhunk://#diff-fdc3381ddadaeaa71644baec628d779cd101a7cabb901724bddf88afbe3d159dR216-R225)