### PR TITLE
Fix: ensure discord_id updates correctly in UserDetailsEditSerializer

### DIFF
--- a/api/dashboard/user/dash_user_serializer.py
+++ b/api/dashboard/user/dash_user_serializer.py
@@ -360,6 +360,9 @@ class UserDetailsEditSerializer(serializers.ModelSerializer):
                     ]
                 )
 
+            if "discord_id" in validated_data:
+                instance.discord_id = validated_data["discord_id"]
+
             if isinstance(role_ids := validated_data.pop("roles", None), list):
                 instance.user_role_link_user.all().delete()
                 UserRoleLink.objects.bulk_create(

--- a/api/dashboard/user/dash_user_serializer.py
+++ b/api/dashboard/user/dash_user_serializer.py
@@ -360,8 +360,9 @@ class UserDetailsEditSerializer(serializers.ModelSerializer):
                     ]
                 )
 
-            if "discord_id" in validated_data:
-                instance.discord_id = validated_data["discord_id"]
+            discord_id = validated_data.pop("discord_id", None)
+            if discord_id is not None:
+                instance.discord_id = discord_id
 
             if isinstance(role_ids := validated_data.pop("roles", None), list):
                 instance.user_role_link_user.all().delete()


### PR DESCRIPTION
---

This PR fixes a bug where the `discord_id` field was not being updated when sending a `PATCH` request to the `/api/v1/dashboard/user/<id>/` endpoint.

#### Changes made:
- Added explicit handling of `discord_id` inside the `update()` method of `UserDetailsEditSerializer`.
- Ensured the field is set on the `User` instance before calling `super().update()`.
- Verified the fix using Postman and MySQL Workbench:
  - PATCH request now persists the new `discord_id`.
  - GET request correctly returns the updated value.

#### Impact:
- Admins can now reliably update a user’s Discord ID via the dashboard API.
- Prevents silent failures where API returned `200 OK` but the field was not saved.

---

### Testing
- Sent a PATCH request.
- Confirmed success message in API response.
- Verified updated value via GET request and direct SQL query.

---