### PR TITLE
Fix college sorting by mapping org to org__title

### DIFF
--- a/api/dashboard/college/college_view.py
+++ b/api/dashboard/college/college_view.py
@@ -23,7 +23,11 @@ class CollegeApi(APIView):
             colleges,
             request,
             search_fields=["org__title"],
-            sort_fields={'org': 'org'},
+            sort_fields={
+                'org': 'org__title',
+                'level': 'level',
+                'created_at': 'created_at',
+            },
         )
         serializer = CollegeListSerializer(
             paginated_queryset.get("queryset"), many=True


### PR DESCRIPTION
Fixes #2651

## Problem
The `sortBy=org` parameter sorted by organization UUID instead of organization name.

## Solution
Updated the `sort_fields` mapping in `college_view.py` to use:

org → org__title
level → level
created_at → created_at

## Testing
Verified using Postman with:

GET /api/v1/dashboard/college?sortBy=org  
GET /api/v1/dashboard/college?sortBy=-org  
GET /api/v1/dashboard/college?sortBy=level  
GET /api/v1/dashboard/college?sortBy=-level  
GET /api/v1/dashboard/college?sortBy=created_at  
GET /api/v1/dashboard/college?sortBy=-created_at  

All returned **200 OK**.


<img width="1920" height="1080" alt="Screenshot 2026-03-18 213418" src="https://github.com/user-attachments/assets/19c78083-8135-406e-9755-d14a4b98d40e" />
<img width="1920" height="1080" alt="Screenshot 2026-03-18 213352" src="https://github.com/user-attachments/assets/58308d4c-b00f-4def-96da-44fd2ecb38d2" />
<img width="1920" height="1080" alt="Screenshot 2026-03-18 213329" src="https://github.com/user-attachments/assets/a2f33c7b-9ef8-4d34-b45d-4c2441eb1756" />



<img width="1920" height="1080" alt="Screenshot 2026-03-18 213246" src="https://github.com/user-attachments/assets/4a7fba19-1c8a-4b98-9a18-6094f1fc60a9" />

<img width="1920" height="1080" alt="Screenshot 2026-03-18 213157" src="https://github.com/user-attachments/assets/54afa245-3ba9-41d1-be17-a1a5e97af486" />
