### PR TITLE
Add sortBy Support to IG Manage and IG Request Endpoints

### DIFF
--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -40,6 +40,7 @@ class InterestGroupAPI(APIView):
             {
                 "name": "name",
                 "members": "members",
+                "status": "status",
                 "updated_on": "updated_at",
                 "updated_by": "updated_by__full_name",
                 "created_on": "created_at",
@@ -378,6 +379,9 @@ class InterestGroupRequestAPI(APIView):
             {
                 "name": "name",
                 "status": "status",
+                "ig_name": "name",
+                "user_full_name": "created_by__full_name",
+                "created_at": "created_at",
                 "created_on": "created_at",
                 "updated_on": "updated_at",
             },


### PR DESCRIPTION
### **Summary**
Extends the existing pagination layer with additional sortBy query parameter options for two Interest Group dashboard endpoints.

### **Changes**
GET /api/v1/dashboard/ig/ — IG Manage

- Added status sort key

GET /api/v1/dashboard/ig/request/ — IG Request

- Added ig_name sort key (sorts by IG name)
- Added user_full_name sort key (sorts by the requesting user's full name)
- Added created_at sort key (sorts by creation timestamp)

### **Usage Examples**
```
GET /api/v1/dashboard/ig/?pageIndex=1&perPage=10&sortBy=status
GET /api/v1/dashboard/ig/request/?pageIndex=1&perPage=10&sortBy=ig_name
GET /api/v1/dashboard/ig/request/?pageIndex=1&perPage=10&sortBy=user_full_name
GET /api/v1/dashboard/ig/request/?pageIndex=1&perPage=10&sortBy=created_at
```
Prefix any sortBy value with - for descending order (e.g. sortBy=-created_at).