### PR TITLE
Add comic module to API

### DIFF
--- a/api/muComics/comic/__init__.py
+++ b/api/muComics/comic/__init__.py
@@ -1,0 +1,1 @@
+# Comic module

--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -14,6 +14,8 @@ Endpoints:
 from django.utils import timezone
 from django.db.models import Q
 
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers as s
 from rest_framework.views import APIView
 
 from db.comic import Comic, ComicContributorLink
@@ -62,6 +64,11 @@ class ComicListCreateView(APIView):
     """
     authentication_classes = [CustomizePermission]
 
+    @extend_schema(
+        tags=['muComics'],
+        description="List all active (non-deleted) comics. Supports search by title, status filter, and sort by created_at or title.",
+        responses={200: ComicListItemSerializer(many=True)},
+    )
     def get(self, request):
         user_id = JWTUtils.fetch_user_id(request)
         queryset = _get_active_comics()
@@ -93,6 +100,12 @@ class ComicListCreateView(APIView):
             pagination=paginated['pagination'],
         )
 
+    @extend_schema(
+        tags=['muComics'],
+        description="Create a new comic. Any authenticated user may create a comic. Returns the full comic detail on success.",
+        request=ComicWriteSerializer,
+        responses={200: ComicDetailSerializer},
+    )
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
 
@@ -134,6 +147,11 @@ class ComicDetailView(APIView):
             return None, 'Comic not found.'
         return comic, None
 
+    @extend_schema(
+        tags=['muComics'],
+        description="Retrieve full detail for a single active comic, including contributors and genres.",
+        responses={200: ComicDetailSerializer},
+    )
     def get(self, request, comic_id):
         user_id = JWTUtils.fetch_user_id(request)
         comic, error = self._get_comic_or_error(comic_id)
@@ -147,6 +165,12 @@ class ComicDetailView(APIView):
             ).data,
         ).get_success_response()
 
+    @extend_schema(
+        tags=['muComics'],
+        description="Partially update a comic's title, description, or cover image. Only the creator or an assigned editor contributor may edit. Archived comics cannot be edited.",
+        request=ComicWriteSerializer,
+        responses={200: ComicDetailSerializer},
+    )
     def patch(self, request, comic_id):
         user_id = JWTUtils.fetch_user_id(request)
         comic, error = self._get_comic_or_error(comic_id)
@@ -157,7 +181,7 @@ class ComicDetailView(APIView):
         if not can_edit_comic(user_id, comic):
             return CustomResponse(
                 general_message='You do not have permission to edit this comic.'
-            ).get_failure_response()
+            ).get_unauthorized_response()
 
         # Archived comics cannot be edited
         if comic.status == Comic.Status.ARCHIVED:
@@ -184,6 +208,14 @@ class ComicDetailView(APIView):
             ).data,
         ).get_success_response()
 
+    @extend_schema(
+        tags=['muComics'],
+        description="Soft-delete a comic (sets deleted_at). Only the original creator may delete. The comic is hidden from all list/detail responses after deletion.",
+        responses={200: inline_serializer(
+            name='ComicDeleteResponse',
+            fields={'id': s.CharField()},
+        )},
+    )
     def delete(self, request, comic_id):
         user_id = JWTUtils.fetch_user_id(request)
         comic, error = self._get_comic_or_error(comic_id)
@@ -194,7 +226,7 @@ class ComicDetailView(APIView):
         if comic.created_by_id != user_id:
             return CustomResponse(
                 general_message='Only the comic creator can delete this comic.'
-            ).get_failure_response()
+            ).get_unauthorized_response()
 
         now = timezone.now()
         comic.deleted_at    = now
@@ -227,6 +259,17 @@ class ComicPublishView(APIView):
 
     REQUIRED_FIELDS = ['title', 'description']
 
+    @extend_schema(
+        tags=['muComics'],
+        description="Publish a draft comic (draft → published). Only the creator may publish. Requires title and description to be present. Archived comics cannot be re-published.",
+        responses={200: inline_serializer(
+            name='ComicPublishResponse',
+            fields={
+                'id':     s.CharField(),
+                'status': s.CharField(),
+            },
+        )},
+    )
     def post(self, request, comic_id):
         user_id = JWTUtils.fetch_user_id(request)
         comic   = _get_active_comics().filter(id=comic_id).first()
@@ -238,7 +281,7 @@ class ComicPublishView(APIView):
         if comic.created_by_id != user_id:
             return CustomResponse(
                 general_message='Only the comic creator can publish this comic.'
-            ).get_failure_response()
+            ).get_unauthorized_response()
 
         if comic.status == Comic.Status.PUBLISHED:
             return CustomResponse(
@@ -286,6 +329,17 @@ class ComicArchiveView(APIView):
     """
     authentication_classes = [CustomizePermission]
 
