### PR TITLE
new endpoint for mentor dasbaord added

### DIFF
--- a/api/dashboard/mentor/mentor_serializers.py
+++ b/api/dashboard/mentor/mentor_serializers.py
@@ -727,6 +727,86 @@ class GlobalSessionPendingSerializer(MentorSessionListSerializer):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Mentee Detail (endpoint 1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MenteeDetailSerializer(serializers.Serializer):
+    """Full profile of a single mentee as seen by a mentor or admin."""
+
+    user_id = serializers.UUIDField()
+    full_name = serializers.CharField()
+    email = serializers.EmailField()
+    muid = serializers.CharField()
+    total_sessions = serializers.IntegerField()
+    completed_sessions = serializers.IntegerField()
+    total_karma_earned = serializers.IntegerField()
+    tasks_reviewed = serializers.IntegerField()
+    tasks_approved = serializers.IntegerField()
+    tasks_rejected = serializers.IntegerField()
+    sessions = serializers.ListField(child=serializers.DictField())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bulk Attendance Update (endpoint 2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class AttendanceEntrySerializer(serializers.Serializer):
+    """Single participant attendance update entry."""
+
+    user_id = serializers.CharField(max_length=36)
+    attendance_status = serializers.ChoiceField(
+        choices=[s.value for s in MentorshipSessionUserLink.AttendanceStatus]
+    )
+
+
+class MentorSessionAttendanceSerializer(serializers.Serializer):
+    """Bulk attendance update — list of (user_id, attendance_status) pairs."""
+
+    participants = AttendanceEntrySerializer(many=True, min_length=1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Admin Tier Update (endpoint 10)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MentorTierUpdateSerializer(serializers.Serializer):
+    """Admin changes a verified mentor's tier."""
+
+    mentor_tier = serializers.ChoiceField(
+        choices=[t.value for t in UserMentor.MentorTier]
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public Session List (endpoint 5)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class PublicMentorSessionSerializer(serializers.ModelSerializer):
+    """Completed session entry for a mentor's public profile."""
+
+    ig_name = serializers.SerializerMethodField()
+    participant_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MentorshipSession
+        fields = [
+            "id",
+            "title",
+            "mode",
+            "ig_name",
+            "starts_at",
+            "ends_at",
+            "participant_count",
+        ]
+
+    def get_ig_name(self, obj):
+        return obj.ig.name if obj.ig else None
+
+    def get_participant_count(self, obj):
+        return obj.participants.count()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Public endpoints
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/api/dashboard/mentor/mentor_serializers.py
+++ b/api/dashboard/mentor/mentor_serializers.py
@@ -30,6 +30,11 @@ class MentorOnboardingSerializer(serializers.ModelSerializer):
             "updated_by": {"required": True},
         }
 
+    def validate_preferred_ig_ids(self, value):
+        if value is not None and not isinstance(value, list):
+            raise serializers.ValidationError("preferred_ig_ids must be a list of UUIDs.")
+        return value
+
 
 class MentorOnboardingUpdateSerializer(serializers.ModelSerializer):
     """Partial update of mentor's own profile fields."""
@@ -41,6 +46,11 @@ class MentorOnboardingUpdateSerializer(serializers.ModelSerializer):
             "updated_by": {"required": True},
             "preferred_ig_ids": {"required": False},
         }
+
+    def validate_preferred_ig_ids(self, value):
+        if value is not None and not isinstance(value, list):
+            raise serializers.ValidationError("preferred_ig_ids must be a list of UUIDs.")
+        return value
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -148,6 +158,7 @@ class MentorSessionListSerializer(serializers.ModelSerializer):
             "starts_at",
             "ends_at",
             "meeting_link",
+            "venue",
             "status",
             "is_global",
             "ig_id",
@@ -155,6 +166,7 @@ class MentorSessionListSerializer(serializers.ModelSerializer):
             "created_by_name",
             "created_at",
             "participant_count",
+            "max_participants",
         ]
 
     def get_ig_name(self, obj):
@@ -183,6 +195,7 @@ class MentorSessionDetailSerializer(serializers.ModelSerializer):
             "starts_at",
             "ends_at",
             "meeting_link",
+            "venue",
             "status",
             "is_global",
             "ig_id",
@@ -193,6 +206,7 @@ class MentorSessionDetailSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_by_name",
             "updated_at",
+            "max_participants",
             "participants",
         ]
 
@@ -216,8 +230,10 @@ class MentorSessionCreateSerializer(serializers.ModelSerializer):
             "starts_at",
             "ends_at",
             "meeting_link",
+            "venue",
             "is_global",
             "status",
+            "max_participants",
             "created_by",
             "updated_by",
         ]
@@ -225,9 +241,39 @@ class MentorSessionCreateSerializer(serializers.ModelSerializer):
             "ig": {"required": False, "allow_null": True},
             "is_global": {"required": False},
             "status": {"required": False},
+            "venue": {"required": False, "allow_null": True},
+            "max_participants": {"required": False, "allow_null": True},
             "created_by": {"required": True},
             "updated_by": {"required": True},
         }
+
+    def validate(self, attrs):
+        from utils.utils import DateTimeUtils
+        starts_at = attrs.get("starts_at")
+        ends_at = attrs.get("ends_at")
+        now = DateTimeUtils.get_current_utc_time()
+        
+        if starts_at and ends_at:
+            if starts_at >= ends_at:
+                raise serializers.ValidationError("starts_at must be before ends_at.")
+        if starts_at and starts_at < now:
+            raise serializers.ValidationError("starts_at cannot be in the past.")
+
+        mode = attrs.get("mode", MentorshipSession.Mode.ONLINE)
+        venue = attrs.get("venue")
+        meeting_link = attrs.get("meeting_link")
+
+        if mode == MentorshipSession.Mode.ONLINE:
+            if not meeting_link:
+                raise serializers.ValidationError({"meeting_link": "Meeting link is required for ONLINE sessions."})
+        elif mode == MentorshipSession.Mode.OFFLINE:
+            if not venue:
+                raise serializers.ValidationError({"venue": "Venue is required for OFFLINE sessions."})
+        elif mode == MentorshipSession.Mode.HYBRID:
+            if not meeting_link and not venue:
+                raise serializers.ValidationError("At least one of meeting_link or venue is required for HYBRID sessions.")
+
+        return attrs
 
 
 class MentorSessionUpdateSerializer(serializers.ModelSerializer):
@@ -242,9 +288,40 @@ class MentorSessionUpdateSerializer(serializers.ModelSerializer):
             "starts_at",
             "ends_at",
             "meeting_link",
+            "venue",
+            "max_participants",
             "updated_by",
         ]
-        extra_kwargs = {"updated_by": {"required": True}}
+        extra_kwargs = {
+            "updated_by": {"required": True},
+            "venue": {"required": False, "allow_null": True},
+            "max_participants": {"required": False, "allow_null": True},
+        }
+
+    def validate(self, attrs):
+
+        starts_at = attrs.get("starts_at", self.instance.starts_at if self.instance else None)
+        ends_at = attrs.get("ends_at", self.instance.ends_at if self.instance else None)
+        
+        if starts_at and ends_at:
+            if starts_at >= ends_at:
+                raise serializers.ValidationError("starts_at must be before ends_at.")
+
+        mode = attrs.get("mode", getattr(self.instance, "mode", MentorshipSession.Mode.ONLINE))
+        venue = attrs.get("venue", getattr(self.instance, "venue", None))
+        meeting_link = attrs.get("meeting_link", getattr(self.instance, "meeting_link", None))
+
+        if mode == MentorshipSession.Mode.ONLINE:
+            if not meeting_link:
+                raise serializers.ValidationError({"meeting_link": "Meeting link is required for ONLINE sessions."})
+        elif mode == MentorshipSession.Mode.OFFLINE:
+            if not venue:
+                raise serializers.ValidationError({"venue": "Venue is required for OFFLINE sessions."})
+        elif mode == MentorshipSession.Mode.HYBRID:
+            if not meeting_link and not venue:
+                raise serializers.ValidationError("At least one of meeting_link or venue is required for HYBRID sessions.")
+
+        return attrs
 
 
 class MentorSessionStatusSerializer(serializers.ModelSerializer):
@@ -327,6 +404,15 @@ class MentorAvailabilityWriteSerializer(serializers.ModelSerializer):
             "updated_by": {"required": True},
         }
 
