### PR TITLE
Fix/job view tracking

### DIFF
--- a/api/dashboard/company/job_views.py
+++ b/api/dashboard/company/job_views.py
@@ -346,7 +346,7 @@ class TrackJobViewAPIView(APIView):
 
     Increments the view count for a specific job listing.
     """
-    permission_classes = [CustomizePermission]
+    permission_classes = []
 
     @extend_schema(
         tags=['Dashboard - Company Jobs'],
@@ -354,15 +354,8 @@ class TrackJobViewAPIView(APIView):
     )
     def post(self, request, job_id):
         try:
-            user_id = JWTUtils.fetch_user_id(request)
-            company = _get_company_for_user(user_id)
-            if not company:
-                return CustomResponse(
-                    general_message="Company profile not found or access denied."
-                ).get_failure_response(status_code=404)
-
             # Get the job
-            job = CompanyJob.objects.filter(id=job_id, company=company, is_deleted=False).first()
+            job = CompanyJob.objects.filter(id=job_id, is_deleted=False).first()
             if not job:
                 return CustomResponse(
                     general_message="Job not found or access denied.",

--- a/db/settings.py
+++ b/db/settings.py
@@ -9,7 +9,7 @@ class Device(models.Model):
     id          = models.CharField(primary_key=True, max_length=36)
     browser     = models.CharField(max_length=36, null=False)
     os          = models.CharField(max_length=36, null=False)
-    user_id     = models.ForeignKey(User, on_delete=models.CASCADE)
+    user_id     = models.ForeignKey(User, on_delete=models.CASCADE, db_column="user_id")
     last_log_in = models.DateTimeField(null=False)
 
     class Meta:


### PR DESCRIPTION
### Description
Fixed an issue where the job view tracking API (`POST /api/v1/dashboard/company/jobs/<job_id>/view/`) returned a `404 Company profile not found or access denied` error when hit by candidates/learners or anonymous users.
