### PR TITLE
fix: resolve unknown column device.user_id_id error on admin user edit

### DIFF
--- a/db/settings.py
+++ b/db/settings.py
@@ -9,7 +9,7 @@ class Device(models.Model):
     id          = models.CharField(primary_key=True, max_length=36)
     browser     = models.CharField(max_length=36, null=False)
     os          = models.CharField(max_length=36, null=False)
-    user_id     = models.ForeignKey(User, on_delete=models.CASCADE)
+    user_id     = models.ForeignKey(User, on_delete=models.CASCADE, db_column="user_id")
     last_log_in = models.DateTimeField(null=False)
 
     class Meta:


### PR DESCRIPTION
This PR fixes a bug where admins were unable to edit user details via the frontend. The issue occurred because Django was incorrectly querying for a device.user_id_id column when validating related models during the user update.

By explicitly adding db_column="user_id" to the Device model's foreign key, Django now correctly maps to the existing user_id database column, resolving the crash.