### PR TITLE
Fix: Null Dereference & ORM Bugs in District and Zonal Dashboard APIs

### DIFF
--- a/api/dashboard/district/dash_district_serializer.py
+++ b/api/dashboard/district/dash_district_serializer.py
@@ -137,7 +137,7 @@ class DistrictStudentDetailsSerializer(serializers.Serializer):
 
     class Meta:
         fields = (
-            "user_id"
+            "user_id",
             "full_name",
             "karma",
             "muid",
@@ -163,12 +163,12 @@ class DistrictCollegeDetailsSerializer(serializers.Serializer):
 
     class Meta:
         fields = (
-            'id'
+            'id',
             'title',
             'level',
             'code',
             'lead',
-            'lead_number'
+            'lead_number',
         )
 
     def get_lead(self, obj):

--- a/api/dashboard/district/dash_district_views.py
+++ b/api/dashboard/district/dash_district_views.py
@@ -23,6 +23,11 @@ class DistrictDetailAPI(APIView):
 
         user_org_link = get_user_college_link(user_id)
 
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
+
         serializer = dash_district_serializer.DistrictDetailsSerializer(
             user_org_link, many=False
         )
@@ -38,6 +43,11 @@ class DistrictTopThreeCampusAPI(APIView):
         user_id = JWTUtils.fetch_user_id(request)
 
         user_org_link = get_user_college_link(user_id)
+
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
 
         org_karma_dict = (
             UserOrganizationLink.objects.filter(
@@ -78,6 +88,11 @@ class DistrictStudentLevelStatusAPI(APIView):
 
         user_org_link = get_user_college_link(user_id)
 
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
+
         district = user_org_link.org.district
 
         levels = Level.objects.all()
@@ -97,13 +112,18 @@ class DistrictStudentDetailsAPI(APIView):
 
         user_org_link = get_user_college_link(user_id)
 
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
+
         rank = (
             Wallet.objects.filter(
                 user__user_organization_link_user__org__district=user_org_link.org.district,
                 user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
             )
             .distinct()
-            .order_by("-karma", '-update_at', "created_at")
+            .order_by("-karma", "-updated_at", "created_at")
             .values(
                 "user_id",
                 "karma",
@@ -158,13 +178,18 @@ class DistrictStudentDetailsCSVAPI(APIView):
 
         user_org_link = get_user_college_link(user_id)
 
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
+
         rank = (
             Wallet.objects.filter(
                 user__user_organization_link_user__org__district=user_org_link.org.district,
                 user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
             )
             .distinct()
-            .order_by("-karma", '-updated_at', "created_at")
+            .order_by("-karma", "-updated_at", "created_at")
             .values(
                 "user_id",
                 "karma",
@@ -200,6 +225,11 @@ class DistrictsCollageDetailsAPI(APIView):
         user_id = JWTUtils.fetch_user_id(request)
 
         user_org_link = get_user_college_link(user_id)
+
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
 
         organizations = (
             Organization.objects.filter(
@@ -264,6 +294,11 @@ class DistrictsCollageDetailsCSVAPI(APIView):
         user_id = JWTUtils.fetch_user_id(request)
 
         user_org_link = get_user_college_link(user_id)
+
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
 
         organizations = (
             Organization.objects.filter(

--- a/api/dashboard/zonal/dash_zonal_serializer.py
+++ b/api/dashboard/zonal/dash_zonal_serializer.py
@@ -55,13 +55,13 @@ class ZonalDetailsSerializer(serializers.ModelSerializer):
 
     def get_karma(self, obj):
         return UserOrganizationLink.objects.filter(
-            org_org_type=OrganizationType.COLLEGE.value,
+            org__org_type=OrganizationType.COLLEGE.value,
             org__district__zone=obj.org.district.zone,
         ).aggregate(total_karma=Sum("user__wallet_user__karma"))["total_karma"]
 
     def get_total_members(self, obj):
         return UserOrganizationLink.objects.filter(
-            org_org_type=OrganizationType.COLLEGE.value,
+            org__org_type=OrganizationType.COLLEGE.value,
             org__district__zone=obj.org.district.zone,
         ).count()
 
@@ -108,7 +108,7 @@ class ZonalStudentLevelStatusSerializer(serializers.ModelSerializer):
         zone = self.context.get("zone")
         return (
             User.objects.filter(
-                user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
                 user_organization_link_user__org__district__zone=zone,
                 user_lvl_link_user__level=obj,
             )

--- a/api/dashboard/zonal/dash_zonal_views.py
+++ b/api/dashboard/zonal/dash_zonal_views.py
@@ -22,6 +22,11 @@ class ZonalDetailsAPI(APIView):
 
         user_org_link = dash_zonal_helper.get_user_college_link(user_id)
 
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
+
         serializer = dash_zonal_serializer.ZonalDetailsSerializer(
             user_org_link, many=False
         )
@@ -36,6 +41,11 @@ class ZonalTopThreeDistrictAPI(APIView):
         user_id = JWTUtils.fetch_user_id(request)
 
         user_org_link = dash_zonal_helper.get_user_college_link(user_id)
+
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
 
         district_karma_dict = (
             UserOrganizationLink.objects.filter(
@@ -78,6 +88,11 @@ class ZonalStudentLevelStatusAPI(APIView):
 
         user_org_link = dash_zonal_helper.get_user_college_link(user_id)
 
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
+
         zone = user_org_link.org.district.zone
 
         levels = Level.objects.all()
@@ -95,6 +110,11 @@ class ZonalStudentDetailsAPI(APIView):
         user_id = JWTUtils.fetch_user_id(request)
 
         user_org_link = dash_zonal_helper.get_user_college_link(user_id)
+
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
 
         rank = (
             Wallet.objects.filter(
@@ -157,6 +177,11 @@ class ZonalStudentDetailsCSVAPI(APIView):
 
         user_org_link = dash_zonal_helper.get_user_college_link(user_id)
 
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
+
         rank = (
             Wallet.objects.filter(
                 user__user_organization_link_user__org__district__zone=user_org_link.org.district.zone,
@@ -199,6 +224,11 @@ class ZonalCollegeDetailsAPI(APIView):
         user_id = JWTUtils.fetch_user_id(request)
 
         user_org_link = dash_zonal_helper.get_user_college_link(user_id)
+
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
 
         organizations = (
             Organization.objects.filter(
@@ -263,6 +293,11 @@ class ZonalCollegeDetailsCSVAPI(APIView):
         user_id = JWTUtils.fetch_user_id(request)
 
         user_org_link = dash_zonal_helper.get_user_college_link(user_id)
+
+        if user_org_link is None:
+            return CustomResponse(
+                general_message="No college organization linked to this user."
+            ).get_failure_response()
 
         organizations = (
             Organization.objects.filter(


### PR DESCRIPTION
### **Problem**

> Multiple endpoints in the district and zonal dashboard APIs were crashing with a 500 AttributeError: 'NoneType' object has no attribute 'org' when the authenticated user had no linked college organization in UserOrganizationLink. Additionally, several ORM and serializer bugs caused silent data corruption and FieldError crashes.

### **Changes**

- **Added Missing None Checks (Crash Fix)**: Added checks in all 14 views (7 district, 7 zonal) to prevent 500 AttributeError crashes when a user doesn't have a linked college organization. It now returns a proper 400 error message.

- **Fixed org_org_type Typo**: Fixed a missing double-underscore in dash_zonal_serializer.py that was causing the API to silently ignore the college filter and return incorrect karma and member counts.

- **Fixed user__ Prefix Error**: Removed an invalid user__ prefix in the zonal serializer that would have caused a FieldError runtime crash on the student level status endpoint.

- **Fixed Missing Commas in Serializers**: Added accidentally missing commas in dash_district_serializer.py
 tuples. This prevents Python from silently concatenating "user_id" and "full_name" together and dropping user_id from the API response.

- **Fixed Sorting Typo**: Corrected a typo (-update_at to -updated_at) in DistrictStudentDetailsAPI
 that would have caused a sorting crash.