### PR TITLE
feat: Mentorship Operations & Session Management

### DIFF
--- a/api/dashboard/mentorship/__init__.py
+++ b/api/dashboard/mentorship/__init__.py
@@ -1,0 +1,1 @@
+# Mentorship API module

--- a/api/dashboard/mentorship/mentorship_views.py
+++ b/api/dashboard/mentorship/mentorship_views.py
@@ -1,0 +1,391 @@
+from django.db.models import Count, Max, F, Q, Subquery, OuterRef
+from rest_framework.views import APIView
+
+from db.user import User, UserMentor
+from db.task import (
+    KarmaActivityLog, UserIgLink, UserIgLvlLink,
+    Wallet, UserLvlLink, InterestGroup, MentorSession
+)
+from db.achievement import UserIgKarma
+from utils.permission import CustomizePermission, JWTUtils, role_required
+from utils.response import CustomResponse
+from utils.types import RoleType
+from utils.utils import CommonUtils
+from . import serializers as mentorship_serializers
+
+
+
+class MentorStatusAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.MENTOR.value])
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        mentor = UserMentor.objects.filter(user_id=user_id).first()
+        if mentor is None:
+            return CustomResponse(
+                general_message="Mentor profile not found"
+            ).get_failure_response()
+
+        serializer = mentorship_serializers.MentorStatusSerializer(mentor)
+        return CustomResponse(response=serializer.data).get_success_response()
+
+
+class MentorProfileAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.MENTOR.value])
+    def patch(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        mentor = UserMentor.objects.filter(user_id=user_id).first()
+        if mentor is None:
+            return CustomResponse(
+                general_message="Mentor profile not found"
+            ).get_failure_response()
+
+        serializer = mentorship_serializers.MentorProfileUpdateSerializer(
+            mentor, data=request.data, partial=True,
+            context={"user_id": user_id},
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message="Profile updated successfully"
+            ).get_success_response()
+
+        return CustomResponse(message=serializer.errors).get_failure_response()
+
+
+class MentorSessionAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.MENTOR.value])
+    def get(self, request):
+        """List sessions for the authenticated mentor."""
+        user_id = JWTUtils.fetch_user_id(request)
+
+        sessions = MentorSession.objects.filter(
+            mentor_id=user_id
+        ).select_related("mentee", "ig")
+
+        params = request.query_params
+
+        if status := params.get("status"):
+            sessions = sessions.filter(status=status)
+
+        if date_from := params.get("date_from"):
+            sessions = sessions.filter(scheduled_at__date__gte=date_from)
+
+        if date_to := params.get("date_to"):
+            sessions = sessions.filter(scheduled_at__date__lte=date_to)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            sessions,
+            request,
+            search_fields=["title"],
+            sort_fields={
+                "scheduled_at": "scheduled_at",
+                "title": "title",
+            },
+        )
+
+        serializer = mentorship_serializers.MentorSessionListSerializer(
+            paginated["queryset"], many=True
+        )
+        return CustomResponse(
+            response={
+                "data": serializer.data,
+                "pagination": paginated["pagination"],
+            }
+        ).get_success_response()
+
+    @role_required([RoleType.MENTOR.value])
+    def post(self, request):
+        """Create a new session — verified mentors only."""
+        user_id = JWTUtils.fetch_user_id(request)
+
+        mentor = UserMentor.objects.filter(user_id=user_id).first()
+        if mentor is None or not mentor.is_verified:
+            return CustomResponse(
+                general_message="Only verified mentors can create sessions"
+            ).get_failure_response(
+                status_code=403,
+                http_status_code=403,
+            )
+
+        ig_id = request.data.get("ig_id")
+        if ig_id:
+            mentor_ig_ids = UserIgLink.objects.filter(
+                user_id=user_id
+            ).values_list("ig_id", flat=True)
+            if ig_id not in mentor_ig_ids:
+                return CustomResponse(
+                    general_message="You are not authorized for this interest group"
+                ).get_failure_response(
+                    status_code=403,
+                    http_status_code=403,
+                )
+
+        serializer = mentorship_serializers.MentorSessionCreateSerializer(
+            data=request.data, context={"user_id": user_id}
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message="Session created successfully"
+            ).get_success_response()
+
+        return CustomResponse(message=serializer.errors).get_failure_response()
+
+    @role_required([RoleType.MENTOR.value])
+    def patch(self, request, session_id=None):
+        """Update session status (complete/cancel) and notes."""
+        if not session_id:
+            return CustomResponse(
+                general_message="session_id is required"
+            ).get_failure_response()
+
+        user_id = JWTUtils.fetch_user_id(request)
+
+        session = MentorSession.objects.filter(id=session_id).first()
+        if session is None:
+            return CustomResponse(
+                general_message="Session not found"
+            ).get_failure_response()
+
+        if session.mentor_id != user_id:
+            return CustomResponse(
+                general_message="Not your session to update"
+            ).get_failure_response(
+                status_code=403,
+                http_status_code=403,
+            )
+
+        serializer = mentorship_serializers.MentorSessionUpdateSerializer(
+            session, data=request.data, partial=True,
+            context={"user_id": user_id},
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message="Session updated successfully"
+            ).get_success_response()
+
+        return CustomResponse(message=serializer.errors).get_failure_response()
+
+
+class MentorMenteeAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.MENTOR.value])
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        ig_id = request.query_params.get("ig_id")
+
+        session_qs = MentorSession.objects.filter(mentor_id=user_id)
+        if ig_id:
+            session_qs = session_qs.filter(ig_id=ig_id)
+
+        mentee_stats = (
+            session_qs
+            .values("mentee_id")
+            .annotate(
+                session_count=Count("id"),
+                last_session_at=Max("scheduled_at"),
+            )
+        )
+
+        mentee_ids = [m["mentee_id"] for m in mentee_stats]
+        stats_map = {m["mentee_id"]: m for m in mentee_stats}
+
+        mentees = (
+            User.objects.filter(id__in=mentee_ids)
+            .annotate(
+                karma=F("wallet_user__karma"),
+                level=F("user_lvl_link_user__level__name"),
+            )
+        )
+
+        paginated = CommonUtils.get_paginated_queryset(
+            mentees,
+            request,
+            search_fields=["full_name", "muid"],
+            sort_fields={
+                "full_name": "full_name",
+                "karma": "wallet_user__karma",
+            },
+        )
+
+        data = []
+        for mentee in paginated["queryset"]:
+            stats = stats_map.get(mentee.id, {})
+
+            ig_karma = None
+            ig_level = None
+            if ig_id:
+                ig_karma_obj = UserIgKarma.objects.filter(
+                    user_id=mentee.id, ig_id=ig_id
+                ).first()
+                if ig_karma_obj:
+                    ig_karma = ig_karma_obj.total_karma
+
+                ig_lvl_obj = UserIgLvlLink.objects.filter(
+                    user_id=mentee.id, ig_id=ig_id
+                ).select_related("level").first()
+                if ig_lvl_obj:
+                    ig_level = ig_lvl_obj.level.name
+
+            data.append({
+                "user_id": mentee.id,
+                "full_name": mentee.full_name,
+                "muid": mentee.muid,
+                "profile_pic": str(mentee.profile_pic) if mentee.profile_pic else None,
+                "karma": mentee.karma or 0,
+                "level": mentee.level,
+                "ig_karma": ig_karma,
+                "ig_level": ig_level,
+                "session_count": stats.get("session_count", 0),
+                "last_session_at": stats.get("last_session_at"),
+            })
+
+        return CustomResponse(
+            response={
+                "data": data,
+                "pagination": paginated["pagination"],
+            }
+        ).get_success_response()
+
+
+
+class MentorTaskQueueAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.MENTOR.value])
+    def get(self, request):
+        """Task verification queue filtered by mentor's IGs."""
+        user_id = JWTUtils.fetch_user_id(request)
+
+        # Guard: verified mentor only
+        mentor = UserMentor.objects.filter(user_id=user_id).first()
+        if mentor is None or not mentor.is_verified:
+            return CustomResponse(
+                general_message="Only verified mentors can access the task queue"
+            ).get_failure_response(
+                status_code=403,
+                http_status_code=403,
+            )
+
+        mentor_ig_ids = list(
+            UserIgLink.objects.filter(user_id=user_id)
+            .values_list("ig_id", flat=True)
+        )
+
+        logs = (
+            KarmaActivityLog.objects.filter(
+                task__ig_id__in=mentor_ig_ids
+            )
+            .select_related("user", "task", "task__ig")
+        )
+
+        params = request.query_params
+        if ig_id := params.get("ig_id"):
+            logs = logs.filter(task__ig_id=ig_id)
+
+        status_filter = params.get("status", "pending")
+        if status_filter == "pending":
+            logs = logs.filter(appraiser_approved__isnull=True)
+        elif status_filter == "approved":
+            logs = logs.filter(appraiser_approved=True)
+        elif status_filter == "rejected":
+            logs = logs.filter(appraiser_approved=False)
+
+        logs = logs.order_by("-created_at")
+
+        paginated = CommonUtils.get_paginated_queryset(
+            logs,
+            request,
+            search_fields=["user__full_name", "task__title"],
+            sort_fields={
+                "created_at": "created_at",
+            },
+        )
+
+        serializer = mentorship_serializers.TaskQueueSerializer(
+            paginated["queryset"], many=True
+        )
+        return CustomResponse(
+            response={
+                "data": serializer.data,
+                "pagination": paginated["pagination"],
+            }
+        ).get_success_response()
+
+    @role_required([RoleType.MENTOR.value])
+    def patch(self, request, log_id=None):
+        """Approve or reject a pending task."""
+        if not log_id:
+            return CustomResponse(
+                general_message="log_id is required"
+            ).get_failure_response()
+
+        user_id = JWTUtils.fetch_user_id(request)
+
+        mentor = UserMentor.objects.filter(user_id=user_id).first()
+        if mentor is None or not mentor.is_verified:
+            return CustomResponse(
+                general_message="Only verified mentors can approve tasks"
+            ).get_failure_response(
+                status_code=403,
+                http_status_code=403,
+            )
+
+        log_entry = KarmaActivityLog.objects.filter(
+            id=log_id
+        ).select_related("task", "task__ig").first()
+
+        if log_entry is None:
+            return CustomResponse(
+                general_message="Karma log entry not found"
+            ).get_failure_response()
+
+        if log_entry.appraiser_approved is not None:
+            return CustomResponse(
+                general_message="This task has already been actioned"
+            ).get_failure_response(
+                status_code=403,
+                http_status_code=403,
+            )
+
+        if log_entry.task and log_entry.task.ig:
+            is_authorized = UserIgLink.objects.filter(
+                user_id=user_id,
+                ig_id=log_entry.task.ig_id,
+            ).exists()
+            if not is_authorized:
+                return CustomResponse(
+                    general_message="You are not authorized for this task's interest group"
+                ).get_failure_response(
+                    status_code=403,
+                    http_status_code=403,
+                )
+
+        action_status = request.data.get("status")
+        if action_status not in ("approved", "rejected"):
+            return CustomResponse(
+                general_message="status is required and must be 'approved' or 'rejected'"
+            ).get_failure_response()
+
+        remarks = request.data.get("remarks")
+
+        log_entry.appraiser_approved = (action_status == "approved")
+        log_entry.appraiser_approved_by_id = user_id
+        log_entry.remarks = remarks
+        log_entry.updated_by_id = user_id
+        log_entry.save()
+
+        action_word = "approved" if action_status == "approved" else "rejected"
+        return CustomResponse(
+            general_message=f"Task {action_word} successfully"
+        ).get_success_response()

