### PR TITLE
feat(muComics): Implement Community Interaction features for MuComics

### DIFF
--- a/alter-scripts/alter-1.62.py
+++ b/alter-scripts/alter-1.62.py
@@ -51,7 +51,9 @@ def create_comic_comment_table():
               CONSTRAINT `fk_comic_comment_ref_comic_id` FOREIGN KEY (`comic_id`) REFERENCES `comic` (`id`) ON DELETE CASCADE,
               CONSTRAINT `fk_comic_comment_ref_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `comic_comment` (`id`) ON DELETE CASCADE,
               CONSTRAINT `fk_comic_comment_ref_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
-              CONSTRAINT `fk_comic_comment_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL
+              CONSTRAINT `fk_comic_comment_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL,
+              CONSTRAINT `fk_comic_comment_ref_upd_by` FOREIGN KEY (`updated_by`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+              CONSTRAINT `fk_comic_comment_ref_cre_by` FOREIGN KEY (`created_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
             """
         )

--- a/alter-scripts/alter-1.62.py
+++ b/alter-scripts/alter-1.62.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from pathlib import Path
+from decouple import config
+import django
+
+from connection import execute
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+os.chdir(BASE_DIR)
+sys.path.append(str(BASE_DIR))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mulearnbackend.settings')
+django.setup()
+
+DB_NAME = config('DATABASE_NAME')
+
+
+def table_exists(table_name: str) -> bool:
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.TABLES
+        WHERE TABLE_SCHEMA = '{DB_NAME}'
+          AND TABLE_NAME = '{table_name}';
+    """
+    result = execute(query)
+    return result and result[0][0] > 0
+
+
+def create_comic_comment_table():
+    if not table_exists('comic_comment'):
+        execute(
+            """
+            CREATE TABLE `comic_comment` (
+              `id` varchar(36) NOT NULL,
+              `comic_id` varchar(36) NOT NULL,
+              `chapter_id` varchar(36) DEFAULT NULL,
+              `parent_id` varchar(36) DEFAULT NULL,
+              `user_id` varchar(36) NOT NULL,
+              `message` text NOT NULL,
+              `deleted_at` datetime DEFAULT NULL,
+              `deleted_by` varchar(36) DEFAULT NULL,
+              `updated_by` varchar(36) NOT NULL,
+              `updated_at` datetime NOT NULL,
+              `created_by` varchar(36) NOT NULL,
+              `created_at` datetime NOT NULL,
+              PRIMARY KEY (`id`),
+              KEY `idx_comic_comment_comic` (`comic_id`,`created_at`),
+              KEY `idx_comic_comment_chapter` (`chapter_id`,`created_at`),
+              KEY `idx_comic_comment_parent` (`parent_id`),
+              KEY `idx_comic_comment_user` (`user_id`),
+              CONSTRAINT `fk_comic_comment_ref_comic_id` FOREIGN KEY (`comic_id`) REFERENCES `comic` (`id`) ON DELETE CASCADE,
+              CONSTRAINT `fk_comic_comment_ref_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `comic_comment` (`id`) ON DELETE CASCADE,
+              CONSTRAINT `fk_comic_comment_ref_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+              CONSTRAINT `fk_comic_comment_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+            """
+        )
+        print("[alter-1.62] Created table 'comic_comment'.")
+    else:
+        print("[alter-1.62] Table 'comic_comment' already exists.")
+
+
+if __name__ == '__main__':
+    create_comic_comment_table()
+    execute("UPDATE system_setting SET value = '1.62', updated_at = now() WHERE `key` = 'db.version';")
+    print("[alter-1.62] Updated database version to 1.62.")

--- a/api/muComics/comment/__init__.py
+++ b/api/muComics/comment/__init__.py
@@ -1,0 +1,1 @@
+# MuComics Comment module

--- a/api/muComics/comment/admin_views.py
+++ b/api/muComics/comment/admin_views.py
@@ -3,6 +3,7 @@ MuComics Admin/Moderation views (Endpoints 7-8).
 Requires Comic Admin role.
 """
 from django.utils import timezone
+from django.db import transaction
 from rest_framework.views import APIView
 from drf_spectacular.utils import extend_schema
 
@@ -106,12 +107,13 @@ class AdminCommentDeleteAPI(APIView):
             ).get_failure_response()
 
         now = timezone.now()
-        comment.deleted_at = now
-        comment.deleted_by_id = user_id
-        comment.updated_at = now
-        comment.save()
+        with transaction.atomic():
+            comment.deleted_at = now
+            comment.deleted_by_id = user_id
+            comment.updated_at = now
+            comment.save()
 
-        _decrement_comment_count(comment.comic_id)
+            _decrement_comment_count(comment.comic_id)
 
         return CustomResponse(
             general_message="Comment removed by moderator"

--- a/api/muComics/comment/admin_views.py
+++ b/api/muComics/comment/admin_views.py
@@ -111,6 +111,7 @@ class AdminCommentDeleteAPI(APIView):
             comment.deleted_at = now
             comment.deleted_by_id = user_id
             comment.updated_at = now
+            comment.updated_by_id = user_id
             comment.save()
 
             _decrement_comment_count(comment.comic_id)

--- a/api/muComics/comment/admin_views.py
+++ b/api/muComics/comment/admin_views.py
@@ -24,7 +24,7 @@ class AdminCommentListAPI(APIView):
     def get(self, request):
         queryset = ComicComment.objects.select_related(
             'user', 'comic', 'deleted_by'
-        ).order_by('-created_at')
+        ).prefetch_related('replies').order_by('-created_at')
 
         # Filter by comic_id
         comic_id = request.query_params.get('comic_id')
@@ -57,8 +57,21 @@ class AdminCommentListAPI(APIView):
             sort_fields={'created_at': 'created_at'},
         )
 
