### PR TITLE
fix: resolve 500 error on CSV export due to missing headers

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -97,10 +97,21 @@ class CommonUtils:
     def generate_csv(queryset: QuerySet, csv_name: str) -> HttpResponse:
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = f'attachment; filename="{csv_name}.csv"'
-        fieldnames = list(queryset[0].keys())
-        writer = csv.DictWriter(response, fieldnames=fieldnames)
-        writer.writeheader()
-        writer.writerows(queryset)
+
+        if not queryset:
+            fieldnames = []
+        else:
+            # Collect all unique keys across all rows
+            fieldnames = []
+            for row in queryset:
+                for key in row.keys():
+                    if key not in fieldnames:
+                        fieldnames.append(key)
+
+        writer = csv.DictWriter(response, fieldnames=fieldnames, extrasaction='ignore')
+        if fieldnames:
+            writer.writeheader()
+            writer.writerows(queryset)
 
         compressed_response = HttpResponse(
             gzip.compress(response.content),


### PR DESCRIPTION
Fixed the CSV export 500 error. The CSV writer was crashing when the first record had null fields omitted by the serializer, so I updated generate_csv to dynamically gather all headers across all rows before writing the file.