### PR TITLE
feat(profile): added editable profile with projects, experience & bio

### DIFF
--- a/api/dashboard/profile/profile_serializer.py
+++ b/api/dashboard/profile/profile_serializer.py
@@ -84,6 +84,9 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "interest_groups",
             "is_public",
             "percentile",
+            "bio",
+            "projects",
+            "experience",
         )
 
     def _get_user_org_link(self, obj, org_type):
@@ -396,6 +399,9 @@ class UserProfileEditSerializer(serializers.ModelSerializer):
             "gender",
             "dob",
             "district",
+            "bio",
+            "projects",
+            "experience",
         ]
 
 

--- a/api/dashboard/profile/profile_view.py
+++ b/api/dashboard/profile/profile_view.py
@@ -166,6 +166,28 @@ class UserProfileAPI(APIView):
 
         return CustomResponse(response=serializer.data).get_success_response()
 
+    def patch(self, request):
+        JWTUtils.is_jwt_authenticated(request)
+        user_id = JWTUtils.fetch_user_id(request)
+        user = User.objects.get(id=user_id)
+
+        serializer = profile_serializer.UserProfileEditSerializer(
+            user, data=request.data, partial=True
+        )
+
+        if serializer.is_valid():
+            serializer.save()
+
+            DiscordWebhooks.general_updates(
+                WebHookCategory.USER_PROFILE.value,
+                WebHookActions.UPDATE.value,
+                user_id,
+            )
+
+            return CustomResponse(response=serializer.data).get_success_response()
+
+        return CustomResponse(response=serializer.errors).get_failure_response()
+
 
 class UserLogAPI(APIView):
     def get(self, request, muid=None):

--- a/api_docs/Dashboard_Profile.md
+++ b/api_docs/Dashboard_Profile.md
@@ -34,12 +34,73 @@ Base path: `/api/dashboard/profile/`
 
 
 ## Endpoint: `user-profile/`
-- Brief: Collection endpoint.
-- Request body example (JSON):
+- Brief: GET - Fetch authenticated user's full profile. PATCH - Update authenticated user's profile fields.
+
+### GET Request
+- Response example (success - returns full profile including bio, projects, experience):
 ```json
 {
-  "field1": "value1",
-  "field2": "value2"
+  "hasError": false,
+  "statusCode": 200,
+  "message": {
+    "general": [
+      "Success"
+    ]
+  },
+  "response": {
+    "data": {
+      "id": "user-uuid",
+      "full_name": "John Doe",
+      "muid": "john-doe@mulearn",
+      "karma": 1500,
+      "profile_pic": "https://...",
+      "bio": "Passionate developer and open source contributor",
+      "projects": [
+        {
+          "title": "μLearn Tracker",
+          "link": "https://github.com/user/repo",
+          "description": "Track tasks and progress",
+          "tags": ["React", "Firebase"]
+        }
+      ],
+      "experience": [
+        "Intern at Tech Company (2023-2024)",
+        "Developer at Startup (2024-Present)"
+      ]
+    }
+  }
+}
+```
+
+### PATCH Request
+- Requires: Authentication token
+- Request body example (all fields optional):
+```json
+{
+  "full_name": "John Doe",
+  "email": "john@example.com",
+  "bio": "I love building amazing products",
+  "projects": [
+    {
+      "title": "μLearn Tracker",
+      "link": "https://github.com/user/repo",
+      "description": "Track tasks and progress",
+      "tags": ["React", "Firebase"]
+    },
+    {
+      "title": "Portfolio Site",
+      "link": "https://johndoe.dev",
+      "description": "Personal portfolio",
+      "tags": ["Next.js", "Tailwind"]
+    }
+  ],
+  "experience": [
+    "Intern at Tech Company (2023-2024)",
+    "Developer at Startup (2024-Present)"
+  ],
+  "gender": "Male",
+  "dob": "1999-05-15",
+  "mobile": "+91987654321"
 }
 ```
 - Response example (success):
@@ -53,7 +114,22 @@ Base path: `/api/dashboard/profile/`
     ]
   },
   "response": {
-    "data": "..."
+    "data": {
+      "full_name": "John Doe",
+      "email": "john@example.com",
+      "bio": "I love building amazing products",
+      "projects": [
+        {
+          "title": "μLearn Tracker",
+          "link": "https://github.com/user/repo",
+          "description": "Track tasks and progress",
+          "tags": ["React", "Firebase"]
+        }
+      ],
+      "experience": [
+        "Intern at Tech Company (2023-2024)"
+      ]
+    }
   }
 }
 ```

--- a/db/user.py
+++ b/db/user.py
@@ -33,6 +33,9 @@ class User(models.Model):
     interested_in_gig_work = models.BooleanField(default=False)
     suspended_by = models.ForeignKey("self", on_delete=models.SET(settings.SYSTEM_ADMIN_ID), blank=True, null=True,
                                      related_name="user_suspended_by_user", db_column="suspended_by", default=None)
+    bio = models.TextField(blank=True, null=True)
+    projects = models.JSONField(default=list, blank=True)
+    experience = models.JSONField(default=list, blank=True)
     objects = user_manager.ActiveUserManager()
     every = models.Manager()
 

--- a/schema.sql
+++ b/schema.sql
@@ -1834,6 +1834,12 @@ CREATE TABLE `user` (
   `suspended_by` varchar(36) DEFAULT NULL,
   `interested_in_work` tinyint(1) DEFAULT '0',
   `interested_in_gig_work` tinyint(1) DEFAULT '0',
+
+
+  `bio` TEXT,
+  `projects` JSON,
+  `experience` JSON,
+
   PRIMARY KEY (`id`),
   UNIQUE KEY `muid` (`muid`),
   UNIQUE KEY `email` (`email`),
@@ -1844,7 +1850,7 @@ CREATE TABLE `user` (
   CONSTRAINT `fk_user_ref_deleted_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_user_ref_district_id` FOREIGN KEY (`district_id`) REFERENCES `district` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_user_ref_suspended_by` FOREIGN KEY (`suspended_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+); ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
## 🎯 Editable Profile Page for Projects, Experience, and Bio

### Changes Made:
- ✅ Extended User model with `bio`, `projects`, and `experience` fields
- ✅ Updated serializers to include new fields in GET/PATCH responses
- ✅ Added PATCH endpoint to `/api/v1/dashboard/profile/user-profile/`
- ✅ Updated API documentation with examples
- ✅ Authenticated users can now update their own profile

### Files Changed:
- `db/user.py` - Added model fields
- `api/dashboard/profile/profile_serializer.py` - Updated serializers
- `api/dashboard/profile/profile_view.py` - Added PATCH method
- `api_docs/Dashboard_Profile.md` - Updated documentation

### Issue: #2433