+        # Bulk fetch chapter titles for the paginated page
+        chapter_ids = [c.chapter_id for c in paginated['queryset'] if c.chapter_id]
+        chapter_titles = {}
+        if chapter_ids:
+            unique_chapter_ids = list(set(chapter_ids))
+            from django.db import connection
+            with connection.cursor() as cursor:
+                format_strings = ','.join(['%s'] * len(unique_chapter_ids))
+                cursor.execute(f"SELECT id, title FROM chapter WHERE id IN ({format_strings})", unique_chapter_ids)
+                for row in cursor.fetchall():
+                    chapter_titles[row[0]] = row[1]
+
         serializer = AdminCommentListSerializer(
             paginated['queryset'], many=True,
+            context={'chapter_titles': chapter_titles}
         )
 
         return CustomResponse().paginated_response(

--- a/api/muComics/comment/admin_views.py
+++ b/api/muComics/comment/admin_views.py
@@ -1,0 +1,102 @@
+"""
+MuComics Admin/Moderation views (Endpoints 7-8).
+Requires Comic Admin role.
+"""
+from django.utils import timezone
+from rest_framework.views import APIView
+
+from db.comic_comment import ComicComment
+from utils.permission import CustomizePermission, JWTUtils, role_required
+from utils.response import CustomResponse
+from utils.utils import CommonUtils
+
+from .comment_serializers import AdminCommentListSerializer
+from .comment_views import _decrement_comment_count
+
+
+class AdminCommentListAPI(APIView):
+    """
+    GET /admin/comments/ — list all comments for moderation (flat list)
+    """
+    permission_classes = [CustomizePermission]
+
+    @role_required(["Comic Admin"])
+    def get(self, request):
+        queryset = ComicComment.objects.select_related(
+            'user', 'comic', 'deleted_by'
+        ).order_by('-created_at')
+
+        # Filter by comic_id
+        comic_id = request.query_params.get('comic_id')
+        if comic_id:
+            queryset = queryset.filter(comic_id=comic_id)
+
+        # Filter by chapter_id
+        chapter_id = request.query_params.get('chapter_id')
+        if chapter_id:
+            queryset = queryset.filter(chapter_id=chapter_id)
+
+        # Filter by user_id
+        user_id_filter = request.query_params.get('user_id')
+        if user_id_filter:
+            queryset = queryset.filter(user_id=user_id_filter)
+
+        # Deleted filters
+        include_deleted = request.query_params.get('include_deleted', 'false').lower() == 'true'
+        deleted_only = request.query_params.get('deleted_only', 'false').lower() == 'true'
+
+        if deleted_only:
+            queryset = queryset.filter(deleted_at__isnull=False)
+        elif not include_deleted:
+            queryset = queryset.filter(deleted_at__isnull=True)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            queryset,
+            request,
+            search_fields=['message'],
+            sort_fields={'created_at': 'created_at'},
+        )
+
+        serializer = AdminCommentListSerializer(
+            paginated['queryset'], many=True,
+        )
+
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+
+class AdminCommentDeleteAPI(APIView):
+    """
+    DELETE /admin/comments/<comment_id>/ — soft-delete any comment (moderator)
+    """
+    permission_classes = [CustomizePermission]
+
+    @role_required(["Comic Admin"])
+    def delete(self, request, comment_id):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        try:
+            comment = ComicComment.objects.get(id=comment_id)
+        except ComicComment.DoesNotExist:
+            return CustomResponse(
+                general_message="Comment not found"
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        if comment.is_deleted:
+            return CustomResponse(
+                general_message="Comment has already been deleted"
+            ).get_failure_response()
+
+        now = timezone.now()
+        comment.deleted_at = now
+        comment.deleted_by_id = user_id
+        comment.updated_at = now
+        comment.save()
+
+        _decrement_comment_count(comment.comic_id)
+
+        return CustomResponse(
+            general_message="Comment removed by moderator"
+        ).get_success_response()

--- a/api/muComics/comment/admin_views.py
+++ b/api/muComics/comment/admin_views.py
@@ -4,6 +4,7 @@ Requires Comic Admin role.
 """
 from django.utils import timezone
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema
 
 from db.comic_comment import ComicComment
 from utils.permission import CustomizePermission, JWTUtils, role_required
@@ -20,6 +21,7 @@ class AdminCommentListAPI(APIView):
     """
     permission_classes = [CustomizePermission]
 
+    @extend_schema(tags=['muComics'])
     @role_required(["Comic Admin"])
     def get(self, request):
         queryset = ComicComment.objects.select_related(
@@ -86,6 +88,7 @@ class AdminCommentDeleteAPI(APIView):
     """
     permission_classes = [CustomizePermission]
 
+    @extend_schema(tags=['muComics'])
     @role_required(["Comic Admin"])
     def delete(self, request, comment_id):
         user_id = JWTUtils.fetch_user_id(request)

--- a/api/muComics/comment/comment_serializers.py
+++ b/api/muComics/comment/comment_serializers.py
@@ -1,0 +1,165 @@
+from rest_framework import serializers
+
+from db.user import User
+
+
+class CommentUserSerializer(serializers.ModelSerializer):
+    """Lightweight user info embedded in comment responses."""
+    profile_pic = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ['id', 'full_name', 'muid', 'profile_pic']
+
+    def get_profile_pic(self, obj):
+        return obj.profile_pic
+
+
+class CommentReplySerializer(serializers.Serializer):
+    """Single reply (no further nesting)."""
+    id = serializers.CharField()
+    parent_id = serializers.CharField()
+    user = serializers.SerializerMethodField()
+    message = serializers.SerializerMethodField()
+    is_edited = serializers.BooleanField()
+    is_deleted = serializers.SerializerMethodField()
+    is_owner = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField()
+    updated_at = serializers.DateTimeField()
+
+    def get_user(self, obj):
+        return CommentUserSerializer(obj.user).data
+
+    def get_message(self, obj):
+        if obj.is_deleted:
+            return "[deleted]"
+        return obj.message
+
+    def get_is_deleted(self, obj):
+        return obj.is_deleted
+
+    def get_is_owner(self, obj):
+        request_user_id = self.context.get('user_id')
+        if not request_user_id:
+            return False
+        return obj.user_id == request_user_id
+
+
+class CommentListSerializer(serializers.Serializer):
+    """Top-level comment with nested replies."""
+    id = serializers.CharField()
+    comic_id = serializers.CharField()
+    chapter_id = serializers.CharField(allow_null=True)
+    parent_id = serializers.CharField(allow_null=True)
+    user = serializers.SerializerMethodField()
+    message = serializers.SerializerMethodField()
+    is_edited = serializers.BooleanField()
+    is_deleted = serializers.SerializerMethodField()
+    is_owner = serializers.SerializerMethodField()
+    reply_count = serializers.SerializerMethodField()
+    replies = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField()
+    updated_at = serializers.DateTimeField()
+
+    def get_user(self, obj):
+        return CommentUserSerializer(obj.user).data
+
+    def get_message(self, obj):
+        if obj.is_deleted:
+            return "[deleted]"
+        return obj.message
+
+    def get_is_deleted(self, obj):
+        return obj.is_deleted
+
+    def get_is_owner(self, obj):
+        request_user_id = self.context.get('user_id')
+        if not request_user_id:
+            return False
+        return obj.user_id == request_user_id
+
+    def get_reply_count(self, obj):
+        return obj.replies.filter(deleted_at__isnull=True).count()
+
+    def get_replies(self, obj):
+        active_replies = obj.replies.filter(
+            deleted_at__isnull=True
+        ).select_related('user').order_by('created_at')
+        return CommentReplySerializer(
+            active_replies, many=True, context=self.context
+        ).data
+
+
+class CommentCreateSerializer(serializers.Serializer):
+    """Validates POST body for comment creation."""
+    message = serializers.CharField(min_length=1, max_length=2000)
+    parent_id = serializers.CharField(required=False, allow_null=True, default=None)
+
+    def validate_message(self, value):
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError("Message cannot be empty or whitespace only.")
+        return value
+
+
+class CommentUpdateSerializer(serializers.Serializer):
+    """Validates PATCH body for comment editing."""
+    message = serializers.CharField(min_length=1, max_length=2000)
+
+    def validate_message(self, value):
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError("Message cannot be empty or whitespace only.")
+        return value
+
+
+class AdminCommentListSerializer(serializers.Serializer):
+    """Admin view — flat list with extra metadata."""
+    id = serializers.CharField()
+    comic_id = serializers.CharField()
+    comic_title = serializers.SerializerMethodField()
+    chapter_id = serializers.CharField(allow_null=True)
+    chapter_title = serializers.SerializerMethodField()
+    parent_id = serializers.CharField(allow_null=True)
+    user = serializers.SerializerMethodField()
+    message = serializers.CharField()
+    is_edited = serializers.BooleanField()
+    is_deleted = serializers.SerializerMethodField()
+    deleted_at = serializers.DateTimeField(allow_null=True)
+    deleted_by_user = serializers.SerializerMethodField()
+    reply_count = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField()
+    updated_at = serializers.DateTimeField()
+
+    def get_comic_title(self, obj):
+        return obj.comic.title if obj.comic else None
+
+    def get_chapter_title(self, obj):
+        if not obj.chapter_id:
+            return None
+        from django.db import connection
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT title FROM chapter WHERE id = %s", [obj.chapter_id])
+                row = cursor.fetchone()
+                return row[0] if row else None
+        except Exception:
+            return None
+
+    def get_user(self, obj):
+        return CommentUserSerializer(obj.user).data
+
+    def get_is_deleted(self, obj):
+        return obj.is_deleted
+
+    def get_deleted_by_user(self, obj):
+        if not obj.deleted_by:
+            return None
+        return {
+            "id": obj.deleted_by.id,
+            "full_name": obj.deleted_by.full_name,
+            "muid": obj.deleted_by.muid,
+        }
+
+    def get_reply_count(self, obj):
+        return obj.replies.count()

--- a/api/muComics/comment/comment_serializers.py
+++ b/api/muComics/comment/comment_serializers.py
@@ -161,4 +161,4 @@ class AdminCommentListSerializer(serializers.Serializer):
         }
 
     def get_reply_count(self, obj):
-        return len(obj.replies.all())
+        return len([r for r in obj.replies.all() if not r.is_deleted])

--- a/api/muComics/comment/comment_serializers.py
+++ b/api/muComics/comment/comment_serializers.py
@@ -79,12 +79,18 @@ class CommentListSerializer(serializers.Serializer):
         return obj.user_id == request_user_id
 
     def get_reply_count(self, obj):
+        if hasattr(obj, 'active_replies'):
+            return len(obj.active_replies)
         return obj.replies.filter(deleted_at__isnull=True).count()
 
     def get_replies(self, obj):
-        active_replies = obj.replies.filter(
-            deleted_at__isnull=True
-        ).select_related('user').order_by('created_at')
+        if hasattr(obj, 'active_replies'):
+            active_replies = obj.active_replies
+        else:
+            active_replies = obj.replies.filter(
+                deleted_at__isnull=True
+            ).select_related('user').order_by('created_at')
+            
         return CommentReplySerializer(
             active_replies, many=True, context=self.context
         ).data

--- a/api/muComics/comment/comment_serializers.py
+++ b/api/muComics/comment/comment_serializers.py
@@ -143,14 +143,7 @@ class AdminCommentListSerializer(serializers.Serializer):
     def get_chapter_title(self, obj):
         if not obj.chapter_id:
             return None
-        from django.db import connection
-        try:
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT title FROM chapter WHERE id = %s", [obj.chapter_id])
-                row = cursor.fetchone()
-                return row[0] if row else None
-        except Exception:
-            return None
+        return self.context.get('chapter_titles', {}).get(obj.chapter_id)
 
     def get_user(self, obj):
         return CommentUserSerializer(obj.user).data
@@ -168,4 +161,4 @@ class AdminCommentListSerializer(serializers.Serializer):
         }
 
     def get_reply_count(self, obj):
-        return obj.replies.count()
+        return len(obj.replies.all())

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -193,7 +193,7 @@ class ComicCommentCreateAPI(APIView):
             _increment_comment_count(comic_id)
 
         from db.user import User
-        user = User.objects.get(id=user_id)
+        user = User.every.get(id=user_id)
 
         return CustomResponse(
             general_message="Comment created successfully",
@@ -334,7 +334,7 @@ class ChapterCommentCreateAPI(APIView):
             _increment_comment_count(comic_id)
 
         from db.user import User
-        user = User.objects.get(id=user_id)
+        user = User.every.get(id=user_id)
 
         return CustomResponse(
             general_message="Comment created successfully",

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -68,10 +68,9 @@ def _decrement_comment_count(comic_id):
 from django.db import models
 
 
-class ComicCommentListCreateAPI(APIView):
+class ComicCommentListAPI(APIView):
     """
-    GET  /comments/comic/<comic_id>/  — list top-level comments with replies
-    POST /comments/comic/<comic_id>/  — create a comment (top-level or reply)
+    GET  /comments/comic/<comic_id>/list/  — list top-level comments with replies
     """
 
     def get(self, request, comic_id):
@@ -121,14 +120,14 @@ class ComicCommentListCreateAPI(APIView):
             pagination=paginated['pagination'],
         )
 
-    def post(self, request, comic_id):
-        try:
-            JWTUtils.is_jwt_authenticated(request)
-        except Exception:
-            return CustomResponse(
-                general_message="Invalid token header"
-            ).get_failure_response(status_code=1000, http_status_code=401)
 
+class ComicCommentCreateAPI(APIView):
+    """
+    POST /comments/comic/<comic_id>/create/  — create a comment (top-level or reply)
+    """
+    permission_classes = [CustomizePermission]
+
+    def post(self, request, comic_id):
         user_id = JWTUtils.fetch_user_id(request)
 
         comic = Comic.objects.filter(id=comic_id, deleted_at__isnull=True).first()

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -428,6 +428,7 @@ class CommentDetailAPI(APIView):
             comment.deleted_at = now
             comment.deleted_by_id = user_id
             comment.updated_at = now
+            comment.updated_by_id = user_id
             comment.save()
 
             _decrement_comment_count(comment.comic_id)

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -12,7 +12,7 @@ Endpoints:
 import uuid
 
 from django.db import connection
-from django.db.models import Q, Exists, OuterRef
+from django.db.models import Q, Exists, OuterRef, Prefetch
 from django.utils import timezone
 from rest_framework.views import APIView
 
@@ -88,6 +88,15 @@ class ComicCommentListAPI(APIView):
             deleted_at__isnull=True
         )
 
+        # Prefetch replies for the serializer
+        prefetch_replies = Prefetch(
+            'replies',
+            queryset=ComicComment.objects.filter(
+                deleted_at__isnull=True
+            ).select_related('user').order_by('created_at'),
+            to_attr='active_replies'
+        )
+
         queryset = ComicComment.objects.filter(
             comic_id=comic_id,
             parent__isnull=True,
@@ -95,7 +104,7 @@ class ComicCommentListAPI(APIView):
             has_active_replies=Exists(active_replies)
         ).filter(
             Q(deleted_at__isnull=True) | Q(has_active_replies=True)
-        ).select_related('user').order_by('-created_at')
+        ).select_related('user').prefetch_related(prefetch_replies).order_by('-created_at')
 
         paginated = CommonUtils.get_paginated_queryset(
             queryset,
@@ -219,6 +228,15 @@ class ChapterCommentListCreateAPI(APIView):
             deleted_at__isnull=True
         )
 
+        # Prefetch replies for the serializer
+        prefetch_replies = Prefetch(
+            'replies',
+            queryset=ComicComment.objects.filter(
+                deleted_at__isnull=True
+            ).select_related('user').order_by('created_at'),
+            to_attr='active_replies'
+        )
+
         queryset = ComicComment.objects.filter(
             chapter_id=chapter_id,
             parent__isnull=True,
@@ -226,7 +244,7 @@ class ChapterCommentListCreateAPI(APIView):
             has_active_replies=Exists(active_replies)
         ).filter(
             Q(deleted_at__isnull=True) | Q(has_active_replies=True)
-        ).select_related('user').order_by('-created_at')
+        ).select_related('user').prefetch_related(prefetch_replies).order_by('-created_at')
 
         paginated = CommonUtils.get_paginated_queryset(
             queryset,

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -11,7 +11,7 @@ Endpoints:
 """
 import uuid
 
-from django.db import connection
+from django.db import connection, transaction
 from django.db.models import Q, Exists, OuterRef, Prefetch
 from django.utils import timezone
 from rest_framework.views import APIView
@@ -176,20 +176,21 @@ class ComicCommentCreateAPI(APIView):
                 ).get_failure_response()
 
         now = timezone.now()
-        comment = ComicComment.objects.create(
-            id=str(uuid.uuid4()),
-            comic_id=comic_id,
-            chapter_id=None,
-            parent_id=parent_id,
-            user_id=user_id,
-            message=message,
-            updated_by_id=user_id,
-            updated_at=now,
-            created_by_id=user_id,
-            created_at=now,
-        )
+        with transaction.atomic():
+            comment = ComicComment.objects.create(
+                id=str(uuid.uuid4()),
+                comic_id=comic_id,
+                chapter_id=None,
+                parent_id=parent_id,
+                user_id=user_id,
+                message=message,
+                updated_by_id=user_id,
+                updated_at=now,
+                created_by_id=user_id,
+                created_at=now,
+            )
 
-        _increment_comment_count(comic_id)
+            _increment_comment_count(comic_id)
 
         from db.user import User
         user = User.objects.get(id=user_id)
@@ -316,20 +317,21 @@ class ChapterCommentCreateAPI(APIView):
                 ).get_failure_response()
 
         now = timezone.now()