+    def validate(self, attrs):
+        start_time = attrs.get("start_time", self.instance.start_time if self.instance else None)
+        end_time = attrs.get("end_time", self.instance.end_time if self.instance else None)
+        
+        if start_time and end_time:
+            if start_time >= end_time:
+                raise serializers.ValidationError("start_time must be before end_time.")
+        return attrs
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Task Requests
@@ -388,9 +474,32 @@ class MentorTaskRequestCreateSerializer(serializers.ModelSerializer):
             "updated_by": {"required": True},
         }
 
+    def validate_hashtag(self, value):
+        if not value:
+            raise serializers.ValidationError("Hashtag cannot be empty.")
+            
+        value = value.strip().lower()
+        if not value.startswith("#"):
+            value = f"#{value}"
+
+        if TaskList.objects.filter(hashtag=value).exists():
+            raise serializers.ValidationError("A task/request with this hashtag already exists.")
+            
+        if MentorTaskRequest.objects.filter(hashtag=value, status__in=[MentorTaskRequest.Status.PENDING, MentorTaskRequest.Status.APPROVED]).select_for_update().exists():
+            raise serializers.ValidationError("A task/request with this hashtag already exists.")
+            
+        return value
+
 
 class MentorTaskRequestReviewSerializer(serializers.ModelSerializer):
     """Admin approves or rejects a mentor task request."""
+
+    status = serializers.ChoiceField(
+        choices=[
+            MentorTaskRequest.Status.APPROVED.value,
+            MentorTaskRequest.Status.REJECTED.value,
+        ]
+    )
 
     class Meta:
         model = MentorTaskRequest
@@ -459,6 +568,15 @@ class IgOpportunityWriteSerializer(serializers.ModelSerializer):
             "created_by": {"required": True},
             "updated_by": {"required": True},
         }
+
+    def validate(self, attrs):
+        starts_at = attrs.get("starts_at", getattr(self.instance, "starts_at", None))
+        ends_at = attrs.get("ends_at", getattr(self.instance, "ends_at", None))
+        
+        if starts_at and ends_at:
+            if starts_at >= ends_at:
+                raise serializers.ValidationError("starts_at must be before ends_at.")
+        return attrs
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -606,3 +724,57 @@ class GlobalSessionPendingSerializer(MentorSessionListSerializer):
         """Top-3 IGs by keyword overlap with session title+description."""
         suggestions = self.context.get("ig_suggestions", {})
         return suggestions.get(obj.id, [])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public endpoints
+# ─────────────────────────────────────────────────────────────────────────────
+
+class PublicMentorCardSerializer(serializers.ModelSerializer):
+    """Public read-only profile for frontend mentor discovery pages."""
+    full_name = serializers.CharField(source="user.full_name")
+    muid = serializers.CharField(source="user.muid")
+    profile_pic = serializers.CharField(source="user.profile_pic", allow_null=True)
+    linked_igs = serializers.SerializerMethodField()
+    availability_slots = serializers.SerializerMethodField()
+    session_stats = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UserMentor
+        fields = [
+            "full_name",
+            "muid",
+            "profile_pic",
+            "about",
+            "expertise",
+            "mentor_tier",
+            "linked_igs",
+            "availability_slots",
+            "session_stats",
+        ]
+
+    def get_linked_igs(self, obj):
+        from db.task import UserIgLink
+        links = UserIgLink.objects.filter(
+            user_id=obj.user_id,
+            assignment_type=UserIgLink.AssignmentType.MENTOR,
+            is_active=True
+        ).select_related("ig")
+        return [{"ig_id": link.ig_id, "name": link.ig.name} for link in links if link.ig]
+
+    def get_availability_slots(self, obj):
+        from db.mentor import MentorAvailabilitySlot
+        slots = MentorAvailabilitySlot.objects.filter(mentor_user_id=obj.user_id, is_active=True)
+        return MentorAvailabilitySerializer(slots, many=True).data
+
+    def get_session_stats(self, obj):
+        from db.mentor import MentorshipSessionUserLink, MentorshipSession
+        links = MentorshipSessionUserLink.objects.filter(
+            user_id=obj.user_id,
+            participant_role__in=[
+                MentorshipSessionUserLink.ParticipantRole.MENTOR, 
+                MentorshipSessionUserLink.ParticipantRole.CO_MENTOR
+            ]
+        ).values_list("session_id", flat=True)
+        completed = MentorshipSession.objects.filter(id__in=links, status=MentorshipSession.Status.COMPLETED).count()
+        return {"completed_sessions": completed, "hours": obj.hours}

