### PR TITLE
feat: Add Event Task Management and Analytics APIs

### DIFF
--- a/api/dashboard/events/analytics_views.py
+++ b/api/dashboard/events/analytics_views.py
@@ -1,0 +1,132 @@
+"""
+Event Analytics API views.
+Provides performance stats for event organisers.
+"""
+from rest_framework.views import APIView
+
+from django.db.models import Sum, Count
+from django.db.models.functions import TruncDate
+
+from db.events import EventInterest
+from db.task import TaskList, KarmaActivityLog
+from utils.permission import CustomizePermission, JWTUtils
+from utils.response import CustomResponse
+from utils.types import RoleType
+
+from .serializers import can_manage_event, get_live_events
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers as s
+
+
+class EventAnalyticsAPI(APIView):
+    """
+    GET /events/manage/<event_id>/analytics/
+    Returns performance stats for the event:
+      - summary (interests, tasks, completions, karma)
+      - interest_trend (day-by-day)
+      - task_breakdown (per-task completions + karma)
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Events'],
+        description="Retrieve analytics and performance stats for an event.",
+        responses={200: inline_serializer(
+            name='EventAnalyticsResponse',
+            fields={
+                'summary': s.DictField(),
+                'interest_trend': s.ListField(child=s.DictField()),
+                'task_breakdown': s.ListField(child=s.DictField()),
+            },
+        )},
+    )
+    def get(self, request, event_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+
+        event = get_live_events().filter(id=event_id).first()
+        if not event:
+            return CustomResponse(
+                general_message='Event not found.'
+            ).get_failure_response()
+
+        is_admin = RoleType.ADMIN.value in roles
+        if not is_admin and not can_manage_event(user_id, event):
+            return CustomResponse(
+                general_message='You do not have permission to view analytics for this event.'
+            ).get_failure_response()
+
+        # ── Linked tasks ─────────────────────────────────────────
+        linked_tasks = TaskList.objects.filter(event_fk=event)
+        total_tasks = linked_tasks.count()
+        approved_tasks = linked_tasks.filter(approval_status='approved').count()
+        pending_tasks = linked_tasks.filter(approval_status='pending').count()
+
+        # ── Interest stats ───────────────────────────────────────
+        interests = EventInterest.objects.filter(event=event)
+        total_interests = interests.count()
+
+        # Interest trend (day-by-day)
+        interest_trend = list(
+            interests.annotate(
+                date=TruncDate('expressed_at')
+            ).values('date').annotate(
+                count=Count('id')
+            ).order_by('date')
+        )
+        # Format dates to ISO strings
+        interest_trend = [
+            {
+                'date': item['date'].isoformat() if item['date'] else None,
+                'count': item['count'],
+            }
+            for item in interest_trend
+        ]
+
+        # ── Task completion stats (from KarmaActivityLog) ────────
+        task_ids = list(linked_tasks.values_list('id', flat=True))
+
+        completion_logs = KarmaActivityLog.objects.filter(
+            task_id__in=task_ids,
+            appraiser_approved=True,
+        )
+
+        total_completions = completion_logs.count()
+        total_karma_awarded = completion_logs.aggregate(
+            total=Sum('karma')
+        )['total'] or 0
+
+        # Per-task breakdown
+        task_breakdown = []
+        for task in linked_tasks.select_related('type'):
+            task_completions = completion_logs.filter(task=task)
+            completions_count = task_completions.count()
+            task_karma = task_completions.aggregate(
+                total=Sum('karma')
+            )['total'] or 0
+
+            task_breakdown.append({
+                'task_id': str(task.id),
+                'title': task.title,
+                'hashtag': task.hashtag,
+                'karma': task.karma,
+                'approval_status': task.approval_status,
+                'completions': completions_count,
+                'total_karma_awarded': task_karma,
+            })
+
+        return CustomResponse(
+            general_message='Event analytics retrieved.',
+            response={
+                'summary': {
+                    'total_interests': total_interests,
+                    'total_tasks': total_tasks,
+                    'approved_tasks': approved_tasks,
+                    'pending_tasks': pending_tasks,
+                    'total_task_completions': total_completions,
+                    'total_karma_awarded': total_karma_awarded,
+                },
+                'interest_trend': interest_trend,
+                'task_breakdown': task_breakdown,
+            },
+        ).get_success_response()

--- a/api/dashboard/events/serializers.py
+++ b/api/dashboard/events/serializers.py
@@ -177,6 +177,62 @@ class LinkedTaskSerializer(serializers.ModelSerializer):
 
 
 # ─────────────────────────────────────────────────────────────
+# EVENT TASK MANAGEMENT  (full CRUD serializers)
+# ─────────────────────────────────────────────────────────────
+
+class EventTaskSerializer(serializers.ModelSerializer):
+    """Read serializer for event-linked tasks (list + detail responses)."""
+    type = serializers.SerializerMethodField()
+    ig = MinimalIGSerializer(read_only=True)
+    level = serializers.SerializerMethodField()
+    channel = serializers.CharField(source='channel.name', default=None)
+    org = serializers.CharField(source='org.title', default=None)
+    created_by = MinimalUserSerializer(read_only=True)
+
+    class Meta:
+        model = TaskList
+        fields = [
+            'id', 'hashtag', 'title', 'description', 'karma',
+            'approval_status', 'active', 'type', 'ig', 'level',
+            'channel', 'org', 'variable_karma', 'usage_count',
+            'bonus_time', 'bonus_karma',
+            'created_by', 'created_at', 'updated_at',
+        ]
+
+    def get_type(self, obj):
+        if obj.type:
+            return {'id': str(obj.type.id), 'title': obj.type.title}
+        return None
+
+    def get_level(self, obj):
+        if obj.level:
+            return {'id': str(obj.level.id), 'name': obj.level.name}
+        return None
+
+
+class EventTaskWriteSerializer(serializers.ModelSerializer):
+    """Write serializer for creating/updating event-linked tasks."""
+
+    class Meta:
+        model = TaskList
+        fields = [
+            'hashtag', 'title', 'description', 'karma',
+            'type', 'ig', 'level', 'org', 'bonus_time',
+        ]
+        extra_kwargs = {
+            'hashtag': {'required': True},
+            'title': {'required': True},
+            'type': {'required': True},
+            'description': {'required': False, 'allow_blank': True},
+            'karma': {'required': False},
+            'ig': {'required': False, 'allow_null': True},
+            'level': {'required': False, 'allow_null': True},
+            'org': {'required': False, 'allow_null': True},
+            'bonus_time': {'required': False, 'allow_null': True},
+        }
+
+
+# ─────────────────────────────────────────────────────────────
 # EVENT LIST ITEM  (lean — for paginated feeds)
 # ─────────────────────────────────────────────────────────────
 

--- a/api/dashboard/events/task_views.py
+++ b/api/dashboard/events/task_views.py
@@ -1,0 +1,290 @@
+"""
+Event Task Management API views.
+CRUD operations for tasks linked to events.
+Event organiser / co-owner / admin access required.
+"""
+import uuid
+
+from rest_framework.views import APIView
+
+from db.events import Event
+from db.task import TaskList, TaskType, Channel, InterestGroup, Level
+from db.organization import Organization
+from utils.permission import CustomizePermission, JWTUtils
+from utils.response import CustomResponse
+from utils.utils import CommonUtils, DateTimeUtils
+from utils.types import RoleType
+
+from .serializers import (
+    EventTaskSerializer,
+    EventTaskWriteSerializer,
+    can_manage_event,
+    get_live_events,
+)
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers as s
+
+
+def _check_event_task_permission(request, event_id):
+    """
+    Validate that the event exists and the caller can manage it.
+    Returns (event, user_id, error_response) — error_response is None on success.
+    """
+    user_id = JWTUtils.fetch_user_id(request)
+    roles = JWTUtils.fetch_role(request)
+
+    event = get_live_events().filter(id=event_id).first()
+    if not event:
+        return None, user_id, CustomResponse(
+            general_message='Event not found.'
+        ).get_failure_response()
+
+    is_admin = RoleType.ADMIN.value in roles
+    if not is_admin and not can_manage_event(user_id, event):
+        return None, user_id, CustomResponse(
+            general_message='You do not have permission to manage tasks for this event.'
+        ).get_failure_response()
+
+    return event, user_id, None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EVENT TASK LIST + CREATE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class EventTaskListCreateAPI(APIView):
+    """
+    GET  /events/manage/<event_id>/tasks/   → list tasks linked to this event
+    POST /events/manage/<event_id>/tasks/   → create a new task linked to this event
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Events'],
+        description="List all tasks linked to an event.",
+        responses={200: EventTaskSerializer(many=True)},
+    )
+    def get(self, request, event_id):
+        event, user_id, error = _check_event_task_permission(request, event_id)
+        if error:
+            return error
+
+        tasks = TaskList.objects.select_related(
+            'type', 'ig', 'level', 'channel', 'org', 'created_by'
+        ).filter(event_fk=event)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            tasks,
+            request,
+            search_fields=['title', 'hashtag', 'description'],
+            sort_fields={
+                'created_at': 'created_at',
+                'karma': 'karma',
+                'title': 'title',
+            },
+        )
+
+        serializer = EventTaskSerializer(
+            paginated.get('queryset'), many=True
+        )
+
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated.get('pagination'),
+        )
+
+    @extend_schema(
+        tags=['Dashboard - Events'],
+        description="Create a new task linked to an event. Task will require admin approval.",
+        request=EventTaskWriteSerializer,
+        responses={200: EventTaskSerializer},
+    )
+    def post(self, request, event_id):
+        event, user_id, error = _check_event_task_permission(request, event_id)
+        if error:
+            return error
+
+        serializer = EventTaskWriteSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                message=serializer.errors
+            ).get_failure_response()
+
+        now = DateTimeUtils.get_current_utc_time()
+        task = serializer.save(
+            id=uuid.uuid4(),
+            event_fk=event,
+            approval_status='pending',
+            active=False,
+            variable_karma=False,
+            usage_count=1,
+            created_by_id=user_id,
+            updated_by_id=user_id,
+            created_at=now,
+            updated_at=now,
+        )
+
+        # Re-fetch with select_related for the response
+        task = TaskList.objects.select_related(
+            'type', 'ig', 'level', 'channel', 'org', 'created_by'
+        ).get(pk=task.pk)
+
+        return CustomResponse(
+            general_message='Task created and linked to event. Pending admin approval.',
+            response=EventTaskSerializer(task).data,
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EVENT TASK DETAIL (GET / PATCH / DELETE)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class EventTaskDetailAPI(APIView):
+    """
+    GET    /events/manage/<event_id>/tasks/<task_id>/   → task detail
+    PATCH  /events/manage/<event_id>/tasks/<task_id>/   → partial update
+    DELETE /events/manage/<event_id>/tasks/<task_id>/   → delete task
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_task(self, event, task_id):
+        """Get a task that belongs to the given event."""
+        return TaskList.objects.select_related(
+            'type', 'ig', 'level', 'channel', 'org', 'created_by'
+        ).filter(id=task_id, event_fk=event).first()
+
+    @extend_schema(
+        tags=['Dashboard - Events'],
+        description="Retrieve a specific task linked to an event.",
+        responses={200: EventTaskSerializer},
+    )
+    def get(self, request, event_id, task_id):
+        event, user_id, error = _check_event_task_permission(request, event_id)
+        if error:
+            return error
+
+        task = self._get_task(event, task_id)
+        if not task:
+            return CustomResponse(
+                general_message='Task not found or does not belong to this event.'
+            ).get_failure_response()
+
+        return CustomResponse(
+            general_message='Task detail retrieved.',
+            response=EventTaskSerializer(task).data,
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['Dashboard - Events'],
+        description="Partially update a task linked to an event.",
+        request=EventTaskWriteSerializer,
+        responses={200: EventTaskSerializer},
+    )
+    def patch(self, request, event_id, task_id):
+        event, user_id, error = _check_event_task_permission(request, event_id)
+        if error:
+            return error
+
+        task = self._get_task(event, task_id)
+        if not task:
+            return CustomResponse(
+                general_message='Task not found or does not belong to this event.'
+            ).get_failure_response()
+
+        serializer = EventTaskWriteSerializer(task, data=request.data, partial=True)
+        if not serializer.is_valid():
+            return CustomResponse(
+                message=serializer.errors
+            ).get_failure_response()
+
+        serializer.save(
+            updated_by_id=user_id,
+            updated_at=DateTimeUtils.get_current_utc_time(),
+        )
+
+        # Re-fetch with select_related for the response
+        task = TaskList.objects.select_related(
+            'type', 'ig', 'level', 'channel', 'org', 'created_by'
+        ).get(pk=task_id)
+
+        return CustomResponse(
+            general_message='Task updated successfully.',
+            response=EventTaskSerializer(task).data,
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['Dashboard - Events'],
+        description="Delete a task linked to an event.",
+        responses={200: inline_serializer(
+            name='EventTaskDeleteResponse',
+            fields={'message': s.CharField()},
+        )},
+    )
+    def delete(self, request, event_id, task_id):
+        event, user_id, error = _check_event_task_permission(request, event_id)
+        if error:
+            return error
+
+        task = self._get_task(event, task_id)
+        if not task:
+            return CustomResponse(
+                general_message='Task not found or does not belong to this event.'
+            ).get_failure_response()
+
+        task.delete()
+
+        return CustomResponse(
+            general_message='Task deleted successfully.',
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EVENT TASK METADATA (dropdown data)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class EventTaskMetaAPI(APIView):
+    """
+    GET /events/manage/<event_id>/tasks/meta/
+    Returns dropdown data for task creation/editing forms.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Events'],
+        description="Retrieve dropdown metadata for event task forms.",
+        responses={200: inline_serializer(
+            name='EventTaskMetaResponse',
+            fields={
+                'task_types': s.ListField(child=s.DictField()),
+                'interest_groups': s.ListField(child=s.DictField()),
+                'levels': s.ListField(child=s.DictField()),
+                'channels': s.ListField(child=s.DictField()),
+                'organizations': s.ListField(child=s.DictField()),
+            },
+        )},
+    )
+    def get(self, request, event_id):
+        event, user_id, error = _check_event_task_permission(request, event_id)
+        if error:
+            return error
+
+        return CustomResponse(
+            general_message='Task metadata retrieved.',
+            response={
+                'task_types': list(
+                    TaskType.objects.values('id', 'title').order_by('title')
+                ),
+                'interest_groups': list(
+                    InterestGroup.objects.values('id', 'name').order_by('name')
+                ),
+                'levels': list(
+                    Level.objects.values('id', 'name').order_by('name')
+                ),
+                'channels': list(
+                    Channel.objects.values('id', 'name').order_by('name')
+                ),
+                'organizations': list(
+                    Organization.objects.values('id', 'title').order_by('title')
+                ),
+            },
+        ).get_success_response()