-        comment = ComicComment.objects.create(
-            id=str(uuid.uuid4()),
-            comic_id=comic_id,
-            chapter_id=chapter_id,
-            parent_id=parent_id,
-            user_id=user_id,
-            message=message,
-            updated_by_id=user_id,
-            updated_at=now,
-            created_by_id=user_id,
-            created_at=now,
-        )
+        with transaction.atomic():
+            comment = ComicComment.objects.create(
+                id=str(uuid.uuid4()),
+                comic_id=comic_id,
+                chapter_id=chapter_id,
+                parent_id=parent_id,
+                user_id=user_id,
+                message=message,
+                updated_by_id=user_id,
+                updated_at=now,
+                created_by_id=user_id,
+                created_at=now,
+            )
 
-        _increment_comment_count(comic_id)
+            _increment_comment_count(comic_id)
 
         from db.user import User
         user = User.objects.get(id=user_id)
@@ -422,12 +424,13 @@ class CommentDetailAPI(APIView):
             ).get_failure_response(status_code=403, http_status_code=403)
 
         now = timezone.now()
-        comment.deleted_at = now
-        comment.deleted_by_id = user_id
-        comment.updated_at = now
-        comment.save()
+        with transaction.atomic():
+            comment.deleted_at = now
+            comment.deleted_by_id = user_id
+            comment.updated_at = now
+            comment.save()
 