--- a/api/dashboard/mentorship/serializers.py
+++ b/api/dashboard/mentorship/serializers.py
@@ -1,0 +1,169 @@
+import uuid
+
+from rest_framework import serializers
+
+from db.user import User, UserMentor
+from db.task import KarmaActivityLog, InterestGroup, MentorSession
+
+
+class MentorStatusSerializer(serializers.ModelSerializer):
+    is_mentor = serializers.SerializerMethodField()
+    tier = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UserMentor
+        fields = [
+            "is_mentor",
+            "is_verified",
+            "tier",
+            "hours",
+            "about",
+            "reason",
+        ]
+
+    def get_is_mentor(self, obj):
+        return True
+
+    def get_tier(self, obj):
+        return "Verified" if obj.is_verified else "Normal"
+
+
+class MentorProfileUpdateSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = UserMentor
+        fields = ["about", "reason", "hours"]
+        extra_kwargs = {
+            "about": {"required": False},
+            "reason": {"required": False},
+            "hours": {"required": False},
+        }
+
+    def update(self, instance, validated_data):
+        user_id = self.context.get("user_id")
+        instance.about = validated_data.get("about", instance.about)
+        instance.reason = validated_data.get("reason", instance.reason)
+        instance.hours = validated_data.get("hours", instance.hours)
+        instance.updated_by_id = user_id
+        instance.save()
+        return instance
+
+
+class MentorSessionCreateSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = MentorSession
+        fields = [
+            "mentee",
+            "ig",
+            "title",
+            "description",
+            "scheduled_at",
+            "duration_minutes",
+            "meeting_link",
+        ]
+        extra_kwargs = {
+            "ig": {"required": False, "allow_null": True},
+            "description": {"required": False, "allow_null": True},
+            "meeting_link": {"required": False, "allow_null": True},
+        }
+
+    def validate_mentee(self, value):
+        if not User.objects.filter(id=value.id).exists():
+            raise serializers.ValidationError("Mentee not found")
+        return value
+
+    def create(self, validated_data):
+        user_id = self.context.get("user_id")
+        validated_data["id"] = str(uuid.uuid4())
+        validated_data["mentor_id"] = user_id
+        validated_data["status"] = MentorSession.Status.SCHEDULED
+        validated_data["created_by_id"] = user_id
+        validated_data["updated_by_id"] = user_id
+        return MentorSession.objects.create(**validated_data)
+
+
+class MentorSessionListSerializer(serializers.ModelSerializer):
+    mentee_id = serializers.CharField(source="mentee.id")
+    mentee_name = serializers.CharField(source="mentee.full_name")
+    ig_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MentorSession
+        fields = [
+            "id",
+            "mentee_id",
+            "mentee_name",
+            "ig_name",
+            "title",
+            "scheduled_at",
+            "duration_minutes",
+            "status",
+            "meeting_link",
+            "notes",
+        ]
+
+    def get_ig_name(self, obj):
+        return obj.ig.name if obj.ig else None
+
+
+class MentorSessionUpdateSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = MentorSession
+        fields = ["status", "notes"]
+        extra_kwargs = {
+            "status": {"required": False},
+            "notes": {"required": False},
+        }
+
+    def validate_status(self, value):
+        if value not in (MentorSession.Status.COMPLETED, MentorSession.Status.CANCELLED):
+            raise serializers.ValidationError("Status must be 'completed' or 'cancelled'")
+        return value
+
+    def update(self, instance, validated_data):
+        user_id = self.context.get("user_id")
+        instance.status = validated_data.get("status", instance.status)
+        instance.notes = validated_data.get("notes", instance.notes)
+        instance.updated_by_id = user_id
+        instance.save()
+        return instance
+
+
+class TaskQueueSerializer(serializers.ModelSerializer):
+    mentee_id = serializers.CharField(source="user.id")
+    mentee_name = serializers.CharField(source="user.full_name")
+    task_id = serializers.CharField(source="task.id")
+    task_title = serializers.CharField(source="task.title")
+    task_hashtag = serializers.CharField(source="task.hashtag")
+    task_karma = serializers.IntegerField(source="task.karma")
+    ig_name = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+
+    class Meta:
+        model = KarmaActivityLog
+        fields = [
+            "id",
+            "mentee_id",
+            "mentee_name",
+            "task_id",
+            "task_title",
+            "task_hashtag",
+            "task_karma",
+            "ig_name",
+            "proof_link",
+            "remarks",
+            "status",
+            "created_at",
+        ]
+
+    def get_ig_name(self, obj):
+        if obj.task and obj.task.ig:
+            return obj.task.ig.name
+        return None
+
+    def get_status(self, obj):
+        if obj.appraiser_approved is None:
+            return "pending"
+        return "approved" if obj.appraiser_approved else "rejected"

