### PR TITLE
feat(intern-dashboard): allow editing all fields on pending timesheets

### DIFF
--- a/api/dashboard/intern/timesheet/serializers.py
+++ b/api/dashboard/intern/timesheet/serializers.py
@@ -57,6 +57,12 @@ class InternTimesheetSerializer(serializers.ModelSerializer):
 
         task_entries = data.get('task') or []
         user_id = self.context.get('user_id')
+        task_ids = [entry.get('task_id') for entry in task_entries if entry.get('task_id')]
+
+        # Bulk fetch tasks
+        intern_tasks = {
+            str(t.id): t for t in InternTask.objects.filter(id__in=task_ids, assigned_to_id=user_id)
+        }
 
         seen_task_ids = set()
         for entry in task_entries:
@@ -71,7 +77,7 @@ class InternTimesheetSerializer(serializers.ModelSerializer):
             seen_task_ids.add(task_id)
 
             # Must belong to this intern
-            intern_task = InternTask.objects.filter(id=task_id, assigned_to_id=user_id).first()
+            intern_task = intern_tasks.get(str(task_id))
             if not intern_task:
                 raise serializers.ValidationError(
                     {"task": f"Task '{task_id}' is not assigned to you or does not exist."}
@@ -192,6 +198,13 @@ class InternTimesheetEditSerializer(serializers.ModelSerializer):
         # 4. Validate task entries if provided
         if 'task' in data:
             task_entries = data.get('task') or []
+            task_ids = [entry.get('task_id') for entry in task_entries if entry.get('task_id')]
+            
+            # Bulk fetch tasks
+            intern_tasks = {
+                str(t.id): t for t in InternTask.objects.filter(id__in=task_ids, assigned_to_id=user_id)
+            }
+            
             seen_task_ids = set()
             for entry in task_entries:
                 task_id = entry.get('task_id')
@@ -203,7 +216,7 @@ class InternTimesheetEditSerializer(serializers.ModelSerializer):
                     )
                 seen_task_ids.add(task_id)
 
