### PR TITLE
feat: Add Media Content Management Module and External Task Verification API

### DIFF
--- a/api/dashboard/media_content/serializers.py
+++ b/api/dashboard/media_content/serializers.py
@@ -1,0 +1,193 @@
+"""
+Serializers for the MediaContent module.
+
+Read serializers  — returned in GET responses; include computed `is_upcoming`.
+Write serializers — used for POST (create) and PATCH (partial update); validate
+                    type-specific required fields, date formats, and enum values.
+"""
+import uuid
+from datetime import date
+
+from rest_framework import serializers
+
+from db.events import MediaContent
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _compute_status(record_date: date) -> str:
+    """Compute status based on date relative to today."""
+    today = date.today()
+    if record_date > today:
+        return 'upcoming'
+    elif record_date == today:
+        return 'ongoing'
+    else:
+        return 'completed'
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# READ serializers
+# ─────────────────────────────────────────────────────────────────────────────
+
+class OfficeHoursReadSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for Office Hours sessions.
+    Exposes all Office Hours fields plus a computed ``status`` flag.
+    """
+    status = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MediaContent
+        fields = [
+            'id',
+            'title',
+            'performer',
+            'designation',
+            'description',
+            'date',
+            'link',
+            'interest_groups',
+            'poster_thumbnail',
+            'status',
+            'created_at',
+            'updated_at',
+        ]
+
+    def get_status(self, obj):
+        return _compute_status(obj.date)
+
+
+class SaltMangoTreeReadSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for Salt Mango Tree episodes.
+    Exposes topic (stored as ``title``), campus, zone, and ``status``.
+    """
+    # CMS used "topic"; we alias `title` → `topic` in the response.
+    topic = serializers.CharField(source='title')
+    status = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MediaContent
+        fields = [
+            'id',
+            'topic',
+            'campus',
+            'zone',
+            'date',
+            'description',
+            'link',
+            'status',
+            'created_at',
+            'updated_at',
+        ]
+
+    def get_status(self, obj):
+        return _compute_status(obj.date)
+
+
+class InspirationStationReadSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for Inspiration Station Radio episodes.
+    Same structure as SMT — topic (``title``), campus, zone, ``status``.
+    """
+    topic = serializers.CharField(source='title')
+    status = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MediaContent
+        fields = [
+            'id',
+            'topic',
+            'campus',
+            'zone',
+            'date',
+            'description',
+            'link',
+            'status',
+            'created_at',
+            'updated_at',
+        ]
+
+    def get_status(self, obj):
+        return _compute_status(obj.date)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# WRITE serializers
+# ─────────────────────────────────────────────────────────────────────────────
+
+class OfficeHoursWriteSerializer(serializers.Serializer):
+    """
+    Write serializer for Office Hours sessions (POST / PATCH).
+
+    Date format accepted: DD/MM/YYYY (matches the CMS schema).
+    It is converted to a Python ``date`` object for DB storage.
+    """
+    title            = serializers.CharField(max_length=300)
+    date             = serializers.CharField(
+        help_text='Format: DD/MM/YYYY'
+    )
+    performer        = serializers.CharField(max_length=200, required=False, allow_blank=True, allow_null=True)
+    designation      = serializers.CharField(max_length=200, required=False, allow_blank=True, allow_null=True)
+    description      = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    link             = serializers.URLField(max_length=500, required=False, allow_blank=True, allow_null=True)
+    interest_groups  = serializers.ListField(
+        child=serializers.CharField(), required=False, allow_null=True
+    )
+    poster_thumbnail = serializers.CharField(max_length=512, required=False, allow_blank=True, allow_null=True)
+
+    def validate_date(self, value):
+        from datetime import datetime
+        try:
+            return datetime.strptime(value, '%d/%m/%Y').date()
+        except ValueError:
+            raise serializers.ValidationError(
+                "Invalid date format. Expected DD/MM/YYYY (e.g. 27/06/2025)."
+            )
+
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        value['content_type'] = MediaContent.ContentType.OFFICE_HOURS
+        return value
+
+
+class _EpisodeWriteSerializer(serializers.Serializer):
+    """
+    Shared base for SMT and Inspiration Station write serializers.
+    Date format accepted: YYYY-MM-DD (matches the CMS schema).
+    """
+    topic       = serializers.CharField(max_length=300)          # maps → title
+    campus      = serializers.CharField(max_length=200)
+    zone        = serializers.ChoiceField(
+        choices=MediaContent.Zone.choices, required=False, allow_null=True
+    )
+    date        = serializers.DateField(
+        input_formats=['%Y-%m-%d'],
+        help_text='Format: YYYY-MM-DD'
+    )
+    description = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    link        = serializers.URLField(max_length=500, required=False, allow_blank=True, allow_null=True)
+
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        # Remap "topic" → "title" so it aligns with the DB column name
+        if 'topic' in value:
+            value['title'] = value.pop('topic')
+        return value
+
+
+class SaltMangoTreeWriteSerializer(_EpisodeWriteSerializer):
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        value['content_type'] = MediaContent.ContentType.SALT_MANGO_TREE
+        return value
+
+
+class InspirationStationWriteSerializer(_EpisodeWriteSerializer):
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        value['content_type'] = MediaContent.ContentType.INSPIRATION_STATION
+        return value

--- a/api/dashboard/media_content/urls.py
+++ b/api/dashboard/media_content/urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    # ── Office Hours ─────────────────────────────────────────────────────────
+    path('office-hours/',                    views.OfficeHoursListCreateAPI.as_view()),
+    path('office-hours/<str:record_id>/',    views.OfficeHoursDetailAPI.as_view()),
+
+    # ── Salt Mango Tree ──────────────────────────────────────────────────────
+    path('salt-mango-tree/',                 views.SaltMangoTreeListCreateAPI.as_view()),
+    path('salt-mango-tree/<str:record_id>/', views.SaltMangoTreeDetailAPI.as_view()),
+
+    # ── Inspiration Station Radio ────────────────────────────────────────────
+    path('inspiration-station/',                 views.InspirationStationListCreateAPI.as_view()),
+    path('inspiration-station/<str:record_id>/', views.InspirationStationDetailAPI.as_view()),
+]

--- a/api/dashboard/media_content/urls.py
+++ b/api/dashboard/media_content/urls.py
@@ -14,4 +14,6 @@ urlpatterns = [
     # ── Inspiration Station Radio ────────────────────────────────────────────
     path('inspiration-station/',                 views.InspirationStationListCreateAPI.as_view()),
     path('inspiration-station/<str:record_id>/', views.InspirationStationDetailAPI.as_view()),
+    path('bulk/import/', views.MediaContentBulkImportAPI.as_view()),
+    path('bulk/export/<str:content_type>/', views.MediaContentBulkExportAPI.as_view())
 ]

--- a/api/dashboard/media_content/views.py
+++ b/api/dashboard/media_content/views.py
@@ -616,7 +616,7 @@ class MediaContentBulkExportAPI(APIView):
                 general_message='Invalid content type. Must be office_hours, salt_mango_tree, or inspiration_station.'
             ).get_failure_response()
 
-        return CommonUtils.generate_csv(serializer.data, f"{content_type}_export.csv")
+        return CommonUtils.generate_csv(serializer.data, f"{content_type}_export")
         
 
         

--- a/api/dashboard/media_content/views.py
+++ b/api/dashboard/media_content/views.py
@@ -113,7 +113,7 @@ class OfficeHoursListCreateAPI(PublicGetMixin, APIView):
 
 
     @extend_schema(tags=['Media Content - Office Hours'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         serializer = OfficeHoursWriteSerializer(data=request.data)
@@ -168,7 +168,7 @@ class OfficeHoursDetailAPI(PublicGetMixin, APIView):
 
 
     @extend_schema(tags=['Media Content - Office Hours'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def patch(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -199,7 +199,7 @@ class OfficeHoursDetailAPI(PublicGetMixin, APIView):
 
 
     @extend_schema(tags=['Media Content - Office Hours'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def delete(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -249,7 +249,7 @@ class SaltMangoTreeListCreateAPI(PublicGetMixin, APIView):
         )
 
     @extend_schema(tags=['Media Content - Salt Mango Tree'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         serializer = SaltMangoTreeWriteSerializer(data=request.data)
@@ -302,7 +302,7 @@ class SaltMangoTreeDetailAPI(PublicGetMixin, APIView):
         ).get_success_response()
 
     @extend_schema(tags=['Media Content - Salt Mango Tree'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def patch(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -332,7 +332,7 @@ class SaltMangoTreeDetailAPI(PublicGetMixin, APIView):
         ).get_success_response()
 
     @extend_schema(tags=['Media Content - Salt Mango Tree'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def delete(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -382,7 +382,7 @@ class InspirationStationListCreateAPI(PublicGetMixin, APIView):
         )
 
     @extend_schema(tags=['Media Content - Inspiration Station'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         serializer = InspirationStationWriteSerializer(data=request.data)
@@ -435,7 +435,7 @@ class InspirationStationDetailAPI(PublicGetMixin, APIView):
         ).get_success_response()
 
     @extend_schema(tags=['Media Content - Inspiration Station'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def patch(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -465,7 +465,7 @@ class InspirationStationDetailAPI(PublicGetMixin, APIView):
         ).get_success_response()
 
     @extend_schema(tags=['Media Content - Inspiration Station'])
-    @RoleRequired([RoleType.ADMIN.value])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
     def delete(self, request, record_id):
         record = self._get_record(record_id)
         if not record:

--- a/api/dashboard/media_content/views.py
+++ b/api/dashboard/media_content/views.py
@@ -21,6 +21,7 @@ from utils.permission import CustomizePermission, JWTUtils, RoleRequired
 from utils.response import CustomResponse
 from utils.types import RoleType
 from utils.utils import CommonUtils
+import csv
 
 from .serializers import (
     OfficeHoursReadSerializer,
@@ -480,3 +481,142 @@ class InspirationStationDetailAPI(PublicGetMixin, APIView):
         return CustomResponse(
             general_message='Inspiration Station episode deleted.'
         ).get_success_response()
+
+
+class MediaContentBulkImportAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Media Content - Import'])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
+    def post(self, request):
+        file = request.data.get('file')
+        if not file:
+            return CustomResponse(
+                general_message='File is required.',
+            ).get_failure_response()
+
+        ALLOWED_CSV_MIME_TYPES = {'text/csv', 'application/csv', 'application/vnd.ms-excel'}
+        if file.content_type not in ALLOWED_CSV_MIME_TYPES:
+            return CustomResponse(
+                general_message='Invalid file type. Please upload a CSV file.',
+            ).get_failure_response()
+
+        import codecs
+        try:
+            reader = csv.DictReader(codecs.iterdecode(file, 'utf-8-sig'))
+            rows = list(reader)  # materialize here so decode errors are caught
+        except Exception:
+            return CustomResponse(
+                general_message='Error reading CSV file. Ensure it is UTF-8 encoded.',
+            ).get_failure_response()
+
+        if not rows:
+            return CustomResponse(
+                general_message='CSV file is empty. No records to import.',
+            ).get_failure_response()
+
+        user_id = JWTUtils.fetch_user_id(request)
+        success_count = 0
+        failed_rows = []
+
+        for row_num, row in enumerate(rows, start=2):
+            content_type = row.get('content_type', '').strip()
+            row_data = dict(row)
+
+            # Clean up empty values to avoid validation issues
+            row_data = {k: v for k, v in row_data.items() if v is not None and str(v).strip() != ''}
+
+            if content_type == MediaContent.ContentType.OFFICE_HOURS:
+                # Normalize: CSV may use 'topic' instead of 'title'
+                if 'topic' in row_data and not row_data.get('title'):
+                    row_data['title'] = row_data.pop('topic')
+                if 'interest_groups' in row_data:
+                    row_data['interest_groups'] = [
+                        ig.strip()
+                        for ig in str(row_data['interest_groups']).split(',')
+                        if ig.strip()
+                    ]
+                serializer = OfficeHoursWriteSerializer(data=row_data)
+
+            elif content_type == MediaContent.ContentType.SALT_MANGO_TREE:
+                # Normalize: CSV may use 'title' instead of 'topic'
+                if 'title' in row_data and not row_data.get('topic'):
+                    row_data['topic'] = row_data.pop('title')
+                serializer = SaltMangoTreeWriteSerializer(data=row_data)
+
+            elif content_type == MediaContent.ContentType.INSPIRATION_STATION:
+                # Normalize: CSV may use 'title' instead of 'topic'
+                if 'title' in row_data and not row_data.get('topic'):
+                    row_data['topic'] = row_data.pop('title')
+                serializer = InspirationStationWriteSerializer(data=row_data)
+
+            else:
+                failed_rows.append({
+                    "row": row_num,
+                    "title": row.get('title') or row.get('topic', ''),
+                    "reason": (
+                        f"Invalid or missing content_type: '{content_type}'. "
+                        "Must be 'office_hours', 'salt_mango_tree', or 'inspiration_station'."
+                    ),
+                })
+                continue
+
+            if serializer.is_valid():
+                data = serializer.validated_data
+                MediaContent.objects.create(
+                    id=str(uuid.uuid4()),
+                    created_by_id=user_id,
+                    updated_by_id=user_id,
+                    **data,
+                )
+                success_count += 1
+            else:
+                failed_rows.append({
+                    "row": row_num,
+                    "title": row.get('title') or row.get('topic', ''),
+                    "reason": serializer.errors,
+                })
+
+        return CustomResponse(
+            general_message='Bulk import completed.',
+            response={
+                'success_count': success_count,
+                'failed_count': len(failed_rows),
+                'failed_rows': failed_rows,
+            }
+        ).get_success_response()
+
+
+class MediaContentBulkExportAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Media Content - Export'])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
+    def get(self, request, content_type):
+        if content_type == MediaContent.ContentType.OFFICE_HOURS:
+            queryset = MediaContent.objects.filter(
+                content_type=MediaContent.ContentType.OFFICE_HOURS,
+                deleted_at__isnull=True,
+            )
+            serializer = OfficeHoursReadSerializer(queryset, many=True)
+        elif content_type == MediaContent.ContentType.SALT_MANGO_TREE:
+            queryset = MediaContent.objects.filter(
+                content_type=MediaContent.ContentType.SALT_MANGO_TREE,
+                deleted_at__isnull=True,
+            )
+            serializer = SaltMangoTreeReadSerializer(queryset, many=True)
+        elif content_type == MediaContent.ContentType.INSPIRATION_STATION:
+            queryset = MediaContent.objects.filter(
+                content_type=MediaContent.ContentType.INSPIRATION_STATION,
+                deleted_at__isnull=True,
+            )
+            serializer = InspirationStationReadSerializer(queryset, many=True)
+        else:
+            return CustomResponse(
+                general_message='Invalid content type. Must be office_hours, salt_mango_tree, or inspiration_station.'
+            ).get_failure_response()
+
+        return CommonUtils.generate_csv(serializer.data, f"{content_type}_export.csv")
+        
+
+        

--- a/api/dashboard/media_content/views.py
+++ b/api/dashboard/media_content/views.py
@@ -22,6 +22,7 @@ from utils.response import CustomResponse
 from utils.types import RoleType
 from utils.utils import CommonUtils
 import csv
+import codecs
 
 from .serializers import (
     OfficeHoursReadSerializer,
@@ -501,7 +502,7 @@ class MediaContentBulkImportAPI(APIView):
                 general_message='Invalid file type. Please upload a CSV file.',
             ).get_failure_response()
 
-        import codecs
+       
         try:
             reader = csv.DictReader(codecs.iterdecode(file, 'utf-8-sig'))
             rows = list(reader)  # materialize here so decode errors are caught

--- a/api/dashboard/media_content/views.py
+++ b/api/dashboard/media_content/views.py
@@ -1,0 +1,482 @@
+"""
+Media Content API views.
+
+Exposes CRUD endpoints for three CMS-migrated content types backed by the
+single ``MediaContent`` model:
+
+  - Office Hours          → /media-content/office-hours/
+  - Salt Mango Tree       → /media-content/salt-mango-tree/
+  - Inspiration Station   → /media-content/inspiration-station/
+
+Read (GET) endpoints are publicly accessible.
+Write (POST / PATCH / DELETE) endpoints require the ADMIN role.
+"""
+import uuid
+
+from django.utils import timezone
+from rest_framework.views import APIView
+
+from db.events import MediaContent
+from utils.permission import CustomizePermission, JWTUtils, RoleRequired
+from utils.response import CustomResponse
+from utils.types import RoleType
+from utils.utils import CommonUtils
+
+from .serializers import (
+    OfficeHoursReadSerializer,
+    OfficeHoursWriteSerializer,
+    SaltMangoTreeReadSerializer,
+    SaltMangoTreeWriteSerializer,
+    InspirationStationReadSerializer,
+    InspirationStationWriteSerializer,
+)
+
+from drf_spectacular.utils import extend_schema
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+class PublicGetMixin:
+    """
+    Mixin to bypass JWT authentication for GET requests.
+    """
+    def get_authenticators(self):
+        if getattr(self, 'request', None) and self.request.method == 'GET':
+            return []
+        return super().get_authenticators()
+
+def _base_qs(content_type: str):
+    """Live (non-deleted) queryset for a given content type."""
+    return MediaContent.objects.filter(
+        content_type=content_type,
+        deleted_at__isnull=True,
+    ).order_by('-date', '-created_at')
+
+
+def _apply_common_filters(qs, request, *, has_zone: bool = False):
+    """Apply shared query-param filters to a MediaContent queryset."""
+    params = request.query_params
+    from datetime import date
+
+    if status := params.get('status'):
+        status = status.lower()
+        if status == 'upcoming':
+            qs = qs.filter(date__gt=date.today())
+        elif status == 'ongoing':
+            qs = qs.filter(date=date.today())
+        elif status == 'completed':
+            qs = qs.filter(date__lt=date.today())
+
+    if has_zone:
+        if zone := params.get('zone'):
+            qs = qs.filter(zone=zone)
+
+    return qs
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Office Hours
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+
+
+
+class OfficeHoursListCreateAPI(PublicGetMixin, APIView):
+    """
+    GET  /media-content/office-hours/  — Public paginated list of sessions.
+    POST /media-content/office-hours/  — Create a session (Admin only).
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Media Content - Office Hours'])
+    def get(self, request):
+        qs = _base_qs(MediaContent.ContentType.OFFICE_HOURS)
+        qs = _apply_common_filters(qs, request, has_zone=False)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            qs, request,
+            search_fields=['title', 'performer', 'description'],
+            sort_fields={
+                'date': 'date',
+                'created_at': 'created_at',
+            },
+        )
+
+        serializer = OfficeHoursReadSerializer(paginated['queryset'], many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+
+    @extend_schema(tags=['Media Content - Office Hours'])
+    @RoleRequired([RoleType.ADMIN])
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        serializer = OfficeHoursWriteSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message='Invalid data.',
+                message=serializer.errors,
+            ).get_failure_response()
+
+        data = serializer.validated_data
+        record = MediaContent.objects.create(
+            id=str(uuid.uuid4()),
+            created_by_id=user_id,
+            updated_by_id=user_id,
+            **data,
+        )
+
+        return CustomResponse(
+            general_message='Office Hours session created successfully.',
+            response=OfficeHoursReadSerializer(record).data,
+        ).get_success_response()
+
+
+class OfficeHoursDetailAPI(PublicGetMixin, APIView):
+    """
+    GET    /media-content/office-hours/<record_id>/  — Public session detail.
+    PATCH  /media-content/office-hours/<record_id>/  — Partial update (Admin only).
+    DELETE /media-content/office-hours/<record_id>/  — Soft-delete (Admin only).
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_record(self, record_id):
+        return MediaContent.objects.filter(
+            id=record_id,
+            content_type=MediaContent.ContentType.OFFICE_HOURS,
+            deleted_at__isnull=True,
+        ).first()
+
+    @extend_schema(tags=['Media Content - Office Hours'])
+    def get(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Office Hours session not found.'
+            ).get_failure_response()
+
+        serializer = OfficeHoursReadSerializer(record)
+        return CustomResponse(
+            general_message='Office Hours session retrieved.',
+            response=serializer.data,
+        ).get_success_response()
+
+
+    @extend_schema(tags=['Media Content - Office Hours'])
+    @RoleRequired([RoleType.ADMIN])
+    def patch(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Office Hours session not found.'
+            ).get_failure_response()
+
+        serializer = OfficeHoursWriteSerializer(data=request.data, partial=True)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message='Invalid data.',
+                message=serializer.errors,
+            ).get_failure_response()
+
+        user_id = JWTUtils.fetch_user_id(request)
+        data = serializer.validated_data
+        data.pop('content_type', None)  # never allow overriding the discriminator
+
+        for attr, value in data.items():
+            setattr(record, attr, value)
+        record.updated_by_id = user_id
+        record.save()
+
+        return CustomResponse(
+            general_message='Office Hours session updated.',
+            response=OfficeHoursReadSerializer(record).data,
+        ).get_success_response()
+
+
+    @extend_schema(tags=['Media Content - Office Hours'])
+    @RoleRequired([RoleType.ADMIN])
+    def delete(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Office Hours session not found.'
+            ).get_failure_response()
+
+        record.deleted_at = timezone.now()
+        record.updated_by_id = JWTUtils.fetch_user_id(request)
+        record.save(update_fields=['deleted_at', 'updated_by_id'])
+
+        return CustomResponse(
+            general_message='Office Hours session deleted.'
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Salt Mango Tree
+# ─────────────────────────────────────────────────────────────────────────────
+
+class SaltMangoTreeListCreateAPI(PublicGetMixin, APIView):
+    """
+    GET  /media-content/salt-mango-tree/  — Public paginated list of episodes.
+    POST /media-content/salt-mango-tree/  — Create an episode (Admin only).
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Media Content - Salt Mango Tree'])
+    def get(self, request):
+        qs = _base_qs(MediaContent.ContentType.SALT_MANGO_TREE)
+        qs = _apply_common_filters(qs, request, has_zone=True)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            qs, request,
+            search_fields=['title', 'campus', 'description'],
+            sort_fields={
+                'date': 'date',
+                'campus': 'campus',
+                'created_at': 'created_at',
+            },
+        )
+
+        serializer = SaltMangoTreeReadSerializer(paginated['queryset'], many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+    @extend_schema(tags=['Media Content - Salt Mango Tree'])
+    @RoleRequired([RoleType.ADMIN])
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        serializer = SaltMangoTreeWriteSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message='Invalid data.',
+                message=serializer.errors,
+            ).get_failure_response()
+
+        data = serializer.validated_data
+        record = MediaContent.objects.create(
+            id=str(uuid.uuid4()),
+            created_by_id=user_id,
+            updated_by_id=user_id,
+            **data,
+        )
+
+        return CustomResponse(
+            general_message='Salt Mango Tree episode created successfully.',
+            response=SaltMangoTreeReadSerializer(record).data,
+        ).get_success_response()
+
+
+class SaltMangoTreeDetailAPI(PublicGetMixin, APIView):
+    """
+    GET    /media-content/salt-mango-tree/<record_id>/
+    PATCH  /media-content/salt-mango-tree/<record_id>/  (Admin)
+    DELETE /media-content/salt-mango-tree/<record_id>/  (Admin)
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_record(self, record_id):
+        return MediaContent.objects.filter(
+            id=record_id,
+            content_type=MediaContent.ContentType.SALT_MANGO_TREE,
+            deleted_at__isnull=True,
+        ).first()
+
+    @extend_schema(tags=['Media Content - Salt Mango Tree'])
+    def get(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Salt Mango Tree episode not found.'
+            ).get_failure_response()
+
+        return CustomResponse(
+            general_message='Salt Mango Tree episode retrieved.',
+            response=SaltMangoTreeReadSerializer(record).data,
+        ).get_success_response()
+
+    @extend_schema(tags=['Media Content - Salt Mango Tree'])
+    @RoleRequired([RoleType.ADMIN])
+    def patch(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Salt Mango Tree episode not found.'
+            ).get_failure_response()
+
+        serializer = SaltMangoTreeWriteSerializer(data=request.data, partial=True)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message='Invalid data.',
+                message=serializer.errors,
+            ).get_failure_response()
+
+        user_id = JWTUtils.fetch_user_id(request)
+        data = serializer.validated_data
+        data.pop('content_type', None)
+
+        for attr, value in data.items():
+            setattr(record, attr, value)
+        record.updated_by_id = user_id
+        record.save()
+
+        return CustomResponse(
+            general_message='Salt Mango Tree episode updated.',
+            response=SaltMangoTreeReadSerializer(record).data,
+        ).get_success_response()
+
+    @extend_schema(tags=['Media Content - Salt Mango Tree'])
+    @RoleRequired([RoleType.ADMIN])
+    def delete(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Salt Mango Tree episode not found.'
+            ).get_failure_response()
+
+        record.deleted_at = timezone.now()
+        record.updated_by_id = JWTUtils.fetch_user_id(request)
+        record.save(update_fields=['deleted_at', 'updated_by_id'])
+
+        return CustomResponse(
+            general_message='Salt Mango Tree episode deleted.'
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Inspiration Station Radio
+# ─────────────────────────────────────────────────────────────────────────────
+
+class InspirationStationListCreateAPI(PublicGetMixin, APIView):
+    """
+    GET  /media-content/inspiration-station/  — Public paginated list.
+    POST /media-content/inspiration-station/  — Create an episode (Admin only).
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Media Content - Inspiration Station'])
+    def get(self, request):
+        qs = _base_qs(MediaContent.ContentType.INSPIRATION_STATION)
+        qs = _apply_common_filters(qs, request, has_zone=True)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            qs, request,
+            search_fields=['title', 'campus', 'description'],
+            sort_fields={
+                'date': 'date',
+                'campus': 'campus',
+                'created_at': 'created_at',
+            },
+        )
+
+        serializer = InspirationStationReadSerializer(paginated['queryset'], many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+    @extend_schema(tags=['Media Content - Inspiration Station'])
+    @RoleRequired([RoleType.ADMIN])
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        serializer = InspirationStationWriteSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message='Invalid data.',
+                message=serializer.errors,
+            ).get_failure_response()
+
+        data = serializer.validated_data
+        record = MediaContent.objects.create(
+            id=str(uuid.uuid4()),
+            created_by_id=user_id,
+            updated_by_id=user_id,
+            **data,
+        )
+
+        return CustomResponse(
+            general_message='Inspiration Station episode created successfully.',
+            response=InspirationStationReadSerializer(record).data,
+        ).get_success_response()
+
+
+class InspirationStationDetailAPI(PublicGetMixin, APIView):
+    """
+    GET    /media-content/inspiration-station/<record_id>/
+    PATCH  /media-content/inspiration-station/<record_id>/  (Admin)
+    DELETE /media-content/inspiration-station/<record_id>/  (Admin)
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_record(self, record_id):
+        return MediaContent.objects.filter(
+            id=record_id,
+            content_type=MediaContent.ContentType.INSPIRATION_STATION,
+            deleted_at__isnull=True,
+        ).first()
+
+    @extend_schema(tags=['Media Content - Inspiration Station'])
+    def get(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Inspiration Station episode not found.'
+            ).get_failure_response()
+
+        return CustomResponse(
+            general_message='Inspiration Station episode retrieved.',
+            response=InspirationStationReadSerializer(record).data,
+        ).get_success_response()
+
+    @extend_schema(tags=['Media Content - Inspiration Station'])
+    @RoleRequired([RoleType.ADMIN])
+    def patch(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Inspiration Station episode not found.'
+            ).get_failure_response()
+
+        serializer = InspirationStationWriteSerializer(data=request.data, partial=True)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message='Invalid data.',
+                message=serializer.errors,
+            ).get_failure_response()
+
+        user_id = JWTUtils.fetch_user_id(request)
+        data = serializer.validated_data
+        data.pop('content_type', None)
+
+        for attr, value in data.items():
+            setattr(record, attr, value)
+        record.updated_by_id = user_id
+        record.save()
+
+        return CustomResponse(
+            general_message='Inspiration Station episode updated.',
+            response=InspirationStationReadSerializer(record).data,
+        ).get_success_response()
+
+    @extend_schema(tags=['Media Content - Inspiration Station'])
+    @RoleRequired([RoleType.ADMIN])
+    def delete(self, request, record_id):
+        record = self._get_record(record_id)
+        if not record:
+            return CustomResponse(
+                general_message='Inspiration Station episode not found.'
+            ).get_failure_response()
+
+        record.deleted_at = timezone.now()
+        record.updated_by_id = JWTUtils.fetch_user_id(request)
+        record.save(update_fields=['deleted_at', 'updated_by_id'])
+
+        return CustomResponse(
+            general_message='Inspiration Station episode deleted.'
+        ).get_success_response()

--- a/api/dashboard/media_content/views.py
+++ b/api/dashboard/media_content/views.py
@@ -113,7 +113,7 @@ class OfficeHoursListCreateAPI(PublicGetMixin, APIView):
 
 
     @extend_schema(tags=['Media Content - Office Hours'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         serializer = OfficeHoursWriteSerializer(data=request.data)
@@ -168,7 +168,7 @@ class OfficeHoursDetailAPI(PublicGetMixin, APIView):
 
 
     @extend_schema(tags=['Media Content - Office Hours'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def patch(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -199,7 +199,7 @@ class OfficeHoursDetailAPI(PublicGetMixin, APIView):
 
 
     @extend_schema(tags=['Media Content - Office Hours'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def delete(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -249,7 +249,7 @@ class SaltMangoTreeListCreateAPI(PublicGetMixin, APIView):
         )
 
     @extend_schema(tags=['Media Content - Salt Mango Tree'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         serializer = SaltMangoTreeWriteSerializer(data=request.data)
@@ -302,7 +302,7 @@ class SaltMangoTreeDetailAPI(PublicGetMixin, APIView):
         ).get_success_response()
 
     @extend_schema(tags=['Media Content - Salt Mango Tree'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def patch(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -332,7 +332,7 @@ class SaltMangoTreeDetailAPI(PublicGetMixin, APIView):
         ).get_success_response()
 
     @extend_schema(tags=['Media Content - Salt Mango Tree'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def delete(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -382,7 +382,7 @@ class InspirationStationListCreateAPI(PublicGetMixin, APIView):
         )
 
     @extend_schema(tags=['Media Content - Inspiration Station'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         serializer = InspirationStationWriteSerializer(data=request.data)
@@ -435,7 +435,7 @@ class InspirationStationDetailAPI(PublicGetMixin, APIView):
         ).get_success_response()
 
     @extend_schema(tags=['Media Content - Inspiration Station'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def patch(self, request, record_id):
         record = self._get_record(record_id)
         if not record:
@@ -465,7 +465,7 @@ class InspirationStationDetailAPI(PublicGetMixin, APIView):
         ).get_success_response()
 
     @extend_schema(tags=['Media Content - Inspiration Station'])
-    @RoleRequired([RoleType.ADMIN])
+    @RoleRequired([RoleType.ADMIN.value])
     def delete(self, request, record_id):
         record = self._get_record(record_id)
         if not record:

--- a/api/dashboard/urls.py
+++ b/api/dashboard/urls.py
@@ -28,4 +28,6 @@ urlpatterns = [
     path("achievement/", include("api.dashboard.achievement.urls")),
     path("skill/", include("api.dashboard.skill.urls")),
     path("task-report/", include("api.dashboard.task_report.urls")),
+    path("media-content/", include("api.dashboard.media_content.urls")),
+    # mentorship/ has been consolidated into mentor/ — do not re-add
 ]

--- a/api/integrations/mulearn_api/views.py
+++ b/api/integrations/mulearn_api/views.py
@@ -6,7 +6,6 @@ from db.task import TaskList, KarmaActivityLog
 from utils.response import CustomResponse
 
 class ExternalTaskVerificationAPI(APIView):
-
     def get(self, request):
         muid = request.query_params.get('muid')
         email = request.query_params.get('email')

--- a/api_docs/media_content_api.md
+++ b/api_docs/media_content_api.md
@@ -1,0 +1,857 @@
+# Media Content API — Comprehensive Documentation
+
+> Base URL prefix: `/api/v1/dashboard/media-content/`
+
+This module exposes CRUD endpoints for three content types previously managed via CMS, now stored in a single `media_content` database table with a `content_type` discriminator.
+
+---
+
+## Table of Contents
+
+- [Authentication & Roles](#authentication--roles)
+- [Common Response Envelope](#common-response-envelope)
+- [Common Query Parameters](#common-query-parameters-list-endpoints)
+- [Office Hours](#-office-hours)
+- [Salt Mango Tree](#-salt-mango-tree)
+- [Inspiration Station Radio](#-inspiration-station-radio)
+- [Error Reference](#error-reference)
+- [Enum Reference](#enum-reference)
+
+---
+
+## Authentication & Roles
+
+| Operation | Auth Required | Role Required |
+|-----------|--------------|---------------|
+| `GET` list / detail | ❌ Public | None |
+| `POST` create | ✅ Bearer JWT | `admin` |
+| `PATCH` update | ✅ Bearer JWT | `admin` |
+| `DELETE` soft-delete | ✅ Bearer JWT | `admin` |
+
+**Header for write operations:**
+```
+Authorization: Bearer <jwt_token>
+```
+
+> **Note:** DELETE is a **soft delete** — `deleted_at` is set and the record is excluded from all future list/detail queries. Data is **not** removed from the database.
+
+---
+
+## Common Response Envelope
+
+**Success:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Success message"] },
+  "response": {}
+}
+```
+
+**Paginated list:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": [] },
+  "response": {
+    "data": [],
+    "pagination": {
+      "count": 42,
+      "totalPages": 5,
+      "isNext": true,
+      "isPrev": false,
+      "nextPage": 2
+    }
+  }
+}
+```
+
+**Error:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": { "general": ["Error message"] },
+  "response": {}
+}
+```
+
+---
+
+## Common Query Parameters (List Endpoints)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pageIndex` | integer | Page number (default: `1`) |
+| `perPage` | integer | Items per page (default: `10`) |
+| `search` | string | Case-insensitive text search across indexed fields |
+| `sortBy` | string | Field to sort by. Prefix with `-` for descending. e.g. `-date` |
+| `status` | `upcoming` / `ongoing` / `completed` | Filter by computed status based on date |
+| `zone` | string | `north` / `central` / `south` — SMT & Inspiration Station only |
+
+---
+
+## 📅 Office Hours
+
+**Content type discriminator:** `office_hours`
+**Date input format:** `DD/MM/YYYY` | **Date output format:** `YYYY-MM-DD`
+
+### Field Reference
+
+| Field | Type | Required | Max Length | Notes |
+|-------|------|----------|------------|-------|
+| `title` | string | ✅ | 300 | Session title |
+| `date` | string | ✅ | — | Must be `DD/MM/YYYY` |
+| `performer` | string | ❌ | 200 | Speaker / host name |
+| `designation` | string | ❌ | 200 | e.g. "Senior Developer" |
+| `description` | string | ❌ | unlimited | Session description |
+| `link` | URL | ❌ | 500 | Meeting or streaming link |
+| `interest_groups` | string[] | ❌ | — | Array of IG slugs |
+| `poster_thumbnail` | string | ❌ | 512 | Image URL |
+
+---
+
+### `GET /api/v1/dashboard/media-content/office-hours/`
+
+List all active Office Hours sessions. **Public.**
+
+**Search fields:** `title`, `performer`, `description`
+
+**Example:**
+```
+GET /api/v1/dashboard/media-content/office-hours/?status=upcoming&pageIndex=1&perPage=5
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": [] },
+  "response": {
+    "data": [
+      {
+        "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "title": "Intro to REST APIs with Django",
+        "performer": "Alice Thomas",
+        "designation": "Senior Developer",
+        "description": "A hands-on session covering DRF best practices.",
+        "date": "2025-08-15",
+        "link": "https://meet.google.com/xyz-abc",
+        "interest_groups": ["web-development", "ai"],
+        "poster_thumbnail": "https://cdn.example.com/poster1.jpg",
+        "status": "upcoming",
+        "created_at": "2025-06-27T06:30:00.000000Z",
+        "updated_at": "2025-06-27T06:30:00.000000Z"
+      }
+    ],
+    "pagination": {
+      "count": 1,
+      "totalPages": 1,
+      "isNext": false,
+      "isPrev": false,
+      "nextPage": null
+    }
+  }
+}
+```
+
+---
+
+### `POST /api/v1/dashboard/media-content/office-hours/`
+
+Create an Office Hours session. **Admin only.**
+
+**Full request body:**
+```json
+{
+  "title": "Introduction to Web3",
+  "date": "15/09/2025",
+  "performer": "Priya Nair",
+  "designation": "Blockchain Developer",
+  "description": "Explore decentralised applications and smart contracts.",
+  "link": "https://meet.google.com/web3-session",
+  "interest_groups": ["blockchain", "web-development"],
+  "poster_thumbnail": "https://cdn.example.com/posters/web3.jpg"
+}
+```
+
+**Minimal request (required fields only):**
+```json
+{
+  "title": "Quick Dev Talk",
+  "date": "20/09/2025"
+}
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Office Hours session created successfully."] },
+  "response": {
+    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+    "title": "Introduction to Web3",
+    "performer": "Priya Nair",
+    "designation": "Blockchain Developer",
+    "description": "Explore decentralised applications and smart contracts.",
+    "date": "2025-09-15",
+    "link": "https://meet.google.com/web3-session",
+    "interest_groups": ["blockchain", "web-development"],
+    "poster_thumbnail": "https://cdn.example.com/posters/web3.jpg",
+    "status": "upcoming",
+    "created_at": "2025-06-27T06:45:00.000000Z",
+    "updated_at": "2025-06-27T06:45:00.000000Z"
+  }
+}
+```
+
+**400 — Missing required fields:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": {
+    "general": ["Invalid data."],
+    "title": ["This field is required."],
+    "date": ["This field is required."]
+  },
+  "response": {}
+}
+```
+
+**400 — Wrong date format:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": {
+    "general": ["Invalid data."],
+    "date": ["Invalid date format. Expected DD/MM/YYYY (e.g. 27/06/2025)."]
+  },
+  "response": {}
+}
+```
+
+**400 — Non-admin:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": {
+    "general": ["You do not have the required role to access this page."]
+  },
+  "response": {}
+}
+```
+
+---
+
+### `GET /api/v1/dashboard/media-content/office-hours/{record_id}/`
+
+Retrieve a single session. **Public.**
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Office Hours session retrieved."] },
+  "response": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "title": "Intro to REST APIs with Django",
+    "performer": "Alice Thomas",
+    "designation": "Senior Developer",
+    "description": "A hands-on session covering DRF best practices.",
+    "date": "2025-08-15",
+    "link": "https://meet.google.com/xyz-abc",
+    "interest_groups": ["web-development", "ai"],
+    "poster_thumbnail": "https://cdn.example.com/poster1.jpg",
+    "status": "upcoming",
+    "created_at": "2025-06-27T06:30:00.000000Z",
+    "updated_at": "2025-06-27T06:30:00.000000Z"
+  }
+}
+```
+
+**400 — Not found or soft-deleted:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": { "general": ["Office Hours session not found."] },
+  "response": {}
+}
+```
+
+---
+
+### `PATCH /api/v1/dashboard/media-content/office-hours/{record_id}/`
+
+Partially update a session. **Admin only.** All fields optional.
+
+**Request (update link + interest groups):**
+```json
+{
+  "link": "https://meet.google.com/new-link",
+  "interest_groups": ["ai", "generative-ai"]
+}
+```
+
+**Request (update date):**
+```json
+{
+  "date": "30/09/2025"
+}
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Office Hours session updated."] },
+  "response": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "title": "Intro to REST APIs with Django",
+    "performer": "Alice Thomas",
+    "designation": "Senior Developer",
+    "description": "A hands-on session covering DRF best practices.",
+    "date": "2025-09-30",
+    "link": "https://meet.google.com/new-link",
+    "interest_groups": ["ai", "generative-ai"],
+    "poster_thumbnail": "https://cdn.example.com/poster1.jpg",
+    "status": "upcoming",
+    "created_at": "2025-06-27T06:30:00.000000Z",
+    "updated_at": "2025-06-27T08:15:00.000000Z"
+  }
+}
+```
+
+---
+
+### `DELETE /api/v1/dashboard/media-content/office-hours/{record_id}/`
+
+Soft-delete a session. **Admin only.**
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Office Hours session deleted."] },
+  "response": {}
+}
+```
+
+**400 — Record not found:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": { "general": ["Office Hours session not found."] },
+  "response": {}
+}
+```
+
+---
+
+## 🥭 Salt Mango Tree
+
+**Content type discriminator:** `salt_mango_tree`
+**Date format:** `YYYY-MM-DD`
+
+> **Note:** The CMS field `topic` is accepted in write requests and returned in responses. It maps internally to the `title` column in the database.
+
+### Field Reference
+
+| Field | Type | Required | Max Length | Notes |
+|-------|------|----------|------------|-------|
+| `topic` | string | ✅ | 300 | Episode topic |
+| `campus` | string | ✅ | 200 | Campus name |
+| `date` | string | ✅ | — | Must be `YYYY-MM-DD` |
+| `zone` | enum | ❌ | — | `north` / `central` / `south` |
+| `description` | string | ❌ | unlimited | Episode description |
+| `link` | URL | ❌ | 500 | Streaming link |
+
+---
+
+### `GET /api/v1/dashboard/media-content/salt-mango-tree/`
+
+List active SMT episodes. **Public.**
+
+**Search fields:** `topic`, `campus`, `description`
+
+**Example:**
+```
+GET /api/v1/dashboard/media-content/salt-mango-tree/?zone=north&status=upcoming
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": [] },
+  "response": {
+    "data": [
+      {
+        "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+        "topic": "Building Sustainable Startups",
+        "campus": "NIT Calicut",
+        "zone": "north",
+        "date": "2025-08-20",
+        "description": "Student founders share their journey from idea to product.",
+        "link": "https://youtube.com/live/smt-ep12",
+        "status": "upcoming",
+        "created_at": "2025-06-27T09:00:00.000000Z",
+        "updated_at": "2025-06-27T09:00:00.000000Z"
+      }
+    ],
+    "pagination": {
+      "count": 1,
+      "totalPages": 1,
+      "isNext": false,
+      "isPrev": false,
+      "nextPage": null
+    }
+  }
+}
+```
+
+---
+
+### `POST /api/v1/dashboard/media-content/salt-mango-tree/`
+
+Create an SMT episode. **Admin only.**
+
+**Full request body:**
+```json
+{
+  "topic": "AI in Agriculture",
+  "campus": "Kerala Agricultural University",
+  "zone": "south",
+  "date": "2025-10-05",
+  "description": "How students are using AI to solve farming challenges.",
+  "link": "https://youtube.com/live/smt-ep15"
+}
+```
+
+**Minimal request:**
+```json
+{
+  "topic": "Open Source Culture",
+  "campus": "IIT Palakkad",
+  "date": "2025-10-15"
+}
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Salt Mango Tree episode created successfully."] },
+  "response": {
+    "id": "e5f6a7b8-c9d0-1234-efab-345678901234",
+    "topic": "AI in Agriculture",
+    "campus": "Kerala Agricultural University",
+    "zone": "south",
+    "date": "2025-10-05",
+    "description": "How students are using AI to solve farming challenges.",
+    "link": "https://youtube.com/live/smt-ep15",
+    "status": "upcoming",
+    "created_at": "2025-06-27T09:15:00.000000Z",
+    "updated_at": "2025-06-27T09:15:00.000000Z"
+  }
+}
+```
+
+**400 — Missing required fields:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": {
+    "general": ["Invalid data."],
+    "campus": ["This field is required."]
+  },
+  "response": {}
+}
+```
+
+**400 — Invalid zone value:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": {
+    "general": ["Invalid data."],
+    "zone": ["\"east\" is not a valid choice."]
+  },
+  "response": {}
+}
+```
+
+**400 — Wrong date format (e.g. DD/MM/YYYY sent instead of YYYY-MM-DD):**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": {
+    "general": ["Invalid data."],
+    "date": ["Date has wrong format. Use one of these formats instead: YYYY-MM-DD."]
+  },
+  "response": {}
+}
+```
+
+---
+
+### `GET /api/v1/dashboard/media-content/salt-mango-tree/{record_id}/`
+
+Retrieve a single SMT episode. **Public.**
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Salt Mango Tree episode retrieved."] },
+  "response": {
+    "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+    "topic": "Building Sustainable Startups",
+    "campus": "NIT Calicut",
+    "zone": "north",
+    "date": "2025-08-20",
+    "description": "Student founders share their journey from idea to product.",
+    "link": "https://youtube.com/live/smt-ep12",
+    "status": "upcoming",
+    "created_at": "2025-06-27T09:00:00.000000Z",
+    "updated_at": "2025-06-27T09:00:00.000000Z"
+  }
+}
+```
+
+**400 — Not found or soft-deleted:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": { "general": ["Salt Mango Tree episode not found."] },
+  "response": {}
+}
+```
+
+---
+
+### `PATCH /api/v1/dashboard/media-content/salt-mango-tree/{record_id}/`
+
+Partially update an SMT episode. **Admin only.**
+
+**Request (update zone and link):**
+```json
+{
+  "zone": "central",
+  "link": "https://youtube.com/live/smt-ep12-v2"
+}
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Salt Mango Tree episode updated."] },
+  "response": {
+    "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+    "topic": "Building Sustainable Startups",
+    "campus": "NIT Calicut",
+    "zone": "central",
+    "date": "2025-08-20",
+    "description": "Student founders share their journey from idea to product.",
+    "link": "https://youtube.com/live/smt-ep12-v2",
+    "status": "upcoming",
+    "created_at": "2025-06-27T09:00:00.000000Z",
+    "updated_at": "2025-06-27T10:00:00.000000Z"
+  }
+}
+```
+
+---
+
+### `DELETE /api/v1/dashboard/media-content/salt-mango-tree/{record_id}/`
+
+Soft-delete an SMT episode. **Admin only.**
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Salt Mango Tree episode deleted."] },
+  "response": {}
+}
+```
+
+---
+
+## 📻 Inspiration Station Radio
+
+**Content type discriminator:** `inspiration_station`
+**Date format:** `YYYY-MM-DD`
+
+> **Note:** Identical field structure to Salt Mango Tree. `topic` is used in request and response, mapped to `title` internally.
+
+### Field Reference
+
+| Field | Type | Required | Max Length | Notes |
+|-------|------|----------|------------|-------|
+| `topic` | string | ✅ | 300 | Episode topic |
+| `campus` | string | ✅ | 200 | Campus name |
+| `date` | string | ✅ | — | Must be `YYYY-MM-DD` |
+| `zone` | enum | ❌ | — | `north` / `central` / `south` |
+| `description` | string | ❌ | unlimited | Episode description |
+| `link` | URL | ❌ | 500 | Streaming link |
+
+---
+
+### `GET /api/v1/dashboard/media-content/inspiration-station/`
+
+List active Inspiration Station episodes. **Public.**
+
+**Search fields:** `topic`, `campus`, `description`
+
+**Example:**
+```
+GET /api/v1/dashboard/media-content/inspiration-station/?status=completed&perPage=3
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": [] },
+  "response": {
+    "data": [
+      {
+        "id": "f6a7b8c9-d0e1-2345-fabc-456789012345",
+        "topic": "From Classroom to Startup",
+        "campus": "IIM Kozhikode",
+        "zone": "south",
+        "date": "2025-04-10",
+        "description": "A founder shares how an MBA project became a funded startup.",
+        "link": null,
+        "status": "completed",
+        "created_at": "2025-04-01T05:00:00.000000Z",
+        "updated_at": "2025-04-01T05:00:00.000000Z"
+      }
+    ],
+    "pagination": {
+      "count": 1,
+      "totalPages": 1,
+      "isNext": false,
+      "isPrev": false,
+      "nextPage": null
+    }
+  }
+}
+```
+
+---
+
+### `POST /api/v1/dashboard/media-content/inspiration-station/`
+
+Create an Inspiration Station episode. **Admin only.**
+
+**Full request body:**
+```json
+{
+  "topic": "Women in Tech: Breaking Barriers",
+  "campus": "Model Engineering College",
+  "zone": "central",
+  "date": "2025-11-01",
+  "description": "Female founders and engineers share their stories and advice.",
+  "link": "https://youtube.com/live/is-ep20"
+}
+```
+
+**Minimal request:**
+```json
+{
+  "topic": "Building in Public",
+  "campus": "CUSAT",
+  "date": "2025-11-10"
+}
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Inspiration Station episode created successfully."] },
+  "response": {
+    "id": "b8c9d0e1-f2a3-4567-bcde-678901234567",
+    "topic": "Women in Tech: Breaking Barriers",
+    "campus": "Model Engineering College",
+    "zone": "central",
+    "date": "2025-11-01",
+    "description": "Female founders and engineers share their stories and advice.",
+    "link": "https://youtube.com/live/is-ep20",
+    "status": "upcoming",
+    "created_at": "2025-06-27T10:00:00.000000Z",
+    "updated_at": "2025-06-27T10:00:00.000000Z"
+  }
+}
+```
+
+**400 — Invalid zone:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": {
+    "general": ["Invalid data."],
+    "zone": ["\"east\" is not a valid choice."]
+  },
+  "response": {}
+}
+```
+
+---
+
+### `GET /api/v1/dashboard/media-content/inspiration-station/{record_id}/`
+
+Retrieve a single Inspiration Station episode. **Public.**
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Inspiration Station episode retrieved."] },
+  "response": {
+    "id": "b8c9d0e1-f2a3-4567-bcde-678901234567",
+    "topic": "Women in Tech: Breaking Barriers",
+    "campus": "Model Engineering College",
+    "zone": "central",
+    "date": "2025-11-01",
+    "description": "Female founders and engineers share their stories and advice.",
+    "link": "https://youtube.com/live/is-ep20",
+    "status": "upcoming",
+    "created_at": "2025-06-27T10:00:00.000000Z",
+    "updated_at": "2025-06-27T10:00:00.000000Z"
+  }
+}
+```
+
+**400 — Not found or soft-deleted:**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": { "general": ["Inspiration Station episode not found."] },
+  "response": {}
+}
+```
+
+---
+
+### `PATCH /api/v1/dashboard/media-content/inspiration-station/{record_id}/`
+
+Partially update an episode. **Admin only.**
+
+**Request:**
+```json
+{
+  "topic": "Women in Tech: Breaking Barriers (Extended Edition)",
+  "date": "2025-11-05"
+}
+```
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Inspiration Station episode updated."] },
+  "response": {
+    "id": "b8c9d0e1-f2a3-4567-bcde-678901234567",
+    "topic": "Women in Tech: Breaking Barriers (Extended Edition)",
+    "campus": "Model Engineering College",
+    "zone": "central",
+    "date": "2025-11-05",
+    "description": "Female founders and engineers share their stories and advice.",
+    "link": "https://youtube.com/live/is-ep20",
+    "status": "upcoming",
+    "created_at": "2025-06-27T10:00:00.000000Z",
+    "updated_at": "2025-06-27T11:00:00.000000Z"
+  }
+}
+```
+
+---
+
+### `DELETE /api/v1/dashboard/media-content/inspiration-station/{record_id}/`
+
+Soft-delete an episode. **Admin only.**
+
+**200 OK:**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": ["Inspiration Station episode deleted."] },
+  "response": {}
+}
+```
+
+---
+
+## Error Reference
+
+| Scenario | HTTP Status | `hasError` | Sample Message |
+|----------|------------|------------|----------------|
+| Success | `200` | `false` | Varies |
+| Validation failure | `400` | `true` | Field-level errors inside `message` |
+| Record not found | `400` | `true` | `"<Type> not found."` |
+| Soft-deleted record accessed | `400` | `true` | `"<Type> not found."` |
+| Wrong type ID on wrong endpoint | `400` | `true` | `"<Type> not found."` |
+| Non-admin write attempt | `400` | `true` | `"You do not have the required role..."` |
+| No / invalid JWT | `401` / `403` | `true` | `"Invalid token header"` |
+
+---
+
+## Enum Reference
+
+### Zone (Salt Mango Tree & Inspiration Station)
+
+| API Value | Label |
+|-----------|-------|
+| `north` | North |
+| `central` | Central |
+| `south` | South |
+
+### Content Type Discriminator (read-only, set per endpoint)
+
+| Value | Module |
+|-------|--------|
+| `office_hours` | Office Hours |
+| `salt_mango_tree` | Salt Mango Tree |
+| `inspiration_station` | Inspiration Station Radio |
+
+---
+
+## Implementation Notes
+
+- All `id` fields are **UUID v4** strings.
+- `created_at` / `updated_at` are ISO 8601 UTC timestamps.
+- `status` is **computed at read time** (`date > today` is upcoming, `date == today` is ongoing, `date < today` is completed) — not stored in the DB.
+- `content_type` is **automatically set** by the endpoint — it cannot be overridden via the request body.
+- Soft-deleted records (`deleted_at IS NOT NULL`) are **invisible** to all list and detail endpoints.
+- An ID from one content type is **not accessible** through another type's endpoint (e.g. an SMT id on the Office Hours detail URL returns 400).

--- a/db/events.py
+++ b/db/events.py
@@ -1,0 +1,78 @@
+import uuid
+
+from django.db import models
+from django.conf import settings
+
+from .user import User
+
+class MediaContent(models.Model):
+    """
+    Unified model for CMS-migrated content types:
+      - Office Hours sessions
+      - Salt Mango Tree episodes
+      - Inspiration Station Radio episodes
+
+    The ``content_type`` field acts as a discriminator. Type-specific
+    fields are nullable and only populated for the relevant type.
+    Soft-delete is supported via ``deleted_at``.
+    """
+
+    class ContentType(models.TextChoices):
+        OFFICE_HOURS        = 'office_hours',         'Office Hours'
+        SALT_MANGO_TREE     = 'salt_mango_tree',      'Salt Mango Tree'
+        INSPIRATION_STATION = 'inspiration_station',  'Inspiration Station Radio'
+
+    class Zone(models.TextChoices):
+        NORTH   = 'north',   'North'
+        CENTRAL = 'central', 'Central'
+        SOUTH   = 'south',   'South'
+
+    # ── Primary key ───────────────────────────────────────────────────────────
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+
+    # ── Discriminator ─────────────────────────────────────────────────────────
+    content_type = models.CharField(
+        max_length=30, choices=ContentType.choices, db_index=True
+    )
+
+    # ── Shared fields (all types) ─────────────────────────────────────────────
+    # Office Hours uses "title"; SMT & Inspiration Station use "topic" —
+    # both are stored in this single column.
+    title       = models.CharField(max_length=300)
+    date        = models.DateField()
+    description = models.TextField(blank=True, null=True)
+    link        = models.CharField(max_length=500, blank=True, null=True)
+
+    # ── Office Hours specific ─────────────────────────────────────────────────
+    performer        = models.CharField(max_length=200, blank=True, null=True)
+    designation      = models.CharField(max_length=200, blank=True, null=True)
+    interest_groups  = models.JSONField(blank=True, null=True)   # list of IG slugs
+    poster_thumbnail = models.CharField(max_length=512, blank=True, null=True)
+
+    # ── SMT & Inspiration Station specific ────────────────────────────────────
+    campus = models.CharField(max_length=200, blank=True, null=True)
+    zone   = models.CharField(
+        max_length=10, choices=Zone.choices, blank=True, null=True
+    )
+
+    # ── Soft delete ───────────────────────────────────────────────────────────
+    deleted_at = models.DateTimeField(blank=True, null=True)
+
+    # ── Audit ─────────────────────────────────────────────────────────────────
+    created_by = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+        db_column='created_by', related_name='media_content_created_by'
+    )
+    updated_by = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+        db_column='updated_by', related_name='media_content_updated_by'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        managed = False
+        db_table = 'media_content'
+        indexes = [
+            models.Index(fields=['content_type', 'date']),
+        ]


### PR DESCRIPTION
## Summary
This PR cherry-picks two feature commits from `dev` into `prod_copy`, introducing the media content management module and an external task verification API endpoint.

## Changes

### 🆕 Media Content Management Module
- Added `MediaContent` model in `db/events.py` to support CMS-migrated content types:
  - **Office Hours** sessions
  - **Salt Mango Tree** episodes
  - **Inspiration Station Radio** episodes
- Implemented full CRUD API views for all three content types
- Registered `media-content/` route in `api/dashboard/urls.py`
- Added API documentation in `api_docs/media_content_api.md`

### 🆕 External Task Verification API
- Added `ExternalTaskVerificationAPI` view in `api/integrations/mulearn_api/views.py`
- Accepts `muid`, `email`, and `hashtag` query parameters
- Returns whether a user has completed and received approval for a specific task

## Files Changed
- `db/events.py` — New `MediaContent` model
- `api/dashboard/media_content/` — New module (views, serializers, urls)
- `api/dashboard/urls.py` — Registered new route
- `api/integrations/mulearn_api/views.py` — New external verification endpoint
- `api_docs/media_content_api.md` — API documentation

## Type of Change
- [x] New feature (non-breaking change)