--- a/api/dashboard/events/urls.py
+++ b/api/dashboard/events/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from . import public_views, manage_views, admin_views, scoped_views, meta_views
+from . import public_views, manage_views, admin_views, scoped_views, meta_views, task_views, analytics_views
 
 urlpatterns = [
 
@@ -36,6 +36,14 @@ urlpatterns = [
     path('manage/<str:event_id>/collaborators/<str:collaborator_id>/accept/', manage_views.ManageEventCollaboratorAcceptAPI.as_view()),
     path('manage/<str:event_id>/collaborators/<str:collaborator_id>/reject/', manage_views.ManageEventCollaboratorRejectAPI.as_view()),
     path('manage/<str:event_id>/collaborators/<str:collaborator_id>/', manage_views.ManageEventCollaboratorRemoveAPI.as_view()),
+
+    # Event Tasks
+    path('manage/<str:event_id>/tasks/meta/', task_views.EventTaskMetaAPI.as_view()),
+    path('manage/<str:event_id>/tasks/<str:task_id>/', task_views.EventTaskDetailAPI.as_view()),
+    path('manage/<str:event_id>/tasks/', task_views.EventTaskListCreateAPI.as_view()),
+
+    # Event Analytics
+    path('manage/<str:event_id>/analytics/', analytics_views.EventAnalyticsAPI.as_view()),
 
     # Manage event detail (GET / PUT / PATCH / DELETE)
     path('manage/<str:event_id>/', manage_views.ManageEventDetailAPI.as_view()),


### PR DESCRIPTION
### Description
This PR implements the **Event Task Management & Analytics APIs** allowing event organisers, co-owners, and admins to manage tasks linked to specific events, as well as view performance analytics.

### Changes Included

**1. Event Task Management APIs (`api/dashboard/events/task_views.py`)**
*   **`GET /events/manage/<event_id>/tasks/`**: Paginated feed of all tasks linked to the event.
*   **`POST /events/manage/<event_id>/tasks/`**: Create a new task linked to the event.
    *   Automatically sets `approval_status="pending"` and `active=False` (requires Admin approval).
    *   Automatically sets `usage_count=1` and `variable_karma=False`.
*   **`GET /events/manage/<event_id>/tasks/<task_id>/`**: Retrieve detail for a specific task.
*   **`PATCH /events/manage/<event_id>/tasks/<task_id>/`**: Partial update for a task.
*   **`DELETE /events/manage/<event_id>/tasks/<task_id>/`**: Delete a task.
*   **`GET /events/manage/<event_id>/tasks/meta/`**: Dropdown data for frontend forms (task types, IGs, levels, channels, orgs).

**2. Event Analytics API (`api/dashboard/events/analytics_views.py`)**
*   **`GET /events/manage/<event_id>/analytics/`**: Returns event performance stats including:
    *   **Summary**: Total interests, task counts (approved/pending), total completions, and karma awarded.
    *   **Interest Trend**: Day-by-day breakdown of event interest.
    *   **Task Breakdown**: Per-task completion and karma statistics (aggregated via `KarmaActivityLog`).

**3. Serializers & Config**
*   Added `EventTaskSerializer` and `EventTaskWriteSerializer` to handle task input/output shapes.
*   Wired up routes in `api/dashboard/events/urls.py` correctly prioritizing static paths before dynamic wildcards.

### Access Control
*   Uses the existing `can_manage_event()` helper.
*   All endpoints require the user to be the **Event Creator**, **Co-owner**, or **Admin**.