### PR TITLE
Add interest group membership management and filtering active interest group

### DIFF
--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -1,6 +1,6 @@
 from django.db.models import Count
 from rest_framework.views import APIView
-
+from django.db import transaction
 from db.task import InterestGroup
 from db.user import User, Role
 from utils.permission import CustomizePermission
@@ -18,7 +18,7 @@ import uuid
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from api.dashboard.roles.dash_roles_serializer import RoleDashboardSerializer
-from db.task import UserIgLink
+from db.task import UserIgLink,UserIgLvlLink, Level
 from db.user import Role, UserMentor, UserRoleLink
 from db.notification import Notification
 from utils.types import RoleType
@@ -699,3 +699,94 @@ class InterestGroupListApi(APIView):
         return CustomResponse(
             response={"interestGroup": serializer.data}
         ).get_success_response()
+
+class InterestGroupMembershipAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="Join Interest Group instantly.",
+        responses={200: InterestGroupSerializer},
+    )
+    def post(self, request, pk):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        ig = InterestGroup.objects.filter(id=pk, status='active').first()
+        if not ig:
+            return CustomResponse(general_message="Interest Group not found or inactive").get_failure_response()
+
+        with transaction.atomic():
+            existing_link = UserIgLink.objects.filter(
+                user_id=user_id,
+                ig_id=pk,
+                assignment_type=UserIgLink.AssignmentType.LEARNER
+            ).first()
+
+            if existing_link and existing_link.is_active:
+                return CustomResponse(general_message="Already joined this Interest Group").get_success_response()
+
+            active_learner_ig_count = UserIgLink.objects.filter(
+                user_id=user_id,
+                assignment_type=UserIgLink.AssignmentType.LEARNER,
+                is_active=True
+            ).count()
+
+            # enforce max 3 selected learner IGs
+            if not existing_link and active_learner_ig_count >= 3:
+                return CustomResponse(general_message="Cannot join more than 3 interest groups").get_failure_response()
+
+            if existing_link:
+                existing_link.is_active = True
+                existing_link.unassigned_at = None
+                existing_link.assigned_by_id = user_id
+                existing_link.save(update_fields=["is_active", "unassigned_at", "assigned_by"])
+            else:
+                UserIgLink.objects.create(
+                    id=uuid.uuid4(),
+                    user_id=user_id,
+                    ig_id=pk,
+                    assignment_type=UserIgLink.AssignmentType.LEARNER,
+                    is_active=True,
+                    assigned_by_id=user_id,
+                    created_by_id=user_id,
+                )
+
+            # ensure level-1 IG link exists
+            level_1 = Level.objects.filter(level_order=1).first()
+            if level_1:
+                UserIgLvlLink.objects.get_or_create(
+                    user_id=user_id,
+                    ig_id=pk,
+                    defaults={
+                        "id": uuid.uuid4(),
+                        "level_id": level_1.id,
+                        "created_by_id": user_id,
+                        "updated_by_id": user_id,
+                    },
+                )
+
+        return CustomResponse(general_message="Joined Interest Group successfully").get_success_response()
+
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="Leave Interest Group instantly.",
+        responses={200: InterestGroupSerializer},
+    )
+    def delete(self, request, pk):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        link = UserIgLink.objects.filter(
+            user_id=user_id,
+            ig_id=pk,
+            assignment_type=UserIgLink.AssignmentType.LEARNER
+        ).first()
+
+        if not link or not link.is_active:
+            return CustomResponse(general_message="Already left this Interest Group").get_success_response()
+
+        link.is_active = False
+        link.unassigned_at = DateTimeUtils.get_current_utc_time()
+        link.save(update_fields=["is_active", "unassigned_at"])
+
+       
+        return CustomResponse(general_message="Left Interest Group successfully").get_success_response()

--- a/api/dashboard/ig/urls.py
+++ b/api/dashboard/ig/urls.py
@@ -10,4 +10,6 @@ urlpatterns = [
     path('csv/', dash_ig_view.InterestGroupCSV.as_view()),  # for IG data CSV download
     path('<str:pk>/', dash_ig_view.InterestGroupAPI.as_view()),  # for edit and delete
     path('get/<str:pk>/', dash_ig_view.InterestGroupGetAPI.as_view()),  # for edit and delete
+    path('<str:pk>/join/', dash_ig_view.InterestGroupMembershipAPI.as_view()),
+    path('<str:pk>/leave/', dash_ig_view.InterestGroupMembershipAPI.as_view()),
 ]

--- a/api/dashboard/profile/profile_serializer.py
+++ b/api/dashboard/profile/profile_serializer.py
@@ -211,7 +211,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
         
         # Get user's currently selected IGs
         selected_ig_ids = set(
-            UserIgLink.objects.filter(user=obj).values_list('ig_id', flat=True)
+            UserIgLink.objects.filter(user=obj, is_active=True, assignment_type=UserIgLink.AssignmentType.LEARNER).values_list('ig_id', flat=True)
         )
         
         interest_groups = []

--- a/api/dashboard/profile/profile_view.py
+++ b/api/dashboard/profile/profile_view.py
@@ -206,7 +206,9 @@ class UserIgEditView(APIView):
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
 
-        user_ig = InterestGroup.objects.filter(user_ig_link_ig__user_id=user_id).all()
+        user_ig = InterestGroup.objects.filter(user_ig_link_ig__user_id=user_id,
+    user_ig_link_ig__is_active=True,
+    user_ig_link_ig__assignment_type=UserIgLink.AssignmentType.LEARNER).all()
 
         serializer = profile_serializer.UserIgListSerializer(user_ig, many=True)
 


### PR DESCRIPTION
This pull request introduces a new API for users to instantly join or leave Interest Groups (IGs), enforces a maximum of three active learner IGs per user, and ensures data consistency for IG membership. It also updates related serializers and views to account for active membership status and assignment type, improving the accuracy of user IG data.

**Interest Group Membership API:**

* Added `InterestGroupMembershipAPI` to handle instant join and leave actions for IGs, including logic to:
  - Prevent joining more than three IGs as a learner,
  - Reactivate existing links or create new ones as needed,
  - Ensure a level-1 IG level link is created on join,
  - Mark links as inactive on leave.
* Registered new join and leave endpoints in `urls.py` for IG membership actions.

**Data Consistency and Filtering:**

* Updated IG selection logic in `profile_serializer.py` to only include active learner IGs, ensuring accurate representation of current memberships.
* Modified the user IG list in `profile_view.py` to filter for active learner IGs, improving the relevance of returned data.

**Imports and Dependencies:**

* Added necessary imports for transaction management and new models (`UserIgLvlLink`, `Level`) in `dash_ig_view.py` to support atomic operations and level link creation. [[1]](diffhunk://#diff-6bf6b21a477f8e93ad250518055a50b4dc9f7c060b71ff430240090d3d65becaL3-R3) [[2]](diffhunk://#diff-6bf6b21a477f8e93ad250518055a50b4dc9f7c060b71ff430240090d3d65becaL21-R21)