### PR TITLE
fix: allow candidates to track job views

### DIFF
--- a/api/dashboard/company/job_views.py
+++ b/api/dashboard/company/job_views.py
@@ -355,7 +355,7 @@ class TrackJobViewAPIView(APIView):
     def post(self, request, job_id):
         try:
             # Get the job
-            job = CompanyJob.objects.filter(id=job_id, is_deleted=False).first()
+            job = CompanyJob.objects.filter(id=job_id, status='Active', is_deleted=False).first()
             if not job:
                 return CustomResponse(
                     general_message="Job not found or access denied.",

--- a/api/dashboard/company/job_views.py
+++ b/api/dashboard/company/job_views.py
@@ -346,7 +346,7 @@ class TrackJobViewAPIView(APIView):
 
     Increments the view count for a specific job listing.
     """
-    permission_classes = [CustomizePermission]
+    permission_classes = []
 
     @extend_schema(
         tags=['Dashboard - Company Jobs'],
@@ -354,15 +354,8 @@ class TrackJobViewAPIView(APIView):
     )
     def post(self, request, job_id):
         try:
-            user_id = JWTUtils.fetch_user_id(request)
-            company = _get_company_for_user(user_id)
-            if not company:
-                return CustomResponse(
-                    general_message="Company profile not found or access denied."
-                ).get_failure_response(status_code=404)
-
             # Get the job
-            job = CompanyJob.objects.filter(id=job_id, company=company, is_deleted=False).first()
+            job = CompanyJob.objects.filter(id=job_id, is_deleted=False).first()
             if not job:
                 return CustomResponse(
                     general_message="Job not found or access denied.",


### PR DESCRIPTION
### Description
Fixed an issue where the job view tracking API (`POST /api/v1/dashboard/company/jobs/<job_id>/view/`) returned a `404 Company profile not found or access denied` error when hit by candidates/learners or anonymous users.