-        _decrement_comment_count(comment.comic_id)
+            _decrement_comment_count(comment.comic_id)
 
         return CustomResponse(
             general_message="Comment deleted successfully"

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -175,6 +175,11 @@ class ComicCommentCreateAPI(APIView):
                     message={"parent_id": ["Cannot reply to a deleted comment"]}
                 ).get_failure_response()
 
+            if parent.chapter_id is not None:
+                return CustomResponse(
+                    message={"parent_id": ["Replies to chapter comments must use the chapter endpoint"]}
+                ).get_failure_response()
+
         now = timezone.now()
         with transaction.atomic():
             comment = ComicComment.objects.create(

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -15,6 +15,7 @@ from django.db import connection
 from django.db.models import Q, Exists, OuterRef, Prefetch
 from django.utils import timezone
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema
 
 from db.comic import Comic
 from db.comic_comment import ComicComment
@@ -73,6 +74,7 @@ class ComicCommentListAPI(APIView):
     GET  /comments/comic/<comic_id>/list/  — list top-level comments with replies
     """
 
+    @extend_schema(tags=['muComics'])
     def get(self, request, comic_id):
         comic = Comic.objects.filter(id=comic_id, deleted_at__isnull=True).first()
         if not comic:
@@ -130,6 +132,7 @@ class ComicCommentCreateAPI(APIView):
     """
     permission_classes = [CustomizePermission]
 
+    @extend_schema(tags=['muComics'])
     def post(self, request, comic_id):
         user_id = JWTUtils.fetch_user_id(request)
 
@@ -207,12 +210,12 @@ class ComicCommentCreateAPI(APIView):
         ).get_success_response()
 
 
