### PR TITLE
fix: resolve FieldError in company home summary API

### DIFF
--- a/api/dashboard/company/analytics_views.py
+++ b/api/dashboard/company/analytics_views.py
@@ -170,7 +170,7 @@ class CompanyDashboardSummaryAPIView(APIView):
         jobs = CompanyJob.objects.filter(company=company, is_deleted=False)
         apps = UserJobApplication.objects.filter(job__company=company)
         period_jobs = jobs.filter(created_at__gte=since) if since else jobs
-        period_apps = apps.filter(created_at__gte=since) if since else apps
+        period_apps = apps.filter(applied_at__gte=since) if since else apps
 
         total_views = jobs.aggregate(total=Sum('total_views'))['total'] or 0
 


### PR DESCRIPTION
- Fixed a 500 Internal Server Error occurring on the `/api/v1/dashboard/company/home-summary/` endpoint.
- The `UserJobApplication` model does not have a `created_at` field; it uses `applied_at`. Updated `analytics_views.py` to filter using `applied_at__gte` to properly calculate period-based metrics for job applications.
