### PR TITLE
fix: prevent status change once application is Selected

### DIFF
--- a/api/dashboard/company/job_serializers.py
+++ b/api/dashboard/company/job_serializers.py
@@ -187,7 +187,7 @@ class ApplicationTrackingSerializer(serializers.ModelSerializer):
         """Require rejection_reason when setting status to Rejected.
         Prevent any status change once the application is Selected."""
         # Once selected, status cannot be changed
-        if self.instance and self.instance.status == 'Selected':
+        if self.instance and self.instance.status == 'Selected' and 'status' in data:
             raise serializers.ValidationError(
                 {"status": "Cannot change the status of a selected application."}
             )

--- a/api/dashboard/company/job_serializers.py
+++ b/api/dashboard/company/job_serializers.py
@@ -184,7 +184,14 @@ class ApplicationTrackingSerializer(serializers.ModelSerializer):
         read_only_fields = ['id', 'job', 'applicant_name', 'applicant_email', 'resume_link', 'cover_letter', 'applied_at']
 
     def validate(self, data):
-        """Require rejection_reason when setting status to Rejected."""
+        """Require rejection_reason when setting status to Rejected.
+        Prevent any status change once the application is Selected."""
+        # Once selected, status cannot be changed
+        if self.instance and self.instance.status == 'Selected':
+            raise serializers.ValidationError(
+                {"status": "Cannot change the status of a selected application."}
+            )
+
         status = data.get('status')
         rejection_reason = data.get('rejection_reason', '').strip() if data.get('rejection_reason') else ''
         if status == 'Rejected' and not rejection_reason:


### PR DESCRIPTION
## Problem
Once a job application status is set to "Selected", 
it could be changed back to any other status (Pending, Rejected, etc.) 
via the PATCH /applications/<app_id>/status/ endpoint.

## Fix
Added validation in ApplicationTrackingSerializer to block 
any status change once the application reaches "Selected" state.
Selected is now a terminal/final state.