-class ChapterCommentListCreateAPI(APIView):
+class ChapterCommentListAPI(APIView):
     """
-    GET  /comments/chapter/<chapter_id>/  — list chapter comments
-    POST /comments/chapter/<chapter_id>/  — create chapter comment
+    GET  /comments/chapter/<chapter_id>/list/  — list chapter comments
     """
 
+    @extend_schema(tags=['muComics'])
     def get(self, request, chapter_id):
         comic_id = _chapter_exists(chapter_id)
         if not comic_id:
@@ -263,14 +266,15 @@ class ChapterCommentListCreateAPI(APIView):
             pagination=paginated['pagination'],
         )
 
-    def post(self, request, chapter_id):
-        try:
-            JWTUtils.is_jwt_authenticated(request)
-        except Exception:
-            return CustomResponse(
-                general_message="Invalid token header"
-            ).get_failure_response(status_code=1000, http_status_code=401)
 
+class ChapterCommentCreateAPI(APIView):
+    """
+    POST /comments/chapter/<chapter_id>/create/  — create chapter comment
+    """
+    permission_classes = [CustomizePermission]
+
+    @extend_schema(tags=['muComics'])
+    def post(self, request, chapter_id):
         user_id = JWTUtils.fetch_user_id(request)
 
         comic_id = _chapter_exists(chapter_id)