--- a/api/dashboard/mentor/mentor_views.py
+++ b/api/dashboard/mentor/mentor_views.py
@@ -22,11 +22,13 @@ from utils.types import RoleType
 from utils.utils import CommonUtils, DateTimeUtils
 
 from .mentor_serializers import (
+    AttendanceEntrySerializer,
     GlobalSessionPendingSerializer,
     IgOpportunitySerializer,
     IgOpportunityWriteSerializer,
     KarmaReviewQueueSerializer,
     KarmaReviewSerializer,
+    MenteeDetailSerializer,
     MentorAvailabilitySerializer,
     MentorAvailabilityWriteSerializer,
     MentorKarmaAwardSerializer,
@@ -35,6 +37,7 @@ from .mentor_serializers import (
     MentorListSerializer,
     MentorOnboardingSerializer,
     MentorOnboardingUpdateSerializer,
+    MentorSessionAttendanceSerializer,
     MentorSessionCreateSerializer,
     MentorSessionDetailSerializer,
     MentorSessionListSerializer,
@@ -45,7 +48,9 @@ from .mentor_serializers import (
     MentorTaskRequestCreateSerializer,
     MentorTaskRequestReviewSerializer,
     MentorTaskRequestSerializer,
+    MentorTierUpdateSerializer,
     MentorVerifySerializer,
+    PublicMentorSessionSerializer,
     SystemActionLogSerializer,
 )
 
@@ -1288,7 +1293,7 @@ class MentorTaskRequestAPI(APIView):
 
 
 class MentorTaskRequestDetailAPI(APIView):
-    """GET — detail; PATCH — admin review (approve/reject)."""
+    """GET — detail; PATCH — admin review (approve/reject); DELETE — mentor withdraws pending request."""
     authentication_classes = [CustomizePermission]
 
     @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
@@ -1383,6 +1388,32 @@ class MentorTaskRequestDetailAPI(APIView):
         return CustomResponse(
             general_message=f"Task request {new_status.lower()}.",
             response={"task_request": MentorTaskRequestSerializer(task_req).data},
+        ).get_success_response()
+
+    @role_required([RoleType.MENTOR.value])
+    def delete(self, request, pk):
+        """Mentor withdraws their own PENDING task request before admin review."""
+        user_id = JWTUtils.fetch_user_id(request)
+
+        task_req = MentorTaskRequest.objects.filter(
+            id=pk, mentor_id=user_id
+        ).first()
+        if not task_req:
+            return CustomResponse(
+                general_message="Task request not found."
+            ).get_failure_response()
+
+        if task_req.status != MentorTaskRequest.Status.PENDING:
+            return CustomResponse(
+                general_message=(
+                    f"Cannot withdraw a task request with status '{task_req.status}'. "
+                    "Only PENDING requests can be withdrawn."
+                )
+            ).get_failure_response()
+
+        task_req.delete()
+        return CustomResponse(
+            general_message="Task request withdrawn successfully."
         ).get_success_response()
 
 
@@ -1796,10 +1827,42 @@ class MentorTaskReviewQueueAPI(APIView):
 
 class MentorTaskReviewDetailAPI(APIView):
     """
+    GET   /mentor/review-queue/<kal_id>/ — single KAL entry detail
     PATCH /mentor/review-queue/<kal_id>/ — mentor approves or rejects a task submission
     Karma is NOT credited here; admin finalises via the existing appraiser flow.
     """
     authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
+    def get(self, request, pk):
+        user_id = JWTUtils.fetch_user_id(request)
+        roles   = JWTUtils.fetch_role(request)
+        is_admin = RoleType.ADMIN.value in roles
+
+        kal = KarmaActivityLog.objects.select_related(
+            "user", "task__ig"
+        ).filter(id=pk).first()
+        if not kal:
+            return CustomResponse(general_message="Task submission not found.").get_failure_response()
+
+        # Mentors can only see items from their own IGs
+        if not is_admin:
+            mentor_ig_ids = (
+                MentorshipSessionUserLink.objects
+                .filter(
+                    user_id=user_id,
+                    participant_role=MentorshipSessionUserLink.ParticipantRole.MENTOR,
+                )
+                .values_list("session__ig_id", flat=True)
+                .distinct()
+            )
+            if kal.task and kal.task.ig_id not in mentor_ig_ids:
+                return CustomResponse(
+                    general_message="Task submission not found."
+                ).get_failure_response()
+
+        serializer = KarmaReviewQueueSerializer(kal)
+        return CustomResponse(response={"submission": serializer.data}).get_success_response()
 
     @role_required([RoleType.MENTOR.value])
     def patch(self, request, pk):
@@ -2256,4 +2319,506 @@ class PublicMentorCardAPI(APIView):
         serializer = PublicMentorCardSerializer(mentor)
         return CustomResponse(
             response=serializer.data
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint 1 — Mentee Detail
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MentorMenteeDetailAPI(APIView):
+    """
+    GET /mentor/mentees/<user_pk>/
+
+    Returns a full profile of a single mentee:
+    - User info
+    - Sessions shared with the requesting mentor (or all sessions for admin)
+    - Karma earned by the mentee from tasks within the mentor's IGs
+    - Task review stats (reviewed / approved / rejected by this mentor)
+    """
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
+    def get(self, request, user_pk):
+        caller_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+        is_admin = RoleType.ADMIN.value in roles
+
+        # Verify the target user exists
+        mentee_user = User.objects.filter(id=user_pk).first()
+        if not mentee_user:
+            return CustomResponse(general_message="User not found.").get_failure_response()
+
+        # Determine which session IDs to scope to
+        if is_admin:
+            # Admin sees all sessions this person attended as MENTEE
+            session_links = MentorshipSessionUserLink.objects.filter(
+                user_id=user_pk,
+                participant_role=MentorshipSessionUserLink.ParticipantRole.MENTEE,
+            )
+        else:
+            # Mentor sees only sessions they were MENTOR/CO_MENTOR in
+            mentor_session_ids = (
+                MentorshipSessionUserLink.objects
+                .filter(
+                    user_id=caller_id,
+                    participant_role__in=[
+                        MentorshipSessionUserLink.ParticipantRole.MENTOR,
+                        MentorshipSessionUserLink.ParticipantRole.CO_MENTOR,
+                    ],
+                )
+                .values_list("session_id", flat=True)
+            )
+            session_links = MentorshipSessionUserLink.objects.filter(
+                user_id=user_pk,
+                session_id__in=mentor_session_ids,
+                participant_role=MentorshipSessionUserLink.ParticipantRole.MENTEE,
+            )
+
+        if not session_links.exists():
+            return CustomResponse(
+                general_message="Mentee has no sessions with you."
+            ).get_failure_response()
+
+        attended_session_ids = list(session_links.values_list("session_id", flat=True))
+
+        # Fetch session details
+        sessions_qs = (
+            MentorshipSession.objects
+            .filter(id__in=attended_session_ids)
+            .select_related("ig")
+            .order_by("-starts_at")
+        )
+        sessions_data = [
+            {
+                "session_id": str(s.id),
+                "title": s.title,
+                "ig_name": s.ig.name if s.ig else None,
+                "status": s.status,
+                "starts_at": s.starts_at,
+                "ends_at": s.ends_at,
+            }
+            for s in sessions_qs
+        ]
+
+        total_sessions = len(attended_session_ids)
+        completed_sessions = sessions_qs.filter(
+            status=MentorshipSession.Status.COMPLETED
+        ).count()
+
+        # Karma earned by this mentee from tasks in the mentor's IGs
+        if is_admin:
+            karma_qs = KarmaActivityLog.objects.filter(user_id=user_pk)
+        else:
+            mentor_ig_ids = (
+                MentorshipSession.objects
+                .filter(id__in=mentor_session_ids)
+                .values_list("ig_id", flat=True)
+                .distinct()
+            )
+            karma_qs = KarmaActivityLog.objects.filter(
+                user_id=user_pk,
+                task__ig_id__in=mentor_ig_ids,
+            )
+
+        total_karma_earned = karma_qs.aggregate(
+            total=Coalesce(Sum("karma"), Value(0, output_field=IntegerField()))
+        )["total"]
+
+        # Task review stats (reviews submitted by this mentor on this mentee's submissions)
+        if is_admin:
+            reviewed_qs = KarmaActivityLog.objects.filter(user_id=user_pk)
+        else:
+            reviewed_qs = KarmaActivityLog.objects.filter(
+                user_id=user_pk,
+                mentor_reviewed_by_id=caller_id,
+            )
+
+        tasks_reviewed = reviewed_qs.exclude(mentor_review_status="PENDING").count()
+        tasks_approved = reviewed_qs.filter(mentor_review_status="APPROVED").count()
+        tasks_rejected = reviewed_qs.filter(mentor_review_status="REJECTED").count()
+
+        data = {
+            "user_id": str(mentee_user.id),
+            "full_name": mentee_user.full_name,
+            "email": mentee_user.email,
+            "muid": mentee_user.muid,
+            "total_sessions": total_sessions,
+            "completed_sessions": completed_sessions,
+            "total_karma_earned": total_karma_earned,
+            "tasks_reviewed": tasks_reviewed,
+            "tasks_approved": tasks_approved,
+            "tasks_rejected": tasks_rejected,
+            "sessions": sessions_data,
+        }
+
+        serializer = MenteeDetailSerializer(data=data)
+        serializer.is_valid()   # data is already clean; validation is a no-op here
+        return CustomResponse(response={"mentee": data}).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint 2 — Bulk Attendance Update
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MentorSessionAttendanceAPI(APIView):
+    """
+    PATCH /mentor/sessions/<pk>/attendance/
+
+    Bulk-update attendance_status for multiple participants in one request.
+
+    Body:
+        {
+          "participants": [
+            { "user_id": "<uuid>", "attendance_status": "ATTENDED" },
+            { "user_id": "<uuid>", "attendance_status": "NO_SHOW" },
+            ...
+          ]
+        }
+
+    - Admin: can update any session.
+    - Mentor: can only update sessions they created.
+    - Validates that every user_id is actually a participant in the session.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
+    def patch(self, request, pk):
+        user_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+        is_admin = RoleType.ADMIN.value in roles
+
+        session = MentorshipSession.objects.filter(id=pk).first()
+        if not session:
+            return CustomResponse(general_message="Session not found.").get_failure_response()
+
+        if not is_admin and str(session.created_by_id) != user_id:
+            return CustomResponse(
+                general_message="You can only update attendance for sessions you created."
+            ).get_failure_response()
+
+        serializer = MentorSessionAttendanceSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(general_message=serializer.errors).get_failure_response()
+
+        participant_updates = serializer.validated_data["participants"]
+
+        # Build map of user_id → attendance_status for fast lookup
+        update_map = {entry["user_id"]: entry["attendance_status"] for entry in participant_updates}
+        requested_user_ids = set(update_map.keys())
+
+        # Fetch existing links for validation
+        existing_links = MentorshipSessionUserLink.objects.filter(
+            session_id=pk,
+            user_id__in=requested_user_ids,
+        )
+        found_user_ids = {str(link.user_id) for link in existing_links}
+        missing = requested_user_ids - found_user_ids
+        if missing:
+            return CustomResponse(
+                general_message=f"The following users are not participants in this session: {', '.join(missing)}"
+            ).get_failure_response()
+
+        # Bulk update inside a transaction
+        with transaction.atomic():
+            updated_count = 0
+            for link in existing_links:
+                new_status = update_map[str(link.user_id)]
+                if link.attendance_status != new_status:
+                    link.attendance_status = new_status
+                    link.save(update_fields=["attendance_status"])
+                    updated_count += 1
+
+        _log_action(
+            action_type=SystemActionLog.ActionType.SESSION_UPDATE,
+            actor_user_id=user_id,
+            entity_name="mentorship_session",
+            entity_id=session.id,
+            ig=session.ig,
+            new_data={"attendance_bulk_update": list(participant_updates)},
+        )
+
+        return CustomResponse(
+            general_message=f"Attendance updated for {updated_count} participant(s)."
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint 5 — Public Session History
+# ─────────────────────────────────────────────────────────────────────────────
+
+class PublicMentorSessionsAPI(APIView):
+    """
+    GET /mentor/<muid>/public/sessions/
+
+    No authentication required.
+    Returns a paginated list of COMPLETED sessions where the mentor was
+    MENTOR or CO_MENTOR.
+
+    Optional query params:
+        ig_id  — filter by interest group
+        mode   — filter by session mode (ONLINE / OFFLINE / HYBRID)
+    """
+
+    def get(self, request, muid):
+        mentor = UserMentor.objects.select_related("user").filter(
+            user__muid=muid, is_verified=True
+        ).first()
+        if not mentor:
+            return CustomResponse(
+                general_message="Verified mentor profile not found."
+            ).get_failure_response()
+
+        ig_id = request.query_params.get("ig_id")
+        mode  = request.query_params.get("mode")
+
+        # Sessions where this user was the MENTOR or CO_MENTOR
+        mentor_session_ids = (
+            MentorshipSessionUserLink.objects
+            .filter(
+                user_id=mentor.user_id,
+                participant_role__in=[
+                    MentorshipSessionUserLink.ParticipantRole.MENTOR,
+                    MentorshipSessionUserLink.ParticipantRole.CO_MENTOR,
+                ],
+            )
+            .values_list("session_id", flat=True)
+        )
+
+        sessions_qs = (
+            MentorshipSession.objects
+            .filter(
+                id__in=mentor_session_ids,
+                status=MentorshipSession.Status.COMPLETED,
+            )
+            .select_related("ig")
+            .prefetch_related("participants")
+        )
+
+        if ig_id:
+            sessions_qs = sessions_qs.filter(ig_id=ig_id)
+        if mode:
+            sessions_qs = sessions_qs.filter(mode=mode)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            sessions_qs, request,
+            search_fields=["title", "ig__name"],
+            sort_fields={"starts_at": "starts_at", "title": "title"},
+        )
+        serializer = PublicMentorSessionSerializer(paginated["queryset"], many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data, pagination=paginated["pagination"]
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint 6 — Session Clone
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MentorSessionCloneAPI(APIView):
+    """
+    POST /mentor/sessions/<pk>/clone/
+
+    Deep-copies a session with the following rules:
+    - title     → "Copy of <original title>"
+    - status    → PENDING_APPROVAL (global) or SCHEDULED (IG-scoped)
+    - starts_at / ends_at → cleared (null); caller must PATCH afterwards
+    - All other fields (description, mode, ig, max_participants,
+      meeting_link, venue, is_global) are preserved
+    - Creator is automatically added as MENTOR participant
+    - Original participants are NOT copied
+    """
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
+    def post(self, request, pk):
+        user_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+        is_admin = RoleType.ADMIN.value in roles
+
+        original = MentorshipSession.objects.filter(id=pk).select_related("ig").first()
+        if not original:
+            return CustomResponse(general_message="Session not found.").get_failure_response()
+
+        # Mentors can only clone their own sessions
+        if not is_admin and str(original.created_by_id) != user_id:
+            return CustomResponse(
+                general_message="You can only clone sessions you created."
+            ).get_failure_response()
+
+        new_status = (
+            MentorshipSession.Status.PENDING_APPROVAL
+            if original.is_global
+            else MentorshipSession.Status.SCHEDULED
+        )
+
+        clone = MentorshipSession.objects.create(
+            title=f"Copy of {original.title}",
+            description=original.description,
+            mode=original.mode,
+            ig=original.ig,
+            is_global=original.is_global,
+            max_participants=original.max_participants,
+            meeting_link=original.meeting_link,
+            venue=original.venue,
+            status=new_status,
+            starts_at=None,
+            ends_at=None,
+            created_by_id=user_id,
+            updated_by_id=user_id,
+        )
+
+        # Auto-add creator as MENTOR participant
+        MentorshipSessionUserLink.objects.create(
+            session=clone,
+            user_id=user_id,
+            participant_role=MentorshipSessionUserLink.ParticipantRole.MENTOR,
+            attendance_status=MentorshipSessionUserLink.AttendanceStatus.INVITED,
+        )
+
+        _log_action(
+            action_type=SystemActionLog.ActionType.SESSION_CREATE,
+            actor_user_id=user_id,
+            entity_name="mentorship_session",
+            entity_id=clone.id,
+            ig=clone.ig,
+            new_data={
+                "cloned_from": str(original.id),
+                "title": clone.title,
+                "is_global": clone.is_global,
+            },
+        )
+
+        return CustomResponse(
+            general_message="Session cloned successfully. Update starts_at and ends_at before publishing.",
+            response={"session": MentorSessionDetailSerializer(clone).data},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint 9 — Public Availability Slots
+# ─────────────────────────────────────────────────────────────────────────────
+
+class PublicMentorAvailabilityAPI(APIView):
+    """
+    GET /mentor/availability/public/?mentor_muid=<muid>
+
+    No authentication required.
+    Returns active availability slots for a verified mentor.
+    Useful for mentee scheduling flows.
+
+    Required query param:
+        mentor_muid — the mentor's muid
+
+    Optional query param:
+        ig_id — filter slots by interest group
+    """
+
+    def get(self, request):
+        mentor_muid = request.query_params.get("mentor_muid")
+        if not mentor_muid:
+            return CustomResponse(
+                general_message="'mentor_muid' query parameter is required."
+            ).get_failure_response()
+
+        mentor = UserMentor.objects.select_related("user").filter(
+            user__muid=mentor_muid, is_verified=True
+        ).first()
+        if not mentor:
+            return CustomResponse(
+                general_message="Verified mentor profile not found."
+            ).get_failure_response()
+
+        ig_id = request.query_params.get("ig_id")
+        slots_qs = MentorAvailabilitySlot.objects.filter(
+            mentor_user_id=mentor.user_id,
+            is_active=True,
+        ).select_related("mentor_user", "ig")
+
+        if ig_id:
+            slots_qs = slots_qs.filter(ig_id=ig_id)
+
+        serializer = MentorAvailabilitySerializer(slots_qs, many=True)
+        return CustomResponse(
+            response={
+                "mentor": {
+                    "full_name": mentor.user.full_name,
+                    "muid": mentor.user.muid,
+                },
+                "availability": serializer.data,
+            }
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint 10 — Admin Mentor Tier Update
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MentorTierUpdateAPI(APIView):
+    """
+    PATCH /mentor/list/<pk>/tier/
+
+    Admin-only. Changes the mentor_tier of a verified mentor after they
+    have already been approved. Sends a notification to the mentor.
+
+    Body:
+        { "mentor_tier": "IG_MENTOR" | "MENTOR" }
+    """
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value])
+    def patch(self, request, pk):
+        admin_id = JWTUtils.fetch_user_id(request)
+
+        mentor = UserMentor.objects.filter(id=pk).select_related("user").first()
+        if not mentor:
+            return CustomResponse(
+                general_message="Mentor not found."
+            ).get_failure_response()
+
+        if not mentor.is_verified:
+            return CustomResponse(
+                general_message="Cannot change the tier of an unverified mentor. Approve the application first."
+            ).get_failure_response()
+
+        serializer = MentorTierUpdateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(general_message=serializer.errors).get_failure_response()
+
+        old_tier = mentor.mentor_tier
+        new_tier = serializer.validated_data["mentor_tier"]
+
+        if old_tier == new_tier:
+            return CustomResponse(
+                general_message=f"Mentor is already at tier '{new_tier}'. No change made."
+            ).get_success_response()
+
+        mentor.mentor_tier = new_tier
+        mentor.updated_by_id = admin_id
+        mentor.save(update_fields=["mentor_tier", "updated_by_id"])
+
+        Notification.objects.create(
+            user=mentor.user,
+            title="Mentor Tier Updated",
+            description=(
+                f"Your mentor tier has been updated from '{old_tier}' to '{new_tier}' "
+                f"by the muLearn admin team."
+            ),
+            created_by_id=admin_id,
+        )
+
+        _log_action(
+            action_type=SystemActionLog.ActionType.TASK_REVIEW,
+            actor_user_id=admin_id,
+            entity_name="user_mentor",
+            entity_id=mentor.id,
+            subject_user=mentor.user,
+            old_data={"mentor_tier": old_tier},
+            new_data={"mentor_tier": new_tier},
+            remarks="Admin tier change",
+        )
+
+        return CustomResponse(
+            general_message=f"Mentor tier updated from '{old_tier}' to '{new_tier}'.",
+            response={"mentor": MentorListSerializer(mentor).data},
         ).get_success_response()

--- a/api/dashboard/mentor/mentor_views.py
+++ b/api/dashboard/mentor/mentor_views.py
@@ -1,3 +1,4 @@
+from django.db import transaction, IntegrityError
 from django.db.models import Count, F as models_F, Q, Sum, Value, IntegerField
 from django.db.models.functions import Coalesce
 from django.utils import timezone
@@ -49,8 +50,6 @@ from .mentor_serializers import (
 )
 
 # ─── Role shorthand ──────────────────────────────────────────────────────────
-ADMIN = RoleType.ADMIN.value
-MENTOR = RoleType.MENTOR.value
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -217,8 +216,8 @@ class MentorOnboardingAPI(APIView):
 class MentorListAPI(APIView):
     """GET — paginated list of all mentor applications (admin only)."""
     authentication_classes = [CustomizePermission]
-
-    @role_required([ADMIN])
+    
+    @role_required([RoleType.ADMIN.value])
     def get(self, request):
         is_verified = request.query_params.get("is_verified")
         mentor_qs = (
@@ -262,7 +261,7 @@ class MentorVerifyAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN])
+    @role_required([RoleType.ADMIN.value])
     def patch(self, request, pk):
         admin_id = JWTUtils.fetch_user_id(request)
         mentor = UserMentor.objects.filter(id=pk).select_related("user").first()
@@ -410,11 +409,11 @@ class MentorOverviewAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
         ig_id = request.query_params.get("ig_id")
         now = DateTimeUtils.get_current_utc_time()
 
@@ -482,7 +481,7 @@ class MentorOverviewAPI(APIView):
                 "scheduled": status_counts.get(MentorshipSession.Status.SCHEDULED, 0),
                 "completed": status_counts.get(MentorshipSession.Status.COMPLETED, 0),
                 "cancelled": status_counts.get(MentorshipSession.Status.CANCELLED, 0),
-                "no_show": status_counts.get(MentorshipSession.Status.NO_SHOW, 0),
+                "rejected": status_counts.get(MentorshipSession.Status.REJECTED, 0),
                 "total": session_total,
             },
             "upcoming": upcoming,
@@ -599,11 +598,11 @@ class MentorSessionAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         session_qs = (
             MentorshipSession.objects
@@ -644,11 +643,11 @@ class MentorSessionAPI(APIView):
             data=serializer.data, pagination=paginated["pagination"]
         )
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def post(self, request):
         user_id  = JWTUtils.fetch_user_id(request)
         roles    = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         ig_id      = request.data.get("ig")
         is_global  = not ig_id  # no IG supplied → treat as global
@@ -732,7 +731,7 @@ class MentorSessionDetailAPI(APIView):
     """GET / PUT / PATCH / DELETE for a single session."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request, pk):
         session = (
             MentorshipSession.objects
@@ -747,11 +746,11 @@ class MentorSessionDetailAPI(APIView):
         serializer = MentorSessionDetailSerializer(session)
         return CustomResponse(response={"session": serializer.data}).get_success_response()
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def patch(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         session = MentorshipSession.objects.filter(id=pk).first()
         if not session:
@@ -789,7 +788,7 @@ class MentorSessionDetailAPI(APIView):
             response={"session": MentorSessionDetailSerializer(session).data},
         ).get_success_response()
 
-    @role_required([ADMIN])
+    @role_required([RoleType.ADMIN.value])
     def delete(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         session = MentorshipSession.objects.filter(id=pk).first()
@@ -823,15 +822,14 @@ class MentorSessionStatusAPI(APIView):
         MentorshipSession.Status.SCHEDULED: [
             MentorshipSession.Status.COMPLETED,
             MentorshipSession.Status.CANCELLED,
-            MentorshipSession.Status.NO_SHOW,
         ],
         MentorshipSession.Status.COMPLETED: [],
         MentorshipSession.Status.CANCELLED: [],
-        MentorshipSession.Status.NO_SHOW: [],
+        MentorshipSession.Status.REJECTED: [],
         MentorshipSession.Status.PENDING_APPROVAL: [],  # use /approve/ endpoint instead
     }
 
-    @role_required([ADMIN])
+    @role_required([RoleType.ADMIN.value])
     def patch(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         session = MentorshipSession.objects.filter(id=pk).first()
@@ -841,6 +839,13 @@ class MentorSessionStatusAPI(APIView):
         new_status = request.data.get("status")
         if not new_status:
             return CustomResponse(general_message="'status' field is required.").get_failure_response()
+
+        data = {"status": new_status, "updated_by": user_id}
+        serializer = MentorSessionStatusSerializer(data=data, instance=session, partial=True)
+        if not serializer.is_valid():
+            return CustomResponse(general_message=serializer.errors).get_failure_response()
+
+        new_status = serializer.validated_data["status"]
 
         if new_status == MentorshipSession.Status.PENDING_APPROVAL:
             return CustomResponse(
@@ -852,11 +857,6 @@ class MentorSessionStatusAPI(APIView):
             return CustomResponse(
                 general_message=f"Cannot transition from '{session.status}' to '{new_status}'."
             ).get_failure_response()
-
-        data = {"status": new_status, "updated_by": user_id}
-        serializer = MentorSessionStatusSerializer(data=data, instance=session, partial=True)
-        if not serializer.is_valid():
-            return CustomResponse(general_message=serializer.errors).get_failure_response()
 
         serializer.save()
 
@@ -878,7 +878,7 @@ class MentorSessionParticipantsAPI(APIView):
     """GET / POST / DELETE participants on a session."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request, pk):
         session = MentorshipSession.objects.filter(id=pk).first()
         if not session:
@@ -894,47 +894,93 @@ class MentorSessionParticipantsAPI(APIView):
             response={"participants": serializer.data}
         ).get_success_response()
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def post(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
-        session = MentorshipSession.objects.filter(id=pk).first()
-        if not session:
-            return CustomResponse(general_message="Session not found.").get_failure_response()
+        
+        with transaction.atomic():
+            session = MentorshipSession.objects.select_for_update().filter(id=pk).first()
+            if not session:
+                return CustomResponse(general_message="Session not found.").get_failure_response()
 
-        data = request.data.copy()
-        data["session"] = pk
+            data = request.data.copy()
+            data["session"] = pk
 
-        # Validate participant user exists
-        participant_user_id = data.get("user")
-        if not User.objects.filter(id=participant_user_id).exists():
-            return CustomResponse(
-                general_message="Participant user not found."
-            ).get_failure_response()
+            # Validate participant user exists
+            participant_user_id = data.get("user")
+            if not User.objects.filter(id=participant_user_id).exists():
+                return CustomResponse(
+                    general_message="Participant user not found."
+                ).get_failure_response()
 
-        # Check for duplicate
-        role = data.get("participant_role")
-        if MentorshipSessionUserLink.objects.filter(
-            session_id=pk, user_id=participant_user_id, participant_role=role
-        ).exists():
-            return CustomResponse(
-                general_message="This user already has this role in the session."
-            ).get_failure_response()
+            # Check for duplicate
+            role = data.get("participant_role")
+            if MentorshipSessionUserLink.objects.filter(
+                session_id=pk, user_id=participant_user_id, participant_role=role
+            ).exists():
+                return CustomResponse(
+                    general_message="This user already has this role in the session."
+                ).get_failure_response()
 
-        serializer = MentorSessionParticipantAddSerializer(data=data)
-        if not serializer.is_valid():
-            return CustomResponse(general_message=serializer.errors).get_failure_response()
+            # Enforce max_participants for mentees
+            if role == MentorshipSessionUserLink.ParticipantRole.MENTEE and session.max_participants is not None:
+                current_mentees = MentorshipSessionUserLink.objects.filter(
+                    session_id=pk,
+                    participant_role=MentorshipSessionUserLink.ParticipantRole.MENTEE
+                ).count()
+                
+                if current_mentees >= session.max_participants:
+                    return CustomResponse(
+                        general_message=f"Session capacity reached ({session.max_participants} mentees)."
+                    ).get_failure_response()
 
-        link = serializer.save()
+            serializer = MentorSessionParticipantAddSerializer(data=data)
+            if not serializer.is_valid():
+                return CustomResponse(general_message=serializer.errors).get_failure_response()
+
+            link = serializer.save()
+
         return CustomResponse(
             general_message="Participant added.",
             response={"participant": MentorSessionParticipantSerializer(link).data},
         ).get_success_response()
 
-    @role_required([ADMIN, MENTOR])
-    def delete(self, request, pk, user_pk):
-        MentorshipSessionUserLink.objects.filter(
-            session_id=pk, user_id=user_pk
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
+    def delete(self, request, pk=None, session_pk=None, user_pk=None):
+        session_id = session_pk or pk
+        user_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+        is_admin = RoleType.ADMIN.value in roles
+
+        session = MentorshipSession.objects.filter(id=session_id).first()
+        if not session:
+            return CustomResponse(general_message="Session not found.").get_failure_response()
+
+        if not is_admin and str(session.created_by_id) != user_id:
+            return CustomResponse(
+                general_message="You do not have permission to modify this session."
+            ).get_failure_response()
+
+        participant_role = request.query_params.get("participant_role")
+        if not participant_role:
+            return CustomResponse(
+                general_message="participant_role query parameter is required."
+            ).get_failure_response()
+
+        if participant_role not in [r.value for r in MentorshipSessionUserLink.ParticipantRole]:
+            return CustomResponse(
+                general_message="Invalid participant_role."
+            ).get_failure_response()
+
+        deleted, _ = MentorshipSessionUserLink.objects.filter(
+            session_id=session_id, user_id=user_pk, participant_role=participant_role
         ).delete()
+
+        if deleted == 0:
+            return CustomResponse(
+                general_message="Participant not found."
+            ).get_failure_response()
+
         return CustomResponse(
             general_message="Participant removed."
         ).get_success_response()
@@ -948,7 +994,7 @@ class GlobalSessionPendingAPI(APIView):
     """GET — paginated list of global sessions awaiting admin approval."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN])
+    @role_required([RoleType.ADMIN.value])
     def get(self, request):
         pending_qs = (
             MentorshipSession.objects
@@ -999,7 +1045,7 @@ class GlobalSessionApproveAPI(APIView):
     """PATCH — admin approves or rejects a pending global session."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN])
+    @role_required([RoleType.ADMIN.value])
     def patch(self, request, pk):
         admin_id = JWTUtils.fetch_user_id(request)
         session = MentorshipSession.objects.filter(id=pk).first()
@@ -1025,7 +1071,7 @@ class GlobalSessionApproveAPI(APIView):
             new_status = MentorshipSession.Status.SCHEDULED
             message = "Global session approved and scheduled."
         elif action == "reject":
-            new_status = MentorshipSession.Status.CANCELLED
+            new_status = MentorshipSession.Status.REJECTED
             message = "Global session rejected."
         else:
             return CustomResponse(
@@ -1071,11 +1117,11 @@ class MentorAvailabilityAPI(APIView):
     """GET — list slots; POST — create a new slot."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         mentor_user_id = request.query_params.get("mentor_user_id")
         ig_id = request.query_params.get("ig_id")
@@ -1104,7 +1150,7 @@ class MentorAvailabilityAPI(APIView):
             data=serializer.data, pagination=paginated["pagination"]
         )
 
-    @role_required([MENTOR])
+    @role_required([RoleType.MENTOR.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         data = request.data.copy()
@@ -1127,7 +1173,7 @@ class MentorAvailabilityDetailAPI(APIView):
     """PUT — full replace; DELETE — soft-delete."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([MENTOR])
+    @role_required([RoleType.MENTOR.value])
     def put(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         slot = MentorAvailabilitySlot.objects.filter(
@@ -1153,11 +1199,11 @@ class MentorAvailabilityDetailAPI(APIView):
             response={"slot": MentorAvailabilitySerializer(slot).data},
         ).get_success_response()
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def delete(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         slot_qs = MentorAvailabilitySlot.objects.filter(id=pk)
         if not is_admin:
@@ -1185,11 +1231,11 @@ class MentorTaskRequestAPI(APIView):
     """GET — list; POST — submit a task proposal."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         status_filter = request.query_params.get("status")
         qs = MentorTaskRequest.objects.select_related(
@@ -1215,7 +1261,7 @@ class MentorTaskRequestAPI(APIView):
             data=serializer.data, pagination=paginated["pagination"]
         )
 
-    @role_required([MENTOR])
+    @role_required([RoleType.MENTOR.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         data = request.data.copy()
@@ -1224,10 +1270,17 @@ class MentorTaskRequestAPI(APIView):
         data["updated_by"] = user_id
 
         serializer = MentorTaskRequestCreateSerializer(data=data)
-        if not serializer.is_valid():
-            return CustomResponse(general_message=serializer.errors).get_failure_response()
+        
+        try:
+            with transaction.atomic():
+                if not serializer.is_valid():
+                    return CustomResponse(general_message=serializer.errors).get_failure_response()
+                task_req = serializer.save()
+        except IntegrityError:
+            return CustomResponse(
+                general_message={"hashtag": ["A task/request with this hashtag already exists."]}
+            ).get_failure_response()
 
-        task_req = serializer.save()
         return CustomResponse(
             general_message="Task proposal submitted. Awaiting admin review.",
             response={"task_request": MentorTaskRequestSerializer(task_req).data},
@@ -1238,11 +1291,11 @@ class MentorTaskRequestDetailAPI(APIView):
     """GET — detail; PATCH — admin review (approve/reject)."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         qs = MentorTaskRequest.objects.select_related(
             "mentor", "ig", "reviewed_by", "created_task"
@@ -1261,7 +1314,7 @@ class MentorTaskRequestDetailAPI(APIView):
             response={"task_request": MentorTaskRequestSerializer(task_req).data}
         ).get_success_response()
 
-    @role_required([ADMIN])
+    @role_required([RoleType.ADMIN.value])
     def patch(self, request, pk):
         admin_id = JWTUtils.fetch_user_id(request)
         task_req = MentorTaskRequest.objects.select_related(
@@ -1292,34 +1345,40 @@ class MentorTaskRequestDetailAPI(APIView):
             "updated_by": admin_id,
         }
 
-        serializer = MentorTaskRequestReviewSerializer(
-            data=data, instance=task_req, partial=True
-        )
-        if not serializer.is_valid():
-            return CustomResponse(general_message=serializer.errors).get_failure_response()
+        try:
+            with transaction.atomic():
+                serializer = MentorTaskRequestReviewSerializer(
+                    data=data, instance=task_req, partial=True
+                )
+                if not serializer.is_valid():
+                    return CustomResponse(general_message=serializer.errors).get_failure_response()
 
-        task_req = serializer.save()
+                task_req = serializer.save()
 
-        # On APPROVED — auto-create the TaskList entry
-        if new_status == MentorTaskRequest.Status.APPROVED:
-            task_type = TaskType.objects.first()  # default type — adjust as needed
-            if not task_type:
-                return CustomResponse(
-                    general_message="No TaskType found. Cannot create task."
-                ).get_failure_response()
+                # On APPROVED — auto-create the TaskList entry
+                if new_status == MentorTaskRequest.Status.APPROVED:
+                    task_type = TaskType.objects.first()  # default type — adjust as needed
+                    if not task_type:
+                        return CustomResponse(
+                            general_message="No TaskType found. Cannot create task."
+                        ).get_failure_response()
 
-            new_task = TaskList.objects.create(
-                hashtag=task_req.hashtag,
-                title=task_req.title,
-                description=task_req.description,
-                karma=task_req.karma,
-                ig=task_req.ig,
-                type=task_type,
-                created_by_id=admin_id,
-                updated_by_id=admin_id,
-            )
-            task_req.created_task = new_task
-            task_req.save(update_fields=["created_task"])
+                    new_task = TaskList.objects.create(
+                        hashtag=task_req.hashtag,
+                        title=task_req.title,
+                        description=task_req.description,
+                        karma=task_req.karma,
+                        ig=task_req.ig,
+                        type=task_type,
+                        created_by_id=admin_id,
+                        updated_by_id=admin_id,
+                    )
+                    task_req.created_task = new_task
+                    task_req.save(update_fields=["created_task"])
+        except IntegrityError:
+            return CustomResponse(
+                general_message={"hashtag": ["A task with this hashtag already exists in the published task list."]}
+            ).get_failure_response()
 
         return CustomResponse(
             general_message=f"Task request {new_status.lower()}.",
@@ -1335,7 +1394,7 @@ class MentorOpportunityAPI(APIView):
     """GET — list; POST — create opportunity."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         ig_id = request.query_params.get("ig_id")
         opp_type = request.query_params.get("type")
@@ -1364,7 +1423,7 @@ class MentorOpportunityAPI(APIView):
             data=serializer.data, pagination=paginated["pagination"]
         )
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         ig_id = request.data.get("ig")
@@ -1402,7 +1461,7 @@ class MentorOpportunityDetailAPI(APIView):
     """GET / PUT / PATCH / DELETE a single opportunity."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request, pk):
         opp = IgOpportunity.objects.select_related("ig", "created_by").filter(id=pk).first()
         if not opp:
@@ -1411,7 +1470,7 @@ class MentorOpportunityDetailAPI(APIView):
             response={"opportunity": IgOpportunitySerializer(opp).data}
         ).get_success_response()
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def patch(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         opp = IgOpportunity.objects.filter(id=pk).first()
@@ -1441,7 +1500,7 @@ class MentorOpportunityDetailAPI(APIView):
             response={"opportunity": IgOpportunitySerializer(opp).data},
         ).get_success_response()
 
-    @role_required([ADMIN])
+    @role_required([RoleType.ADMIN.value])
     def delete(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         opp = IgOpportunity.objects.filter(id=pk).first()
@@ -1464,11 +1523,11 @@ class MentorMenteesAPI(APIView):
     """GET — distinct mentees across sessions."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         ig_id = request.query_params.get("ig_id")
         mentor_user_id = request.query_params.get("mentor_user_id")
@@ -1539,11 +1598,11 @@ class MentorActivityLogAPI(APIView):
     """GET — recent SystemActionLog entries."""
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         ig_id = request.query_params.get("ig_id")
         action_type = request.query_params.get("action_type")
@@ -1581,7 +1640,7 @@ class MentorSessionKarmaAwardAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request, pk):
         awards = (
             MentorKarmaAward.objects
@@ -1593,7 +1652,7 @@ class MentorSessionKarmaAwardAPI(APIView):
             response={"awards": serializer.data}
         ).get_success_response()
 
-    @role_required([ADMIN])
+    @role_required([RoleType.ADMIN.value])
     def post(self, request, pk):
         admin_id = JWTUtils.fetch_user_id(request)
         session = MentorshipSession.objects.filter(id=pk).select_related("ig").first()
@@ -1693,11 +1752,11 @@ class MentorTaskReviewQueueAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         roles = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         status_filter = request.query_params.get("status", "PENDING")
         ig_id = request.query_params.get("ig_id")
@@ -1742,7 +1801,7 @@ class MentorTaskReviewDetailAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([MENTOR])
+    @role_required([RoleType.MENTOR.value])
     def patch(self, request, pk):
         mentor_id = JWTUtils.fetch_user_id(request)
 
@@ -1801,7 +1860,7 @@ class MentorLeaderboardAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         ig_id = request.query_params.get("ig_id")
 
@@ -1916,7 +1975,7 @@ class MentorSessionRemindAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def post(self, request, pk):
         user_id = JWTUtils.fetch_user_id(request)
         session = MentorshipSession.objects.filter(id=pk).first()
@@ -1930,6 +1989,22 @@ class MentorSessionRemindAPI(APIView):
             return CustomResponse(
                 general_message="Reminders can only be sent for SCHEDULED or PENDING_APPROVAL sessions."
             ).get_failure_response()
+
+        # Enforce 12-hour cooldown
+        last_reminder = Notification.objects.filter(
+            url=f"/sessions/{session.id}/",
+            title__contains="Session Reminder"
+        ).order_by("-created_at").first()
+
+        if last_reminder:
+            now = DateTimeUtils.get_current_utc_time()
+            time_diff = now - last_reminder.created_at
+            if time_diff.total_seconds() < 12 * 3600:
+                remaining_hours = int(12 - time_diff.total_seconds() / 3600)
+                wait_msg = f"{remaining_hours} hours" if remaining_hours > 0 else "less than an hour"
+                return CustomResponse(
+                    general_message=f"Cooldown active. Please wait {wait_msg} before sending another reminder."
+                ).get_failure_response()
 
         count = _send_session_reminders(session, triggered_by_id=user_id)
         return CustomResponse(
@@ -1977,7 +2052,7 @@ class MentorMyIgsAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         links = UserIgLink.objects.filter(
@@ -2009,11 +2084,11 @@ class MentorIgRequestListAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def get(self, request):
         user_id  = JWTUtils.fetch_user_id(request)
         roles    = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
         ig_id    = request.query_params.get("ig_id")
 
         if not ig_id:
@@ -2068,11 +2143,11 @@ class MentorIgRequestDetailAPI(APIView):
     """
     authentication_classes = [CustomizePermission]
 
-    @role_required([ADMIN, MENTOR])
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
     def patch(self, request, pk):
         user_id  = JWTUtils.fetch_user_id(request)
         roles    = JWTUtils.fetch_role(request)
-        is_admin = ADMIN in roles
+        is_admin = RoleType.ADMIN.value in roles
 
         link = UserIgLink.objects.filter(
             id=pk,
@@ -2136,3 +2211,49 @@ class MentorIgRequestDetailAPI(APIView):
             general_message=f"Mentor request for {ig_name} rejected."
         ).get_success_response()
 
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Availability Calendar
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MentorAvailabilityCalendarAPI(APIView):
+    """GET - Return slots formatted for calendar consumption."""
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value, RoleType.MENTOR.value])
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+        is_admin = RoleType.ADMIN.value in roles
+
+        slots = MentorAvailabilitySlot.objects.filter(is_active=True).select_related("mentor_user", "ig")
+        if not is_admin:
+            slots = slots.filter(mentor_user_id=user_id)
+            
+        serializer = MentorAvailabilitySerializer(slots, many=True)
+        return CustomResponse(response=serializer.data).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public Endpoints
+# ─────────────────────────────────────────────────────────────────────────────
+
+class PublicMentorCardAPI(APIView):
+    """GET /mentor/<muid>/public/ - Public read-only mentor profile."""
+    # No auth for public endpoints
+    def get(self, request, muid):
+        from .mentor_serializers import PublicMentorCardSerializer
+        mentor = UserMentor.objects.select_related("user").filter(
+            user__muid=muid, is_verified=True
+        ).first()
+
+        if not mentor:
+            return CustomResponse(
+                general_message="Verified mentor profile not found."
+            ).get_failure_response()
+
+        serializer = PublicMentorCardSerializer(mentor)
+        return CustomResponse(
+            response=serializer.data
+        ).get_success_response()

--- a/api/dashboard/mentor/urls.py
+++ b/api/dashboard/mentor/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
 
     # ── Availability ──────────────────────────────────────────────────────────
     path("availability/", mentor_views.MentorAvailabilityAPI.as_view()),
+    path("availability/calendar/", mentor_views.MentorAvailabilityCalendarAPI.as_view()),
     path("availability/<str:pk>/", mentor_views.MentorAvailabilityDetailAPI.as_view()),
 
     # ── Task requests ─────────────────────────────────────────────────────────
@@ -52,5 +53,8 @@ urlpatterns = [
     path("my-igs/", mentor_views.MentorMyIgsAPI.as_view()),
     path("ig-requests/", mentor_views.MentorIgRequestListAPI.as_view()),
     path("ig-requests/<str:pk>/", mentor_views.MentorIgRequestDetailAPI.as_view()),
+
+    # ── Public Endpoints ──────────────────────────────────────────────────────
+    path("<str:muid>/public/", mentor_views.PublicMentorCardAPI.as_view()),
 ]
 

--- a/api/dashboard/mentor/urls.py
+++ b/api/dashboard/mentor/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     # ── Mentor roster (admin) ─────────────────────────────────────────────────
     path("list/", mentor_views.MentorListAPI.as_view()),
     path("<str:pk>/verify/", mentor_views.MentorVerifyAPI.as_view()),
+    path("list/<str:pk>/tier/", mentor_views.MentorTierUpdateAPI.as_view()),         # [10] admin tier change
 
     # ── Overview & Leaderboard ────────────────────────────────────────────────
     path("overview/", mentor_views.MentorOverviewAPI.as_view()),
@@ -27,19 +28,22 @@ urlpatterns = [
     path("sessions/<str:session_pk>/participants/<str:user_pk>/", mentor_views.MentorSessionParticipantsAPI.as_view()),
     path("sessions/<str:pk>/karma-award/", mentor_views.MentorSessionKarmaAwardAPI.as_view()),  # F1
     path("sessions/<str:pk>/remind/", mentor_views.MentorSessionRemindAPI.as_view()),            # F4
+    path("sessions/<str:pk>/attendance/", mentor_views.MentorSessionAttendanceAPI.as_view()),   # [2] bulk attendance
+    path("sessions/<str:pk>/clone/", mentor_views.MentorSessionCloneAPI.as_view()),             # [6] session clone
 
     # ── Task Review Queue ─────────────────────────────────────────────────────
     path("review-queue/", mentor_views.MentorTaskReviewQueueAPI.as_view()),          # F2
-    path("review-queue/<str:pk>/", mentor_views.MentorTaskReviewDetailAPI.as_view()), # F2
+    path("review-queue/<str:pk>/", mentor_views.MentorTaskReviewDetailAPI.as_view()), # F2 + [7] GET added
 
     # ── Availability ──────────────────────────────────────────────────────────
     path("availability/", mentor_views.MentorAvailabilityAPI.as_view()),
     path("availability/calendar/", mentor_views.MentorAvailabilityCalendarAPI.as_view()),
+    path("availability/public/", mentor_views.PublicMentorAvailabilityAPI.as_view()),  # [9] public slots (no auth)
     path("availability/<str:pk>/", mentor_views.MentorAvailabilityDetailAPI.as_view()),
 
     # ── Task requests ─────────────────────────────────────────────────────────
     path("task-requests/", mentor_views.MentorTaskRequestAPI.as_view()),
-    path("task-requests/<str:pk>/", mentor_views.MentorTaskRequestDetailAPI.as_view()),
+    path("task-requests/<str:pk>/", mentor_views.MentorTaskRequestDetailAPI.as_view()),  # [8] DELETE added
 
     # ── Opportunities ─────────────────────────────────────────────────────────
     path("opportunities/", mentor_views.MentorOpportunityAPI.as_view()),
@@ -47,6 +51,7 @@ urlpatterns = [
 
     # ── Aggregates ────────────────────────────────────────────────────────────
     path("mentees/", mentor_views.MentorMenteesAPI.as_view()),
+    path("mentees/<str:user_pk>/", mentor_views.MentorMenteeDetailAPI.as_view()),  # [1] mentee detail
     path("activity-log/", mentor_views.MentorActivityLogAPI.as_view()),
 
     # ── IG Links (new) ────────────────────────────────────────────────────────
@@ -56,5 +61,6 @@ urlpatterns = [
 
     # ── Public Endpoints ──────────────────────────────────────────────────────
     path("<str:muid>/public/", mentor_views.PublicMentorCardAPI.as_view()),
+    path("<str:muid>/public/sessions/", mentor_views.PublicMentorSessionsAPI.as_view()),  # [5] public session history
 ]
 

--- a/db/mentor.py
+++ b/db/mentor.py
@@ -64,7 +64,7 @@ class MentorshipSession(models.Model):
         SCHEDULED        = 'SCHEDULED',        'Scheduled'
         COMPLETED        = 'COMPLETED',        'Completed'
         CANCELLED        = 'CANCELLED',        'Cancelled'
-        NO_SHOW          = 'NO_SHOW',          'No Show'
+        REJECTED         = 'REJECTED',         'Rejected'
 
     id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
     ig = models.ForeignKey(
@@ -78,6 +78,8 @@ class MentorshipSession(models.Model):
     starts_at = models.DateTimeField()
     ends_at = models.DateTimeField()
     meeting_link = models.CharField(max_length=500, null=True, blank=True)
+    venue = models.CharField(max_length=255, null=True, blank=True)
+    max_participants = models.IntegerField(null=True, blank=True)
     # is_global=True when ig is NULL and the session was submitted by a mentor
     # for cross-IG or platform-wide reach; requires admin approval.
     is_global = models.BooleanField(default=False)
@@ -150,6 +152,8 @@ class IgOpportunity(models.Model):
     class OpportunityType(models.TextChoices):
         CHALLENGE = 'CHALLENGE', 'Challenge'
         INTERNSHIP = 'INTERNSHIP', 'Internship'
+        HACKATHON = 'HACKATHON', 'Hackathon'
+        JOB = 'JOB', 'Job'
 
     class Status(models.TextChoices):
         DRAFT = 'DRAFT', 'Draft'
@@ -222,6 +226,7 @@ class SystemActionLog(models.Model):
 
     class ActionType(models.TextChoices):
         PERSONA_SWITCH   = 'PERSONA_SWITCH',   'Persona Switch'
+        MENTOR_VERIFY    = 'MENTOR_VERIFY',    'Mentor Verify'
         TASK_REVIEW      = 'TASK_REVIEW',      'Task Review'
         EVENT_REVIEW     = 'EVENT_REVIEW',     'Event Review'
         SESSION_CREATE   = 'SESSION_CREATE',   'Session Create'

--- a/mulearnbackend/__init__.py
+++ b/mulearnbackend/__init__.py
@@ -2,4 +2,20 @@
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app
 
+from rest_framework.serializers import Serializer
+from rest_framework.exceptions import ValidationError
+
+original_to_internal_value = Serializer.to_internal_value
+
+def strict_to_internal_value(self, data):
+    if isinstance(data, dict):
+        unknown_keys = set(data.keys()) - set(self.fields.keys())
+        if unknown_keys:
+            errors = {key: ["Unknown field."] for key in unknown_keys}
+            raise ValidationError(errors)
+            
+    return original_to_internal_value(self, data)
+
+Serializer.to_internal_value = strict_to_internal_value
+
 __all__ = ("celery_app",)

--- a/utils/permission.py
+++ b/utils/permission.py
@@ -1,6 +1,7 @@
 import datetime
 from datetime import datetime
 
+# pyrefly: ignore [missing-import]
 import jwt
 from django.conf import settings
 from django.http import HttpRequest
@@ -215,7 +216,7 @@ class RoleRequired:
     Class-based view that restricts access to views based on user roles.
 
     Usage:
-    @method_decorator(RoleRequired(['admin']))
+    @method_decorator(RoleRequired([RoleType.ADMIN.value]))
     def my_view(request, arg1, arg2):
         ...
     """


### PR DESCRIPTION
### Mentor API Endpoints

| Method | Endpoint | API Name | Description / Notes |
| :--- | :--- | :--- | :--- |
| `GET` | `/availability/calendar/` | **MentorAvailabilityCalendarAPI** | Returns calendar-formatted slots. |
| `GET` | `/availability/public/` | **PublicMentorAvailabilityAPI** | No auth required; returns a mentor's public slots. |
| `PATCH` | `/mentor/<pk>/verify/` | *(Unspecified)* | Now also has a note field (same doc, but no changes needed). |
| `GET` | `/review-queue/<kal_id>/` | **MentorTaskReviewDetailAPI** | `GET` method was added (documentation previously showed only `PATCH`). |
| `DELETE` | `/task-requests/<pk>/` | *(Unspecified)* | Mentor can now delete (withdraw) their own PENDING request. |
| `GET` | `/mentees/<user_pk>/` | **MentorMenteeDetailAPI** | Returns detailed mentee profile. |
| `PATCH` | `/sessions/<pk>/attendance/` | **MentorSessionAttendanceAPI** | Used for bulk attendance updates. |
| `GET` | `/<muid>/public/` | **PublicMentorCardAPI** | No auth required; public mentor profile card. |
| `GET` | `/<muid>/public/sessions/` | **PublicMentorSessionsAPI** | No auth required; public session history. |
| `POST` | `/sessions/<pk>/clone/` | **MentorSessionCloneAPI** | Used to clone a session. |
| `PATCH` | `/list/<pk>/tier/` | **MentorTierUpdateAPI** | Used for admin tier changes. |