--- a/api/dashboard/mentorship/urls.py
+++ b/api/dashboard/mentorship/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+from . import mentorship_views
+
+urlpatterns = [
+    path("status/", mentorship_views.MentorStatusAPI.as_view(), name="mentor-status"),
+    path("profile/", mentorship_views.MentorProfileAPI.as_view(), name="mentor-profile"),
+    path("sessions/", mentorship_views.MentorSessionAPI.as_view(), name="mentor-sessions"),
+    path("sessions/<str:session_id>/", mentorship_views.MentorSessionAPI.as_view(), name="mentor-session-detail"),
+    path("mentees/", mentorship_views.MentorMenteeAPI.as_view(), name="mentor-mentees"),
+    path("tasks/queue/", mentorship_views.MentorTaskQueueAPI.as_view(), name="mentor-task-queue"),
+    path("tasks/queue/<str:log_id>/", mentorship_views.MentorTaskQueueAPI.as_view(), name="mentor-task-action"),
+]

--- a/api/dashboard/urls.py
+++ b/api/dashboard/urls.py
@@ -28,5 +28,6 @@ urlpatterns = [
     path("achievement/", include("api.dashboard.achievement.urls")),
     path("skill/", include("api.dashboard.skill.urls")),
     path("company/", include("api.dashboard.company.urls")),
-    path("category/", include("api.dashboard.category.urls"))
+    path("category/", include("api.dashboard.category.urls")),
+    path("mentorship/", include("api.dashboard.mentorship.urls")),
 ]