@@ -353,6 +357,7 @@ class CommentDetailAPI(APIView):
     """
     permission_classes = [CustomizePermission]
 
+    @extend_schema(tags=['muComics'])
     def patch(self, request, comment_id):
         user_id = JWTUtils.fetch_user_id(request)
 
@@ -395,6 +400,7 @@ class CommentDetailAPI(APIView):
             },
         ).get_success_response()
 
+    @extend_schema(tags=['muComics'])
     def delete(self, request, comment_id):
         user_id = JWTUtils.fetch_user_id(request)
 

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -1,0 +1,419 @@
+"""
+MuComics Comment views — public comment CRUD (Endpoints 1-6).
+
+Endpoints:
+  GET    /muComics/comments/comic/<comic_id>/          → list comic comments
+  GET    /muComics/comments/chapter/<chapter_id>/       → list chapter comments
+  POST   /muComics/comments/comic/<comic_id>/          → create comic comment
+  POST   /muComics/comments/chapter/<chapter_id>/       → create chapter comment
+  PATCH  /muComics/comments/<comment_id>/               → edit own comment
+  DELETE /muComics/comments/<comment_id>/               → soft-delete own comment
+"""
+import uuid
+
+from django.db import connection
+from django.db.models import Q
+from django.utils import timezone
+from rest_framework.views import APIView
+
+from db.comic import Comic
+from db.comic_comment import ComicComment
+from utils.permission import CustomizePermission, JWTUtils
+from utils.response import CustomResponse
+from utils.utils import CommonUtils
+
+from .comment_serializers import (
+    CommentListSerializer,
+    CommentCreateSerializer,
+    CommentUpdateSerializer,
+    CommentUserSerializer,
+)
+
+
+def _get_user_id_or_none(request):
+    """Safely extract user_id from JWT; returns None if unauthenticated."""
+    try:
+        return JWTUtils.fetch_user_id(request)
+    except Exception:
+        return None
+
+
+def _chapter_exists(chapter_id):
+    """Check if a chapter exists and return its comic_id."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT comic_id FROM chapter WHERE id = %s LIMIT 1", [chapter_id]
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+
+def _increment_comment_count(comic_id):
+    """Atomically increment comic.comment_count by 1."""
+    Comic.objects.filter(id=comic_id).update(
+        comment_count=models.F('comment_count') + 1
+    )
+
+
+def _decrement_comment_count(comic_id):
+    """Atomically decrement comic.comment_count by 1 (min 0)."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "UPDATE comic SET comment_count = GREATEST(comment_count - 1, 0) WHERE id = %s",
+            [comic_id],
+        )
+
+
+# Need to import models for F expression
+from django.db import models
+
+
+class ComicCommentListCreateAPI(APIView):
+    """
+    GET  /comments/comic/<comic_id>/  — list top-level comments with replies
+    POST /comments/comic/<comic_id>/  — create a comment (top-level or reply)
+    """
+
+    def get(self, request, comic_id):
+        comic = Comic.objects.filter(id=comic_id, deleted_at__isnull=True).first()
+        if not comic:
+            return CustomResponse(
+                general_message="Comic not found"
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        user_id = _get_user_id_or_none(request)
+
+        # Get top-level comments (parent_id is NULL)
+        # Include: active comments OR soft-deleted comments that have active replies
+        top_level = ComicComment.objects.filter(
+            comic_id=comic_id,
+            parent__isnull=True,
+        ).select_related('user')
+
+        # Filter out soft-deleted comments with no active replies
+        visible_ids = []
+        for comment in top_level:
+            if not comment.is_deleted:
+                visible_ids.append(comment.id)
+            else:
+                has_active_replies = comment.replies.filter(deleted_at__isnull=True).exists()
+                if has_active_replies:
+                    visible_ids.append(comment.id)
+
+        queryset = ComicComment.objects.filter(
+            id__in=visible_ids
+        ).select_related('user').order_by('-created_at')
+
+        paginated = CommonUtils.get_paginated_queryset(
+            queryset,
+            request,
+            search_fields=['message'],
+            sort_fields={'created_at': 'created_at'},
+        )
+
+        serializer = CommentListSerializer(
+            paginated['queryset'], many=True,
+            context={'user_id': user_id},
+        )
+
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+    def post(self, request, comic_id):
+        try:
+            JWTUtils.is_jwt_authenticated(request)
+        except Exception:
+            return CustomResponse(
+                general_message="Invalid token header"
+            ).get_failure_response(status_code=1000, http_status_code=401)
+
+        user_id = JWTUtils.fetch_user_id(request)
+
+        comic = Comic.objects.filter(id=comic_id, deleted_at__isnull=True).first()
+        if not comic:
+            return CustomResponse(
+                general_message="Comic not found"
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        serializer = CommentCreateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                message=serializer.errors
+            ).get_failure_response()
+
+        message = serializer.validated_data['message']
+        parent_id = serializer.validated_data.get('parent_id')
+
+        # Validate parent_id
+        if parent_id:
+            try:
+                parent = ComicComment.objects.get(id=parent_id)
+            except ComicComment.DoesNotExist:
+                return CustomResponse(
+                    message={"parent_id": ["Parent comment not found"]}
+                ).get_failure_response()
+
+            if parent.parent_id is not None:
+                return CustomResponse(
+                    message={"parent_id": ["Replies can only be made to top-level comments"]}
+                ).get_failure_response()
+
+            if parent.comic_id != comic_id:
+                return CustomResponse(
+                    message={"parent_id": ["Parent comment does not belong to this comic"]}
+                ).get_failure_response()
+
+            if parent.is_deleted:
+                return CustomResponse(
+                    message={"parent_id": ["Cannot reply to a deleted comment"]}
+                ).get_failure_response()
+
+        now = timezone.now()
+        comment = ComicComment.objects.create(
+            id=str(uuid.uuid4()),
+            comic_id=comic_id,
+            chapter_id=None,
+            parent_id=parent_id,
+            user_id=user_id,
+            message=message,
+            updated_by_id=user_id,
+            updated_at=now,
+            created_by_id=user_id,
+            created_at=now,
+        )
+
+        _increment_comment_count(comic_id)
+
+        from db.user import User
+        user = User.objects.get(id=user_id)
+
+        return CustomResponse(
+            general_message="Comment created successfully",
+            response={
+                "id": comment.id,
+                "comic_id": comment.comic_id,
+                "chapter_id": comment.chapter_id,
+                "parent_id": comment.parent_id,
+                "user": CommentUserSerializer(user).data,
+                "message": comment.message,
+                "is_edited": False,
+                "created_at": comment.created_at,
+                "updated_at": comment.updated_at,
+            },
+        ).get_success_response()
+
+
+class ChapterCommentListCreateAPI(APIView):
+    """
+    GET  /comments/chapter/<chapter_id>/  — list chapter comments
+    POST /comments/chapter/<chapter_id>/  — create chapter comment
+    """
+
+    def get(self, request, chapter_id):
+        comic_id = _chapter_exists(chapter_id)
+        if not comic_id:
+            return CustomResponse(
+                general_message="Chapter not found"
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        user_id = _get_user_id_or_none(request)
+
+        top_level = ComicComment.objects.filter(
+            chapter_id=chapter_id,
+            parent__isnull=True,
+        ).select_related('user')
+
+        visible_ids = []
+        for comment in top_level:
+            if not comment.is_deleted:
+                visible_ids.append(comment.id)
+            else:
+                if comment.replies.filter(deleted_at__isnull=True).exists():
+                    visible_ids.append(comment.id)
+
+        queryset = ComicComment.objects.filter(
+            id__in=visible_ids
+        ).select_related('user').order_by('-created_at')
+
+        paginated = CommonUtils.get_paginated_queryset(
+            queryset,
+            request,
+            search_fields=['message'],
+            sort_fields={'created_at': 'created_at'},
+        )
+
+        serializer = CommentListSerializer(
+            paginated['queryset'], many=True,
+            context={'user_id': user_id},
+        )
+
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+    def post(self, request, chapter_id):
+        try:
+            JWTUtils.is_jwt_authenticated(request)
+        except Exception:
+            return CustomResponse(
+                general_message="Invalid token header"
+            ).get_failure_response(status_code=1000, http_status_code=401)
+
+        user_id = JWTUtils.fetch_user_id(request)
+
+        comic_id = _chapter_exists(chapter_id)
+        if not comic_id:
+            return CustomResponse(
+                general_message="Chapter not found"
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        serializer = CommentCreateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                message=serializer.errors
+            ).get_failure_response()
+
+        message = serializer.validated_data['message']
+        parent_id = serializer.validated_data.get('parent_id')
+
+        if parent_id:
+            try:
+                parent = ComicComment.objects.get(id=parent_id)
+            except ComicComment.DoesNotExist:
+                return CustomResponse(
+                    message={"parent_id": ["Parent comment not found"]}
+                ).get_failure_response()
+
+            if parent.parent_id is not None:
+                return CustomResponse(
+                    message={"parent_id": ["Replies can only be made to top-level comments"]}
+                ).get_failure_response()
+
+            if parent.chapter_id != chapter_id:
+                return CustomResponse(
+                    message={"parent_id": ["Parent comment does not belong to this chapter"]}
+                ).get_failure_response()
+
+            if parent.is_deleted:
+                return CustomResponse(
+                    message={"parent_id": ["Cannot reply to a deleted comment"]}
+                ).get_failure_response()
+
+        now = timezone.now()
+        comment = ComicComment.objects.create(
+            id=str(uuid.uuid4()),
+            comic_id=comic_id,
+            chapter_id=chapter_id,
+            parent_id=parent_id,
+            user_id=user_id,
+            message=message,
+            updated_by_id=user_id,
+            updated_at=now,
+            created_by_id=user_id,
+            created_at=now,
+        )
+
+        _increment_comment_count(comic_id)
+
+        from db.user import User
+        user = User.objects.get(id=user_id)
+
+        return CustomResponse(
+            general_message="Comment created successfully",
+            response={
+                "id": comment.id,
+                "comic_id": comment.comic_id,
+                "chapter_id": comment.chapter_id,
+                "parent_id": comment.parent_id,
+                "user": CommentUserSerializer(user).data,
+                "message": comment.message,
+                "is_edited": False,
+                "created_at": comment.created_at,
+                "updated_at": comment.updated_at,
+            },
+        ).get_success_response()
+
+
+class CommentDetailAPI(APIView):
+    """
+    PATCH  /comments/<comment_id>/  — edit own comment
+    DELETE /comments/<comment_id>/  — soft-delete own comment
+    """
+    permission_classes = [CustomizePermission]
+
+    def patch(self, request, comment_id):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        try:
+            comment = ComicComment.objects.get(id=comment_id)
+        except ComicComment.DoesNotExist:
+            return CustomResponse(
+                general_message="Comment not found"
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        if comment.is_deleted:
+            return CustomResponse(
+                general_message="Cannot edit a deleted comment"
+            ).get_failure_response()
+
+        if comment.user_id != user_id:
+            return CustomResponse(
+                general_message="You can only edit your own comments"
+            ).get_failure_response(status_code=403, http_status_code=403)
+
+        serializer = CommentUpdateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                message=serializer.errors
+            ).get_failure_response()
+
+        now = timezone.now()
+        comment.message = serializer.validated_data['message']
+        comment.updated_by_id = user_id
+        comment.updated_at = now
+        comment.save()
+
+        return CustomResponse(
+            general_message="Comment updated successfully",
+            response={
+                "id": comment.id,
+                "message": comment.message,
+                "is_edited": True,
+                "updated_at": comment.updated_at,
+            },
+        ).get_success_response()
+
+    def delete(self, request, comment_id):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        try:
+            comment = ComicComment.objects.get(id=comment_id)
+        except ComicComment.DoesNotExist:
+            return CustomResponse(
+                general_message="Comment not found"
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        if comment.is_deleted:
+            return CustomResponse(
+                general_message="Comment has already been deleted"
+            ).get_failure_response()
+
+        if comment.user_id != user_id:
+            return CustomResponse(
+                general_message="You can only delete your own comments"
+            ).get_failure_response(status_code=403, http_status_code=403)
+
+        now = timezone.now()
+        comment.deleted_at = now
+        comment.deleted_by_id = user_id
+        comment.updated_at = now
+        comment.save()
+
+        _decrement_comment_count(comment.comic_id)
+
+        return CustomResponse(
+            general_message="Comment deleted successfully"
+        ).get_success_response()

--- a/api/muComics/comment/comment_views.py
+++ b/api/muComics/comment/comment_views.py
@@ -12,7 +12,7 @@ Endpoints:
 import uuid
 
 from django.db import connection
-from django.db.models import Q
+from django.db.models import Q, Exists, OuterRef
 from django.utils import timezone
 from rest_framework.views import APIView
 
@@ -82,25 +82,19 @@ class ComicCommentListAPI(APIView):
 
         user_id = _get_user_id_or_none(request)
 
-        # Get top-level comments (parent_id is NULL)
-        # Include: active comments OR soft-deleted comments that have active replies
-        top_level = ComicComment.objects.filter(
-            comic_id=comic_id,
-            parent__isnull=True,
-        ).select_related('user')
-
-        # Filter out soft-deleted comments with no active replies
-        visible_ids = []
-        for comment in top_level:
-            if not comment.is_deleted:
-                visible_ids.append(comment.id)
-            else:
-                has_active_replies = comment.replies.filter(deleted_at__isnull=True).exists()
-                if has_active_replies:
-                    visible_ids.append(comment.id)
+        # Filter: active comments OR soft-deleted comments that have active replies
+        active_replies = ComicComment.objects.filter(
+            parent_id=OuterRef('pk'),
+            deleted_at__isnull=True
+        )
 
         queryset = ComicComment.objects.filter(
-            id__in=visible_ids
+            comic_id=comic_id,
+            parent__isnull=True,
+        ).annotate(
+            has_active_replies=Exists(active_replies)
+        ).filter(
+            Q(deleted_at__isnull=True) | Q(has_active_replies=True)
         ).select_related('user').order_by('-created_at')
 
         paginated = CommonUtils.get_paginated_queryset(
@@ -219,21 +213,19 @@ class ChapterCommentListCreateAPI(APIView):
 
         user_id = _get_user_id_or_none(request)
 
-        top_level = ComicComment.objects.filter(
-            chapter_id=chapter_id,
-            parent__isnull=True,
-        ).select_related('user')
-
-        visible_ids = []
-        for comment in top_level:
-            if not comment.is_deleted:
-                visible_ids.append(comment.id)
-            else:
-                if comment.replies.filter(deleted_at__isnull=True).exists():
-                    visible_ids.append(comment.id)
+        # Filter: active comments OR soft-deleted comments that have active replies
+        active_replies = ComicComment.objects.filter(
+            parent_id=OuterRef('pk'),
+            deleted_at__isnull=True
+        )
 
         queryset = ComicComment.objects.filter(
-            id__in=visible_ids
+            chapter_id=chapter_id,
+            parent__isnull=True,
+        ).annotate(
+            has_active_replies=Exists(active_replies)
+        ).filter(
+            Q(deleted_at__isnull=True) | Q(has_active_replies=True)
         ).select_related('user').order_by('-created_at')
 
         paginated = CommonUtils.get_paginated_queryset(

--- a/api/muComics/comment/urls.py
+++ b/api/muComics/comment/urls.py
@@ -3,35 +3,45 @@ from django.urls import path
 from . import comment_views, admin_views
 
 urlpatterns = [
-    # Endpoint 1 & 3: List / Create Comic Comments
+    # Comic Comments
     path(
-        'comic/<str:comic_id>/',
-        comment_views.ComicCommentListCreateAPI.as_view(),
-        name='comic-comment-list-create',
+        'comic/<str:comic_id>/list/',
+        comment_views.ComicCommentListAPI.as_view(),
+        name='comic-comment-list',
+    ),
+    path(
+        'comic/<str:comic_id>/create/',
+        comment_views.ComicCommentCreateAPI.as_view(),
+        name='comic-comment-create',
     ),
 
-    # Endpoint 2 & 4: List / Create Chapter Comments
+    # Chapter Comments
     path(
-        'chapter/<str:chapter_id>/',
-        comment_views.ChapterCommentListCreateAPI.as_view(),
-        name='chapter-comment-list-create',
+        'chapter/<str:chapter_id>/list/',
+        comment_views.ChapterCommentListAPI.as_view(),
+        name='chapter-comment-list',
+    ),
+    path(
+        'chapter/<str:chapter_id>/create/',
+        comment_views.ChapterCommentCreateAPI.as_view(),
+        name='chapter-comment-create',
     ),
 
-    # Endpoint 7: Admin — List All Comments
+    # Admin — List All Comments
     path(
         'admin/',
         admin_views.AdminCommentListAPI.as_view(),
         name='admin-comment-list',
     ),
 
-    # Endpoint 8: Admin — Delete Comment (Soft-Delete)
+    # Admin — Delete Comment (Soft-Delete)
     path(
         'admin/<str:comment_id>/',
         admin_views.AdminCommentDeleteAPI.as_view(),
         name='admin-comment-delete',
     ),
 
-    # Endpoint 5 & 6: Edit / Delete (User Soft-Delete)
+    # Edit / Delete (User Soft-Delete)
     path(
         '<str:comment_id>/',
         comment_views.CommentDetailAPI.as_view(),

--- a/api/muComics/comment/urls.py
+++ b/api/muComics/comment/urls.py
@@ -1,0 +1,40 @@
+from django.urls import path
+
+from . import comment_views, admin_views
+
+urlpatterns = [
+    # Endpoint 1 & 3: List / Create Comic Comments
+    path(
+        'comic/<str:comic_id>/',
+        comment_views.ComicCommentListCreateAPI.as_view(),
+        name='comic-comment-list-create',
+    ),
+
+    # Endpoint 2 & 4: List / Create Chapter Comments
+    path(
+        'chapter/<str:chapter_id>/',
+        comment_views.ChapterCommentListCreateAPI.as_view(),
+        name='chapter-comment-list-create',
+    ),
+
+    # Endpoint 7: Admin — List All Comments
+    path(
+        'admin/',
+        admin_views.AdminCommentListAPI.as_view(),
+        name='admin-comment-list',
+    ),
+
+    # Endpoint 8: Admin — Delete Comment (Soft-Delete)
+    path(
+        'admin/<str:comment_id>/',
+        admin_views.AdminCommentDeleteAPI.as_view(),
+        name='admin-comment-delete',
+    ),
+
+    # Endpoint 5 & 6: Edit / Delete (User Soft-Delete)
+    path(
+        '<str:comment_id>/',
+        comment_views.CommentDetailAPI.as_view(),
+        name='comment-detail',
+    ),
+]

--- a/api/muComics/urls.py
+++ b/api/muComics/urls.py
@@ -2,4 +2,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('comics/', include('api.muComics.comic.urls')),
+    path('comments/', include('api.muComics.comment.urls')),
 ]

--- a/db/comic_comment.py
+++ b/db/comic_comment.py
@@ -35,13 +35,13 @@ class ComicComment(models.Model):
 
     # Audit
     updated_by = models.ForeignKey(
-        User, on_delete=models.CASCADE,
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
         db_column='updated_by', related_name='comic_comment_updated_by'
     )
     updated_at = models.DateTimeField()
 
     created_by = models.ForeignKey(
-        User, on_delete=models.CASCADE,
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
         db_column='created_by', related_name='comic_comment_created_by'
     )
     created_at = models.DateTimeField()

--- a/db/comic_comment.py
+++ b/db/comic_comment.py
@@ -1,0 +1,67 @@
+import uuid
+
+from django.db import models
+from django.conf import settings
+
+from .user import User
+from .comic import Comic
+
+
+class ComicComment(models.Model):
+
+    id         = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+
+    comic      = models.ForeignKey(
+        Comic, on_delete=models.CASCADE,
+        db_column='comic_id', related_name='comments'
+    )
+    chapter_id = models.CharField(max_length=36, null=True, blank=True)
+    parent     = models.ForeignKey(
+        'self', on_delete=models.CASCADE, null=True, blank=True,
+        db_column='parent_id', related_name='replies'
+    )
+    user       = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='user_id', related_name='comic_comments'
+    )
+    message    = models.TextField()
+
+    # Soft delete
+    deleted_at = models.DateTimeField(null=True, blank=True)
+    deleted_by = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        db_column='deleted_by', related_name='comic_comment_deleted_by'
+    )
+
+    # Audit
+    updated_by = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='updated_by', related_name='comic_comment_updated_by'
+    )
+    updated_at = models.DateTimeField()
+
+    created_by = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        db_column='created_by', related_name='comic_comment_created_by'
+    )
+    created_at = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'comic_comment'
+        indexes = [
+            models.Index(fields=['comic', 'created_at'], name='idx_comic_comment_comic'),
+            models.Index(fields=['chapter_id', 'created_at'], name='idx_comic_comment_chapter'),
+            models.Index(fields=['parent'], name='idx_comic_comment_parent'),
+            models.Index(fields=['user'], name='idx_comic_comment_user'),
+        ]
+
+    @property
+    def is_deleted(self):
+        return self.deleted_at is not None
+
+    @property
+    def is_edited(self):
+        if self.updated_at and self.created_at:
+            return self.updated_at > self.created_at
+        return False

--- a/db/models.py
+++ b/db/models.py
@@ -14,6 +14,8 @@ When you add a new model module under ``db/``, add it to the import list below.
 from db import (  # noqa: F401
     achievement,
     campus,
+    comic,
+    comic_comment,
     company,
     donation,
     donor,

--- a/schema.sql
+++ b/schema.sql
@@ -2248,6 +2248,38 @@ CREATE TABLE `zone` (
   CONSTRAINT `fk_zone_ref_updated_by` FOREIGN KEY (`updated_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `comic_comment`
+--
+
+DROP TABLE IF EXISTS `comic_comment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `comic_comment` (
+  `id` varchar(36) NOT NULL,
+  `comic_id` varchar(36) NOT NULL,
+  `chapter_id` varchar(36) DEFAULT NULL,
+  `parent_id` varchar(36) DEFAULT NULL,
+  `user_id` varchar(36) NOT NULL,
+  `message` text NOT NULL,
+  `deleted_at` datetime DEFAULT NULL,
+  `deleted_by` varchar(36) DEFAULT NULL,
+  `updated_by` varchar(36) NOT NULL,
+  `updated_at` datetime NOT NULL,
+  `created_by` varchar(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_comic_comment_comic` (`comic_id`,`created_at`),
+  KEY `idx_comic_comment_chapter` (`chapter_id`,`created_at`),
+  KEY `idx_comic_comment_parent` (`parent_id`),
+  KEY `idx_comic_comment_user` (`user_id`),
+  CONSTRAINT `fk_comic_comment_ref_comic_id` FOREIGN KEY (`comic_id`) REFERENCES `comic` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_comic_comment_ref_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `comic_comment` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_comic_comment_ref_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_comic_comment_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 SET @@SESSION.SQL_LOG_BIN = @MYSQLDUMP_TEMP_LOG_BIN;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/schema.sql
+++ b/schema.sql
@@ -2277,7 +2277,9 @@ CREATE TABLE `comic_comment` (
   CONSTRAINT `fk_comic_comment_ref_comic_id` FOREIGN KEY (`comic_id`) REFERENCES `comic` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_comic_comment_ref_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `comic_comment` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_comic_comment_ref_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_comic_comment_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL
+  CONSTRAINT `fk_comic_comment_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_comic_comment_ref_upd_by` FOREIGN KEY (`updated_by`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_comic_comment_ref_cre_by` FOREIGN KEY (`created_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 SET @@SESSION.SQL_LOG_BIN = @MYSQLDUMP_TEMP_LOG_BIN;

--- a/utils/types.py
+++ b/utils/types.py
@@ -47,6 +47,7 @@ class RoleType(Enum):
     LEAD_ENABLER = "Lead Enabler"
     MULEARNER = "Mulearner"
     COMPANY = "Company"
+    COMIC_ADMIN = "Comic Admin"
 
     @classmethod
     def IG_CAMPUS_LEAD_ROLE(cls, ig_code: str):


### PR DESCRIPTION
## Description
This PR implements the Community Interaction features for the MuComics module. It introduces a fully threaded comment system with endpoints for both users and moderators. 

## Key Changes
- **Database:** Created the `ComicComment` model mapping to `comic_comment` with support for a single-level nested reply structure.
- **Role System:** Added the `Comic Admin` role to `RoleType` for content moderation.
- **Public Endpoints:** 
  - List & create comic-level and chapter-level comments
  - Edit existing comments
  - User soft-deletion
- **Admin Endpoints:** 
  - List all comments (includes filtering for soft-deleted comments)
  - Admin soft-deletion (moderation)
- **Routing:** Registered all routes under `/api/v1/muComics/comments/`.