+    @extend_schema(
+        tags=['muComics'],
+        description="Archive a draft or published comic (draft/published → archived). Only the creator may archive. Already-archived comics are rejected.",
+        responses={200: inline_serializer(
+            name='ComicArchiveResponse',
+            fields={
+                'id':     s.CharField(),
+                'status': s.CharField(),
+            },
+        )},
+    )
     def post(self, request, comic_id):
         user_id = JWTUtils.fetch_user_id(request)
         comic   = _get_active_comics().filter(id=comic_id).first()
@@ -297,7 +351,7 @@ class ComicArchiveView(APIView):
         if comic.created_by_id != user_id:
             return CustomResponse(
                 general_message='Only the comic creator can archive this comic.'
-            ).get_failure_response()
+            ).get_unauthorized_response()
 
         if comic.status == Comic.Status.ARCHIVED:
             return CustomResponse(

--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -305,7 +305,7 @@ class ComicPublishView(APIView):
         comic.published_at  = now
         comic.updated_by_id = user_id
         comic.updated_at    = now
-        comic.save()
+        comic.save(update_fields=['status', 'published_at', 'updated_by', 'updated_at'])
 
         return CustomResponse(
             general_message=f'Comic "{comic.title}" published successfully.',
@@ -362,7 +362,7 @@ class ComicArchiveView(APIView):
         comic.status        = Comic.Status.ARCHIVED
         comic.updated_by_id = user_id
         comic.updated_at    = now
-        comic.save()
+        comic.save(update_fields=['status', 'updated_by', 'updated_at'])
 
         return CustomResponse(
             general_message=f'Comic "{comic.title}" archived successfully.',

--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -1,0 +1,316 @@
+"""
+Comic CRUD views.
+
+Endpoints:
+  GET    /muComics/comics/                      → list (paginated, search, filter, sort)
+  POST   /muComics/comics/                      → create
+  GET    /muComics/comics/<comic_id>/            → detail
+  PATCH  /muComics/comics/<comic_id>/            → partial update (creator or editor)
+  DELETE /muComics/comics/<comic_id>/            → soft delete (creator only)
+  POST   /muComics/comics/<comic_id>/publish/    → draft → published (creator only)
+  POST   /muComics/comics/<comic_id>/archive/    → published/draft → archived (creator only)
+"""
+
+from django.utils import timezone
+from django.db.models import Q
+
+from rest_framework.views import APIView
+
+from db.comic import Comic, ComicContributorLink
+from utils.permission import CustomizePermission, JWTUtils
+from utils.response import CustomResponse
+from utils.utils import CommonUtils
+
+from .serializers import (
+    ComicListItemSerializer,
+    ComicDetailSerializer,
+    ComicWriteSerializer,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HELPERS
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _get_active_comics():
+    """Base queryset: exclude soft-deleted rows."""
+    return Comic.objects.filter(deleted_at__isnull=True)
+
+
+def can_edit_comic(user_id, comic):
+    """
+    True if the user is the comic's creator OR has been explicitly assigned
+    as an 'editor' contributor on that comic by the creator.
+    """
+    if comic.created_by_id == user_id:
+        return True
+    return ComicContributorLink.objects.filter(
+        comic=comic,
+        user_id=user_id,
+        contributor_type=ComicContributorLink.ContributorType.EDITOR,
+    ).exists()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMIC LIST + CREATE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicListCreateView(APIView):
+    """
+    GET  /muComics/comics/  → paginated list with search, status filter, sort
+    POST /muComics/comics/  → create a new comic (any authenticated user)
+    """
+    authentication_classes = [CustomizePermission]
+
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        queryset = _get_active_comics()
+
+        # Optional status filter: ?status=draft|published|archived
+        if status_filter := request.query_params.get('status'):
+            if status_filter not in Comic.Status.values:
+                return CustomResponse(
+                    general_message=f'Invalid status. Allowed: {", ".join(Comic.Status.values)}.'
+                ).get_failure_response()
+            queryset = queryset.filter(status=status_filter)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            queryset.select_related('created_by'),
+            request,
+            search_fields=['title'],
+            sort_fields={
+                'created_at': 'created_at',
+                'title':      'title',
+            },
+        )
+
+        serializer = ComicListItemSerializer(
+            paginated['queryset'], many=True,
+            context={'user_id': user_id},
+        )
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        serializer = ComicWriteSerializer(
+            data=request.data,
+            context={'user_id': user_id},
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        comic = serializer.save()
+
+        return CustomResponse(
+            general_message=f'Comic "{comic.title}" created successfully.',
+            response=ComicDetailSerializer(
+                comic, context={'user_id': user_id}
+            ).data,
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMIC DETAIL — GET / PATCH / DELETE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicDetailView(APIView):
+    """
+    GET    /muComics/comics/<comic_id>/   → full detail
+    PATCH  /muComics/comics/<comic_id>/   → partial update (creator or assigned editor)
+    DELETE /muComics/comics/<comic_id>/   → soft delete (creator only)
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_comic_or_error(self, comic_id):
+        """Fetch an active comic or return an error string."""
+        comic = _get_active_comics().filter(id=comic_id).first()
+        if not comic:
+            return None, 'Comic not found.'
+        return comic, None
+
+    def get(self, request, comic_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic, error = self._get_comic_or_error(comic_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response()
+
+        return CustomResponse(
+            general_message=f'Comic "{comic.title}" retrieved successfully.',
+            response=ComicDetailSerializer(
+                comic, context={'user_id': user_id}
+            ).data,
+        ).get_success_response()
+
+    def patch(self, request, comic_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic, error = self._get_comic_or_error(comic_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response()
+
+        # Permission: creator or assigned editor
+        if not can_edit_comic(user_id, comic):
+            return CustomResponse(
+                general_message='You do not have permission to edit this comic.'
+            ).get_failure_response()
+
+        # Archived comics cannot be edited
+        if comic.status == Comic.Status.ARCHIVED:
+            return CustomResponse(
+                general_message='Archived comics cannot be edited.'
+            ).get_failure_response()
+
+        serializer = ComicWriteSerializer(
+            comic, data=request.data,
+            partial=True,
+            context={'user_id': user_id},
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        comic = serializer.save()
+
+        return CustomResponse(
+            general_message=f'Comic "{comic.title}" updated successfully.',
+            response=ComicDetailSerializer(
+                comic, context={'user_id': user_id}
+            ).data,
+        ).get_success_response()
+
+    def delete(self, request, comic_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic, error = self._get_comic_or_error(comic_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response()
+
+        # Only the original creator can delete
+        if comic.created_by_id != user_id:
+            return CustomResponse(
+                general_message='Only the comic creator can delete this comic.'
+            ).get_failure_response()
+
+        now = timezone.now()
+        comic.deleted_at    = now
+        comic.deleted_by_id = user_id
+        comic.updated_by_id = user_id
+        comic.updated_at    = now
+        comic.save()
+
+        return CustomResponse(
+            general_message=f'Comic "{comic.title}" deleted successfully.',
+            response={'id': comic.id},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PUBLISH
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicPublishView(APIView):
+    """
+    POST /muComics/comics/<comic_id>/publish/
+    Transitions a draft comic to published (creator only).
+
+    Workflow:
+        draft     → published   ✅
+        archived  → ❌  (cannot re-publish archived)
+        published → ❌  (already published)
+    """
+    authentication_classes = [CustomizePermission]
+
+    REQUIRED_FIELDS = ['title', 'description']
+
+    def post(self, request, comic_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic   = _get_active_comics().filter(id=comic_id).first()
+
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        # Only creator can publish
+        if comic.created_by_id != user_id:
+            return CustomResponse(
+                general_message='Only the comic creator can publish this comic.'
+            ).get_failure_response()
+
+        if comic.status == Comic.Status.PUBLISHED:
+            return CustomResponse(
+                general_message='Comic is already published.'
+            ).get_failure_response()
+
+        if comic.status == Comic.Status.ARCHIVED:
+            return CustomResponse(
+                general_message='Archived comics cannot be published. Unarchive it first.'
+            ).get_failure_response()
+
+        # Validate required fields are filled before publishing
+        missing = [f for f in self.REQUIRED_FIELDS if not getattr(comic, f, None)]
+        if missing:
+            return CustomResponse(
+                general_message=f'Cannot publish: missing required fields: {", ".join(missing)}.'
+            ).get_failure_response()
+
+        now = timezone.now()
+        comic.status        = Comic.Status.PUBLISHED
+        comic.published_at  = now
+        comic.updated_by_id = user_id
+        comic.updated_at    = now
+        comic.save()
+
+        return CustomResponse(
+            general_message=f'Comic "{comic.title}" published successfully.',
+            response={'id': comic.id, 'status': Comic.Status.PUBLISHED},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ARCHIVE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicArchiveView(APIView):
+    """
+    POST /muComics/comics/<comic_id>/archive/
+    Transitions a draft or published comic to archived (creator only).
+
+    Workflow:
+        draft     → archived  ✅
+        published → archived  ✅
+        archived  → ❌  (already archived)
+    """
+    authentication_classes = [CustomizePermission]
+
+    def post(self, request, comic_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic   = _get_active_comics().filter(id=comic_id).first()
+
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        # Only creator can archive
+        if comic.created_by_id != user_id:
+            return CustomResponse(
+                general_message='Only the comic creator can archive this comic.'
+            ).get_failure_response()
+
+        if comic.status == Comic.Status.ARCHIVED:
+            return CustomResponse(
+                general_message='Comic is already archived.'
+            ).get_failure_response()
+
+        now = timezone.now()
+        comic.status        = Comic.Status.ARCHIVED
+        comic.updated_by_id = user_id
+        comic.updated_at    = now
+        comic.save()
+
+        return CustomResponse(
+            general_message=f'Comic "{comic.title}" archived successfully.',
+            response={'id': comic.id, 'status': Comic.Status.ARCHIVED},
+        ).get_success_response()

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -1,0 +1,169 @@
+"""
+Serializers for the Comic CRUD module.
+
+Shapes:
+  ComicListItemSerializer   – lean, used in paginated list responses
+  ComicDetailSerializer     – full, used in detail / create / update responses
+  ComicWriteSerializer      – input, used for POST and PATCH
+"""
+
+import uuid
+
+from django.utils.text import slugify
+from django.utils import timezone
+from rest_framework import serializers
+
+from db.comic import Comic, Genre, ComicContributorLink, ComicGenreLink
+from db.user import User
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MINIMAL NESTED SHAPES
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MinimalUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'full_name', 'muid']
+
+
+class MinimalGenreSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Genre
+        fields = ['id', 'name', 'slug']
+
+
+class ContributorSerializer(serializers.ModelSerializer):
+    user = MinimalUserSerializer(read_only=True)
+
+    class Meta:
+        model = ComicContributorLink
+        fields = ['id', 'user', 'contributor_type', 'created_at']
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMIC LIST (lean — for paginated feeds)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicListItemSerializer(serializers.ModelSerializer):
+    created_by = MinimalUserSerializer(read_only=True)
+
+    class Meta:
+        model = Comic
+        fields = [
+            'id', 'title', 'slug', 'cover_image_key',
+            'status', 'like_count', 'comment_count', 'bookmark_count',
+            'published_at', 'created_by', 'created_at',
+        ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMIC DETAIL (full — for detail / create / update responses)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicDetailSerializer(serializers.ModelSerializer):
+    created_by  = MinimalUserSerializer(read_only=True)
+    updated_by  = MinimalUserSerializer(read_only=True)
+    genres      = serializers.SerializerMethodField()
+    contributors = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Comic
+        fields = [
+            'id', 'title', 'slug', 'description', 'cover_image_key',
+            'status', 'like_count', 'comment_count', 'bookmark_count',
+            'published_at',
+            'genres', 'contributors',
+            'created_by', 'created_at',
+            'updated_by', 'updated_at',
+        ]
+
+    def get_genres(self, obj):
+        links = obj.genre_links.select_related('genre').all()
+        return MinimalGenreSerializer(
+            [link.genre for link in links], many=True
+        ).data
+
+    def get_contributors(self, obj):
+        links = obj.contributor_links.select_related('user').all()
+        return ContributorSerializer(links, many=True).data
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMIC WRITE  (create / update input)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicWriteSerializer(serializers.ModelSerializer):
+    """
+    Input serializer for POST /comics/ and PATCH /comics/<id>/.
+    The caller never sends: slug, status, *_count, published_at, or audit fields.
+    """
+
+    class Meta:
+        model = Comic
+        fields = ['title', 'description', 'cover_image_key']
+        extra_kwargs = {
+            'title': {
+                'required': True,
+                'max_length': 75,   # matches Comic.title max_length in db/comic.py
+            },
+            'description': {
+                'required': False,
+                'allow_null': True,
+                'allow_blank': True,
+            },
+            'cover_image_key': {
+                'required': False,
+                'allow_null': True,
+                'allow_blank': True,
+                'max_length': 255,  # matches Comic.cover_image_key max_length in db/comic.py
+            },
+        }
+
+    def validate_title(self, value):
+        if not value or not value.strip():
+            raise serializers.ValidationError('Title must not be blank.')
+        return value.strip()
+
+    def _generate_unique_slug(self, title):
+        """
+        Generates a URL-safe slug from title.
+        Appends an incrementing counter if the base slug already exists
+        (same pattern as EventWriteSerializer._generate_unique_slug).
+        Slug is truncated to 70 chars before suffix to stay within max_length=75.
+        """
+        base = slugify(title)[:70]
+        slug = base
+        counter = 1
+        while Comic.objects.filter(slug=slug).exists():
+            slug = f'{base}-{counter}'
+            counter += 1
+        return slug
+
+    def create(self, validated_data):
+        user_id = self.context['user_id']
+        now     = timezone.now()
+
+        validated_data['id']           = str(uuid.uuid4())
+        validated_data['slug']         = self._generate_unique_slug(validated_data['title'])
+        validated_data['created_by_id'] = user_id
+        validated_data['updated_by_id'] = user_id
+        validated_data['created_at']   = now
+        validated_data['updated_at']   = now
+        return Comic.objects.create(**validated_data)
+
+    def update(self, instance, validated_data):
+        user_id = self.context['user_id']
+        now     = timezone.now()
+
+        # Re-generate slug only when title changes
+        if 'title' in validated_data and validated_data['title'] != instance.title:
+            validated_data['slug'] = self._generate_unique_slug(validated_data['title'])
+
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+
+        instance.updated_by_id = user_id
+        instance.updated_at    = now
+        instance.save()
+        return instance

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -135,7 +135,7 @@ class ComicWriteSerializer(serializers.ModelSerializer):
         base = slugify(title)[:70]
         slug = base
         counter = 1
-        while Comic.objects.filter(slug=slug).exists():
+        while Comic.objects.filter(slug=slug).exclude(id=self.instance.id).exists():
             slug = f'{base}-{counter}'
             counter += 1
         return slug

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -135,7 +135,15 @@ class ComicWriteSerializer(serializers.ModelSerializer):
         base = slugify(title)[:70]
         slug = base
         counter = 1
-        while Comic.objects.filter(slug=slug).exclude(id=self.instance.id).exists():
+        # On update: exclude the current comic so its own slug is not treated as a collision.
+        # On create: self.instance is None, so no exclusion is applied.
+        exclude_id = self.instance.id if self.instance else None
+        while True:
+            qs = Comic.objects.filter(slug=slug)
+            if exclude_id:
+                qs = qs.exclude(id=exclude_id)
+            if not qs.exists():
+                break
             slug = f'{base}-{counter}'
             counter += 1
         return slug

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -105,7 +105,7 @@ class ComicWriteSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             'title': {
                 'required': True,
-                'max_length': 75,   # matches Comic.title max_length in db/comic.py
+                'max_length': 150,  # matches Comic.title max_length in db/comic.py
             },
             'description': {
                 'required': False,

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -173,5 +173,14 @@ class ComicWriteSerializer(serializers.ModelSerializer):
 
         instance.updated_by_id = user_id
         instance.updated_at    = now
-        instance.save()
+
+        # Only write columns this PATCH actually touched.
+        # 'status' and 'published_at' are intentionally absent — this prevents
+        # a concurrent publish/archive from being silently reverted.
+        changed_fields = list(validated_data.keys())
+        if 'title' in changed_fields:
+            changed_fields.append('slug')   # slug is derived from title
+        changed_fields += ['updated_by', 'updated_at']
+
+        instance.save(update_fields=changed_fields)
         return instance

--- a/api/muComics/comic/urls.py
+++ b/api/muComics/comic/urls.py
@@ -1,0 +1,15 @@
+from django.urls import path
+
+from . import comic_views
+
+urlpatterns = [
+    # List + Create
+    path('',                         comic_views.ComicListCreateView.as_view(),  name='comic-list-create'),
+
+    # Detail + Update + Delete
+    path('<str:comic_id>/',          comic_views.ComicDetailView.as_view(),      name='comic-detail'),
+
+    # Status workflow
+    path('<str:comic_id>/publish/',  comic_views.ComicPublishView.as_view(),     name='comic-publish'),
+    path('<str:comic_id>/archive/',  comic_views.ComicArchiveView.as_view(),     name='comic-archive'),
+]

--- a/api/muComics/urls.py
+++ b/api/muComics/urls.py
@@ -1,0 +1,5 @@
+from django.urls import path, include
+
+urlpatterns = [
+    path('comics/', include('api.muComics.comic.urls')),
+]

--- a/api/urls.py
+++ b/api/urls.py
@@ -17,5 +17,6 @@ urlpatterns = [
     path('launchpad/', include('api.launchpad.urls')),
     path('donate/', include('api.donate.urls')),
     path('calendar/', include('api.calendar.urls')),
+    path('muComics/', include('api.muComics.urls')),
     path("__debug__/", include(debug_toolbar.urls)),
 ]

--- a/db/comic.py
+++ b/db/comic.py
@@ -1,0 +1,149 @@
+import uuid
+
+from django.db import models
+from django.conf import settings
+
+from .user import User
+
+
+class Comic(models.Model):
+
+    class Status(models.TextChoices):
+        DRAFT     = 'draft',     'Draft'
+        PUBLISHED = 'published', 'Published'
+        ARCHIVED  = 'archived',  'Archived'
+
+    id              = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    title           = models.CharField(max_length=150)
+    slug            = models.CharField(max_length=180, unique=True)
+    description     = models.TextField(blank=True, null=True)
+    cover_image_key = models.CharField(max_length=255, blank=True, null=True)  # S3 object key
+
+    status          = models.CharField(
+        max_length=10, choices=Status.choices, default=Status.DRAFT
+    )
+
+    like_count      = models.PositiveIntegerField(default=0)
+    comment_count   = models.PositiveIntegerField(default=0)
+    bookmark_count  = models.PositiveIntegerField(default=0)
+
+    published_at    = models.DateTimeField(blank=True, null=True)
+
+    # Soft delete
+    deleted_at      = models.DateTimeField(blank=True, null=True)
+    deleted_by      = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        db_column='deleted_by', related_name='comic_deleted_by'
+    )
+
+    # Audit
+    updated_by      = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='updated_by', related_name='comic_updated_by'
+    )
+    updated_at      = models.DateTimeField()
+
+    created_by      = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='created_by', related_name='comic_created_by'
+    )
+    created_at      = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'comic'
+        indexes = [
+            models.Index(fields=['status', 'created_at'], name='idx_comic_status_created'),
+            models.Index(fields=['created_by'],            name='idx_comic_created_by'),
+        ]
+
+
+class Genre(models.Model):
+
+    id         = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    name       = models.CharField(max_length=75, unique=True)
+    slug       = models.CharField(max_length=90, unique=True)
+
+    # Audit
+    updated_by = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='updated_by', related_name='genre_updated_by'
+    )
+    updated_at = models.DateTimeField()
+
+    created_by = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='created_by', related_name='genre_created_by'
+    )
+    created_at = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'genre'
+
+
+class ComicGenreLink(models.Model):
+
+    id         = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    comic      = models.ForeignKey(
+        Comic, on_delete=models.CASCADE,
+        db_column='comic_id', related_name='genre_links'
+    )
+    genre      = models.ForeignKey(
+        Genre, on_delete=models.CASCADE,
+        db_column='genre_id', related_name='comic_links'
+    )
+
+    # Audit
+    created_by = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='created_by', related_name='comic_genre_link_created_by'
+    )
+    created_at = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'comic_genre_link'
+        unique_together = [('comic', 'genre')]
+        indexes = [
+            models.Index(fields=['genre'], name='idx_comic_genre_genre'),
+        ]
+
+
+class ComicContributorLink(models.Model):
+
+    class ContributorType(models.TextChoices):
+        CREATOR  = 'creator',  'Creator'
+        WRITER   = 'writer',   'Writer'
+        ARTIST   = 'artist',   'Artist'
+        COLORIST = 'colorist', 'Colorist'
+        EDITOR   = 'editor',   'Editor'
+
+    id               = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    comic            = models.ForeignKey(
+        Comic, on_delete=models.CASCADE,
+        db_column='comic_id', related_name='contributor_links'
+    )
+    user             = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='user_id', related_name='comic_contributor_links'
+    )
+    contributor_type = models.CharField(
+        max_length=10, choices=ContributorType.choices
+    )
+
+    # Audit
+    created_by       = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='created_by', related_name='comic_contributor_link_created_by'
+    )
+    created_at       = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'comic_contributor_link'
+        unique_together = [('comic', 'user', 'contributor_type')]
+        indexes = [
+            models.Index(fields=['user'],                      name='idx_contributor_user'),
+            models.Index(fields=['comic', 'contributor_type'], name='idx_contributor_comic_type'),
+        ]

--- a/db/comic.py
+++ b/db/comic.py
@@ -5,7 +5,6 @@ from django.conf import settings
 
 from .user import User
 
-
 class Comic(models.Model):
 
     class Status(models.TextChoices):
@@ -15,7 +14,7 @@ class Comic(models.Model):
 
     id              = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
     title           = models.CharField(max_length=150)
-    slug            = models.CharField(max_length=180, unique=True)
+    slug            = models.CharField(max_length=75, unique=True)
     description     = models.TextField(blank=True, null=True)
     cover_image_key = models.CharField(max_length=255, blank=True, null=True)  # S3 object key
 
@@ -38,13 +37,13 @@ class Comic(models.Model):
 
     # Audit
     updated_by      = models.ForeignKey(
-        User, on_delete=models.CASCADE,
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
         db_column='updated_by', related_name='comic_updated_by'
     )
     updated_at      = models.DateTimeField()
 
     created_by      = models.ForeignKey(
-        User, on_delete=models.CASCADE,
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
         db_column='created_by', related_name='comic_created_by'
     )
     created_at      = models.DateTimeField()
@@ -62,17 +61,17 @@ class Genre(models.Model):
 
     id         = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
     name       = models.CharField(max_length=75, unique=True)
-    slug       = models.CharField(max_length=90, unique=True)
+    slug       = models.CharField(max_length=75, unique=True)
 
     # Audit
     updated_by = models.ForeignKey(
-        User, on_delete=models.CASCADE,
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
         db_column='updated_by', related_name='genre_updated_by'
     )
     updated_at = models.DateTimeField()
 
     created_by = models.ForeignKey(
-        User, on_delete=models.CASCADE,
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
         db_column='created_by', related_name='genre_created_by'
     )
     created_at = models.DateTimeField()
@@ -96,7 +95,7 @@ class ComicGenreLink(models.Model):
 
     # Audit
     created_by = models.ForeignKey(
-        User, on_delete=models.CASCADE,
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
         db_column='created_by', related_name='comic_genre_link_created_by'
     )
     created_at = models.DateTimeField()
@@ -134,7 +133,7 @@ class ComicContributorLink(models.Model):
 
     # Audit
     created_by       = models.ForeignKey(
-        User, on_delete=models.CASCADE,
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
         db_column='created_by', related_name='comic_contributor_link_created_by'
     )
     created_at       = models.DateTimeField()


### PR DESCRIPTION
This pull request introduces a complete CRUD API for comics in the `muComics` app, including models, serializers, views, and URL routing. It implements endpoints for listing, creating, updating, deleting, publishing, and archiving comics, as well as supporting contributors and genres. The changes establish the core data structures and RESTful API for comics, with appropriate permissions and soft-deletion logic.

**Key changes:**

### Comic Models and Database Layer

* Added `Comic`, `Genre`, `ComicGenreLink`, and `ComicContributorLink` models in `db/comic.py` to represent comics, their genres, and contributors, including status, audit fields, and soft delete support.

### API Endpoints and Views

* Implemented RESTful views in `comic_views.py` for comic listing (with pagination, search, filter, sort), detail, creation, partial update, soft delete, publishing, and archiving, with permission checks for creators and editors.
* Added Django URL routes in `api/muComics/comic/urls.py` to wire up the comic endpoints, and included these in the main app's URL config. [[1]](diffhunk://#diff-3106110c6bcaa0aeb5f391fb34ecd465264e12ff9e5ffc280f8dc9392a8e15c5R1-R15) [[2]](diffhunk://#diff-05aef529bec658d0b80cd3bb6ab3a204bedf3bbbf1ddff95b9810730e2976d06R1-R5)

### Serialization and Validation

* Added serializers in `serializers.py` for comic list items, detail responses, and input (create/update), including nested user and genre representations, and unique slug generation logic.

### Module Structure

* Added a module docstring to `api/muComics/comic/__init__.py` for clarity.

These changes collectively provide a robust foundation for managing comics, including contributor roles, status workflows, and audit trails.