--- a/db/task.py
+++ b/db/task.py
@@ -190,6 +190,8 @@ class KarmaActivityLog(models.Model):
     appraiser_approved_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="appraiser_approved_by",
                                                   blank=True, null=True,
                                               related_name="karma_activity_log_appraiser_approved_by")
+    proof_link = models.CharField(max_length=500, blank=True, null=True)
+    remarks = models.TextField(blank=True, null=True)
     updated_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="updated_by",
                                    related_name="karma_activity_log_updated_by")
     updated_at = models.DateTimeField(auto_now=True)
@@ -338,3 +340,38 @@ class TaskReport(models.Model):
     class Meta:
         managed = False
         db_table = "task_report"
+
+
+class MentorSession(models.Model):
+    class Status(models.TextChoices):
+        SCHEDULED = 'scheduled'
+        COMPLETED = 'completed'
+        CANCELLED = 'cancelled'
+
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    mentor = models.ForeignKey(User, on_delete=models.CASCADE,
+                               related_name='mentor_sessions_mentor')
+    mentee = models.ForeignKey(User, on_delete=models.CASCADE,
+                               related_name='mentor_sessions_mentee')
+    ig = models.ForeignKey(InterestGroup, on_delete=models.SET_NULL,
+                           null=True, blank=True)
+    title = models.CharField(max_length=200)
+    description = models.TextField(null=True, blank=True)
+    scheduled_at = models.DateTimeField()
+    duration_minutes = models.IntegerField()
+    status = models.CharField(max_length=20, choices=Status.choices,
+                              default=Status.SCHEDULED)
+    meeting_link = models.CharField(max_length=500, null=True, blank=True)
+    notes = models.TextField(null=True, blank=True)
+    created_by = models.ForeignKey(User, on_delete=models.CASCADE,
+                                   db_column='created_by',
+                                   related_name='mentor_session_created_by')
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_by = models.ForeignKey(User, on_delete=models.CASCADE,
+                                   db_column='updated_by',
+                                   related_name='mentor_session_updated_by')
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        managed = False
+        db_table = 'mentor_session'