-                intern_task = InternTask.objects.filter(id=task_id, assigned_to_id=user_id).first()
+                intern_task = intern_tasks.get(str(task_id))
                 if not intern_task:
                     raise serializers.ValidationError(
                         {"task": f"Task '{task_id}' is not assigned to you or does not exist."}

--- a/api/dashboard/intern/timesheet/serializers.py
+++ b/api/dashboard/intern/timesheet/serializers.py
@@ -140,3 +140,86 @@ class InternTimesheetHistorySerializer(serializers.ModelSerializer):
 
     def get_score(self, obj):
         return 25 if obj.status == 'APPROVED' else 0
+
+
+class InternTimesheetEditSerializer(serializers.ModelSerializer):
+    task = TaskUpdateEntrySerializer(many=True, required=False, allow_null=True)
+    description = serializers.CharField(max_length=2000, required=False)
+    blockers = serializers.CharField(max_length=1000, required=False, allow_blank=True, allow_null=True)
+    end_of_day_note = serializers.CharField(max_length=1000, required=False, allow_blank=True, allow_null=True)
+    edit_reason = serializers.CharField(max_length=300, required=True, allow_blank=False, allow_null=False)
+    entry_date = serializers.DateField(required=False)
+    hours = serializers.DecimalField(max_digits=4, decimal_places=2, required=False)
+
+    class Meta:
+        model = InternDailyTimesheet
+        fields = [
+            'entry_date', 'task', 'description',
+            'hours', 'blockers', 'end_of_day_note', 'edit_reason',
+        ]
+
+    def validate(self, data):
+        timesheet = self.instance
+        user_id = self.context.get('user_id')
+
+        # 0. edit_reason is mandatory for all modifications
+        if 'edit_reason' not in data or not data.get('edit_reason'):
+            raise serializers.ValidationError({"edit_reason": "edit_reason is mandatory for all modifications."})
+
+        # 1. Validate entry_date if provided
+        entry_date = data.get('entry_date')
+        if entry_date is not None:
+            today = now().date()
+            if entry_date > today:
+                raise serializers.ValidationError({"entry_date": "Future dates are not allowed."})
+
+            # Check duplicate timesheet on the same date for the same user, excluding current timesheet
+            if InternDailyTimesheet.objects.filter(user_id=user_id, entry_date=entry_date).exclude(id=timesheet.id).exists():
+                raise serializers.ValidationError({"entry_date": "A timesheet for this date has already been submitted."})
+
+        # 2. Validate description if provided
+        if 'description' in data and not data.get('description'):
+            raise serializers.ValidationError({"description": "Description is required."})
+
+        # 3. Validate hours if provided
+        if 'hours' in data:
+            hours = data.get('hours')
+            if hours is None or hours <= 0:
+                raise serializers.ValidationError({"hours": "Hours must be greater than 0."})
+            if hours > 24:
+                raise serializers.ValidationError({"hours": "Hours cannot exceed 24 in a single day."})
+
+        # 4. Validate task entries if provided
+        if 'task' in data:
+            task_entries = data.get('task') or []
+            seen_task_ids = set()
+            for entry in task_entries:
+                task_id = entry.get('task_id')
+                status = entry.get('status')
+
+                if task_id in seen_task_ids:
+                    raise serializers.ValidationError(
+                        {"task": f"Duplicate task_id '{task_id}' in submission."}
+                    )
+                seen_task_ids.add(task_id)
+
+                intern_task = InternTask.objects.filter(id=task_id, assigned_to_id=user_id).first()
+                if not intern_task:
+                    raise serializers.ValidationError(
+                        {"task": f"Task '{task_id}' is not assigned to you or does not exist."}
+                    )
+
+                if intern_task.is_verified:
+                    raise serializers.ValidationError(
+                        {"task": f"Task '{intern_task.title}' is already verified and cannot be modified."}
+                    )
+
+                if status == InternTaskStatus.COMPLETED.value and not intern_task.output_link:
+                    raise serializers.ValidationError(
+                        {"task": f"Task '{intern_task.title}' requires an output_link before marking COMPLETED. Use the task submit endpoint first."}
+                    )
+
+                # Enrich entry with title for the snapshot
+                entry['title'] = intern_task.title
+
+        return data

--- a/api/dashboard/intern/timesheet/timesheet_views.py
+++ b/api/dashboard/intern/timesheet/timesheet_views.py
@@ -6,10 +6,11 @@ from drf_spectacular.utils import extend_schema, OpenApiResponse
 
 from utils.permission import CustomizePermission, JWTUtils, role_required
 from utils.response import CustomResponse
-from utils.types import RoleType, InternGuildStatus
+from utils.types import RoleType, InternGuildStatus, InternTaskStatus
 from utils.utils import CommonUtils
 from db.intern import InternDailyTimesheet, UserInternGuildLink, InternTask
 from db.achievement import UserStreak
+from db.mentor import SystemActionLog
 
 from .serializers import InternTimesheetSerializer, InternTimesheetHistorySerializer, InternTimesheetEditSerializer
 
@@ -196,7 +197,7 @@ class InternTimesheetAPI(APIView):
                 new_task_ids = {t['task_id'] for t in new_data['task']}
                 removed_task_ids = old_task_ids - new_task_ids
                 if removed_task_ids:
-                    InternTask.objects.filter(id__in=removed_task_ids, assigned_to_id=user_id).update(status='NOT_STARTED')
+                    InternTask.objects.filter(id__in=removed_task_ids, assigned_to_id=user_id, is_verified=False).update(status=InternTaskStatus.NOT_STARTED.value)
 
                 for entry in new_data['task']:
                     task_id = entry.get('task_id')
@@ -209,7 +210,6 @@ class InternTimesheetAPI(APIView):
             timesheet.edit_reason = edit_reason
             timesheet.save()
 
-            from db.mentor import SystemActionLog
             SystemActionLog.objects.create(
                 action_type=SystemActionLog.ActionType.INTERN_TIMESHEET_EDIT.value,
                 actor_user_id=user_id,

--- a/api/dashboard/intern/timesheet/timesheet_views.py
+++ b/api/dashboard/intern/timesheet/timesheet_views.py
@@ -1,4 +1,4 @@
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.utils.timezone import now
 
 from rest_framework.views import APIView
@@ -11,7 +11,7 @@ from utils.utils import CommonUtils
 from db.intern import InternDailyTimesheet, UserInternGuildLink, InternTask
 from db.achievement import UserStreak
 
-from .serializers import InternTimesheetSerializer, InternTimesheetHistorySerializer
+from .serializers import InternTimesheetSerializer, InternTimesheetHistorySerializer, InternTimesheetEditSerializer
 
 
 class InternTimesheetPrefillAPI(APIView):
@@ -127,7 +127,8 @@ class InternTimesheetAPI(APIView):
     @role_required([RoleType.INTERN.value])
     @extend_schema(
         tags=['Dashboard - Intern'],
-        description="Edit end-of-day note on a timesheet entry.",
+        description="Edit fields on a pending timesheet entry.",
+        request=InternTimesheetEditSerializer,
         responses={200: OpenApiResponse(description="Timesheet updated successfully.")},
     )
     def patch(self, request, timesheet_id):
@@ -137,43 +138,88 @@ class InternTimesheetAPI(APIView):
         if not timesheet:
             return CustomResponse(general_message="Timesheet not found.").get_failure_response()
 
-        if timesheet.status == 'APPROVED':
-            return CustomResponse(general_message="Cannot edit an approved timesheet.").get_failure_response()
+        if timesheet.status != 'PENDING':
+            return CustomResponse(general_message="Only works on timesheets with status = PENDING.").get_failure_response()
 
-        edit_reason = request.data.get("edit_reason")
-        if not edit_reason:
-            return CustomResponse(general_message="edit_reason is mandatory for modifications.").get_failure_response()
+        serializer = InternTimesheetEditSerializer(
+            instance=timesheet,
+            data=request.data,
+            partial=True,
+            context={'user_id': user_id}
+        )
+        if not serializer.is_valid():
+            return CustomResponse(response=serializer.errors).get_failure_response()
 
-        allowed_fields = ["end_of_day_note"]
+        edit_reason = serializer.validated_data.get("edit_reason")
+
         old_data = {}
         new_data = {}
 
-        for field in allowed_fields:
-            if field in request.data:
-                old_val = getattr(timesheet, field)
-                new_val = request.data[field]
-                if old_val != new_val:
+        for field, new_val in serializer.validated_data.items():
+            if field == 'edit_reason':
+                continue
+
+            if field == 'task':
+                new_snapshot = [
+                    {
+                        'task_id': e['task_id'],
+                        'title': e.get('title', ''),
+                        'status': e['status'],
+                        'remark': e.get('remark') or '',
+                    }
+                    for e in new_val
+                ] if new_val is not None else None
+
+                old_val = timesheet.task
+                if old_val != new_snapshot:
                     old_data[field] = old_val
-                    new_data[field] = new_val
-                    setattr(timesheet, field, new_val)
+                    new_data[field] = new_snapshot
+            else:
+                old_val = getattr(timesheet, field)
+                if old_val != new_val:
+                    if field == 'entry_date':
+                        old_data[field] = str(old_val) if old_val else None
+                        new_data[field] = str(new_val) if new_val else None
+                    elif field == 'hours':
+                        old_data[field] = str(old_val) if old_val else None
+                        new_data[field] = str(new_val) if new_val else None
+                    else:
+                        old_data[field] = old_val
+                        new_data[field] = new_val
 
         if not new_data:
             return CustomResponse(general_message="No editable fields provided or no changes detected.").get_failure_response()
 
-        timesheet.edit_reason = edit_reason
-        timesheet.save()
+        with transaction.atomic():
+            if 'task' in new_data:
+                old_task_ids = {t['task_id'] for t in (timesheet.task or [])}
+                new_task_ids = {t['task_id'] for t in new_data['task']}
+                removed_task_ids = old_task_ids - new_task_ids
+                if removed_task_ids:
+                    InternTask.objects.filter(id__in=removed_task_ids, assigned_to_id=user_id).update(status='NOT_STARTED')
 
-        from db.mentor import SystemActionLog
-        SystemActionLog.objects.create(
-            action_type=SystemActionLog.ActionType.INTERN_TIMESHEET_EDIT.value,
-            actor_user_id=user_id,
-            subject_user_id=user_id,
-            entity_name='intern_daily_timesheet',
-            entity_id=timesheet.id,
-            old_data=old_data,
-            new_data=new_data,
-            remarks=edit_reason
-        )
+                for entry in new_data['task']:
+                    task_id = entry.get('task_id')
+                    new_status = entry.get('status')
+                    InternTask.objects.filter(id=task_id, assigned_to_id=user_id).update(status=new_status)
+
+            for field, new_val in new_data.items():
+                setattr(timesheet, field, new_val)
+
+            timesheet.edit_reason = edit_reason
+            timesheet.save()
+
+            from db.mentor import SystemActionLog
+            SystemActionLog.objects.create(
+                action_type=SystemActionLog.ActionType.INTERN_TIMESHEET_EDIT.value,
+                actor_user_id=user_id,
+                subject_user_id=user_id,
+                entity_name='intern_daily_timesheet',
+                entity_id=timesheet.id,
+                old_data=old_data,
+                new_data=new_data,
+                remarks=edit_reason
+            )
 
         return CustomResponse(general_message="Timesheet updated successfully.").get_success_response()
 


### PR DESCRIPTION
Summary
This PR updates the timesheet edit (PATCH /api/v1/dashboard/intern/timesheets/<timesheet_id>/) endpoint to allow interns to edit all fields of their pending timesheets—including description, hours, blockers, end_of_day_note, task, and entry_date—instead of restricting edits solely to end_of_day_note.