--- a/db/user.py
+++ b/db/user.py
@@ -103,6 +103,7 @@ class UserMentor(models.Model):
     about = models.CharField(max_length=1000, blank=True, null=True)
     reason = models.CharField(max_length=1000, blank=True, null=True)
     hours = models.IntegerField()
+    is_verified = models.BooleanField(default=False)
     updated_by = models.ForeignKey(User, on_delete=models.CASCADE, db_column='updated_by',
                                    related_name='user_mentor_updated_by_set')
     updated_at = models.DateTimeField(blank=True, null=True)


### PR DESCRIPTION
## Summary
Implements the Mentorship API suite for mentor operations, session management, mentee tracking, and task verification under `/api/v1/dashboard/mentorship/`.

## Endpoints Added (8 APIs)

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/mentorship/status/` | Mentor verification status & tier |
| PATCH | `/mentorship/profile/` | Update mentor profile (about, hours, reason) |
| POST | `/mentorship/sessions/` | Create a 1:1 mentoring session |
| GET | `/mentorship/sessions/` | List mentor's sessions (with filters) |
| PATCH | `/mentorship/sessions/<id>/` | Update session status & notes |
| GET | `/mentorship/mentees/` | Mentee tracking with karma & progress |
| GET | `/mentorship/tasks/queue/` | Task verification queue filtered by IG |
| PATCH | `/mentorship/tasks/queue/<id>/` | Approve or reject pending tasks |

## Schema Changes (requires manual SQL migration)
- `ALTER TABLE user_mentor` → added `is_verified` column
- `ALTER TABLE karma_activity_log` → added `proof_link`, `remarks` columns
- `CREATE TABLE mentor_session` → new table for 1:1 sessions

## Key Design Decisions
- **No new verification table** — reuses `karma_activity_log` with added `remarks` and `proof_link` columns
- **Mentor-mentee relationship** inferred from `mentor_session` activity (no separate link table)
- **IG-based RBAC** — mentor's authorized IGs determined from `user_ig_link`
- **Verified-only gates** — session creation and task approval restricted to verified mentors
- `created_by` / `updated_by` always auto-set from JWT token

## Files Changed (7)
- `db/user.py` — added `is_verified` to `UserMentor`
- `db/task.py` — added `MentorSession` model, `proof_link` & `remarks` to `KarmaActivityLog`
- `api/dashboard/urls.py` — registered mentorship route
- `api/dashboard/mentorship/__init__.py` — module init
- `api/dashboard/mentorship/urls.py` — URL patterns
- `api/dashboard/mentorship/serializers.py` — serializers
- `api/dashboard/mentorship/mentorship_views.py` — view classes
