### PR TITLE
feat:added comic management module

### DIFF
--- a/api/muComics/comic/admin_views.py
+++ b/api/muComics/comic/admin_views.py
@@ -110,7 +110,7 @@ class GenreListCreateView(APIView):
         if not serializer.is_valid():
             return CustomResponse(
                 general_message=serializer.errors
-            ).get_failure_response("problem here")
+            ).get_failure_response("")
 
         genre = serializer.save()
 

--- a/api/muComics/comic/admin_views.py
+++ b/api/muComics/comic/admin_views.py
@@ -1,0 +1,282 @@
+"""
+Genre admin views — embedded in the comic module.
+
+Endpoints (all authenticated; writes require Admins role):
+  GET    /muComics/comics/genres/                      → list (active only for non-admin; admin can filter ?is_active=)
+  POST   /muComics/comics/genres/                      → create  [Admin]
+  GET    /muComics/comics/genres/<genre_id>/           → detail  (active for non-admin; any for admin)
+  PATCH  /muComics/comics/genres/<genre_id>/           → update name  [Admin]
+  DELETE /muComics/comics/genres/<genre_id>/           → soft deactivate (is_active=False)  [Admin]
+  POST   /muComics/comics/genres/<genre_id>/reinstate/ → reactivate (is_active=True)  [Admin]
+"""
+
+from django.utils import timezone
+
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers as s
+from rest_framework.views import APIView
+
+from db.comic import Genre
+from utils.permission import CustomizePermission, JWTUtils, RoleRequired
+from utils.response import CustomResponse
+from utils.types import RoleType
+from utils.utils import CommonUtils
+
+from .serializers import GenreReadSerializer, GenreWriteSerializer
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HELPERS
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _is_admin(request):
+    """Return True if the JWT carries the Admins role."""
+    return RoleType.ADMIN.value in JWTUtils.fetch_role(request)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GENRE LIST + CREATE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class GenreListCreateView(APIView):
+    """
+    GET  /muComics/comics/genres/
+         Non-admins → only is_active=True genres.
+         Admins     → all genres; optionally filter with ?is_active=true|false.
+
+    POST /muComics/comics/genres/  [Admin only]
+         Create a new genre (is_active defaults to True).
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Genre'],
+        description=(
+            "List genres. Non-admins see only active genres. "
+            "Admins can filter with ?is_active=true|false. "
+            "Supports ?search= (by name) and ?sort=name|created_at."
+        ),
+        responses={200: GenreReadSerializer(many=True)},
+    )
+    def get(self, request):
+        admin = _is_admin(request)
+
+        if admin:
+            queryset = Genre.objects.all()
+            is_active_param = request.query_params.get('is_active')
+            if is_active_param is not None:
+                if is_active_param.lower() == 'true':
+                    queryset = queryset.filter(is_active=True)
+                elif is_active_param.lower() == 'false':
+                    queryset = queryset.filter(is_active=False)
+                else:
+                    return CustomResponse(
+                        general_message='Invalid value for is_active. Use true or false.'
+                    ).get_failure_response()
+        else:
+            # Regular users only ever see active genres
+            queryset = Genre.objects.filter(is_active=True)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            queryset,
+            request,
+            search_fields=['name'],
+            sort_fields={
+                'name':       'name',
+                'created_at': 'created_at',
+            },
+        )
+
+        serializer = GenreReadSerializer(paginated['queryset'], many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+    @extend_schema(
+        tags=['muComics - Genre'],
+        description="Create a new genre. is_active defaults to true. Admin only.",
+        request=GenreWriteSerializer,
+        responses={200: GenreReadSerializer},
+    )
+    @RoleRequired([RoleType.ADMIN])
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        serializer = GenreWriteSerializer(
+            data=request.data,
+            context={'user_id': user_id},
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response("problem here")
+
+        genre = serializer.save()
+
+        return CustomResponse(
+            general_message=f'Genre "{genre.name}" created successfully.',
+            response=GenreReadSerializer(genre).data,
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GENRE DETAIL — GET / PATCH / DELETE (soft deactivate)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class GenreDetailView(APIView):
+    """
+    GET    → active genres only for non-admins; any genre for admins.
+    PATCH  → update name (Admin only).
+    DELETE → soft deactivate: is_active = False (Admin only).
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_genre(self, genre_id, admin):
+        """
+        Fetch genre by id.
+        - Admin: any genre (active or inactive).
+        - Non-admin: only active genres.
+        Returns (genre, error_string).
+        """
+        qs = Genre.objects.all() if admin else Genre.objects.filter(is_active=True)
+        genre = qs.filter(id=genre_id).first()
+        if not genre:
+            return None, 'Genre not found.'
+        return genre, None
+
+    @extend_schema(
+        tags=['muComics - Genre'],
+        description=(
+            "Retrieve a genre. Non-admins only see active genres (inactive → 404). "
+            "Admins can retrieve any genre regardless of is_active status."
+        ),
+        responses={200: GenreReadSerializer},
+    )
+    def get(self, request, genre_id):
+        admin = _is_admin(request)
+        genre, error = self._get_genre(genre_id, admin)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response()
+
+        return CustomResponse(
+            general_message=f'Genre "{genre.name}" retrieved successfully.',
+            response=GenreReadSerializer(genre).data,
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['muComics - Genre'],
+        description="Update a genre's name (slug is regenerated automatically). Admin only.",
+        request=GenreWriteSerializer,
+        responses={200: GenreReadSerializer},
+    )
+    @RoleRequired([RoleType.ADMIN])
+    def patch(self, request, genre_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        # Admin context — can edit active or inactive genre
+        genre, error = self._get_genre(genre_id, admin=True)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response()
+
+        serializer = GenreWriteSerializer(
+            genre,
+            data=request.data,
+            partial=True,
+            context={'user_id': user_id},
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        genre = serializer.save()
+
+        return CustomResponse(
+            general_message=f'Genre "{genre.name}" updated successfully.',
+            response=GenreReadSerializer(genre).data,
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['muComics - Genre'],
+        description=(
+            "Soft-deactivate a genre (sets is_active = False). "
+            "The genre row and all comic_genre_link rows are preserved. "
+            "Admin only."
+        ),
+        responses={200: inline_serializer(
+            name='GenreDeactivateResponse',
+            fields={
+                'id':        s.CharField(),
+                'is_active': s.BooleanField(),
+            },
+        )},
+    )
+    @RoleRequired([RoleType.ADMIN])
+    def delete(self, request, genre_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        genre, error = self._get_genre(genre_id, admin=True)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response()
+
+        if not genre.is_active:
+            return CustomResponse(
+                general_message=f'Genre "{genre.name}" is already inactive.'
+            ).get_failure_response()
+
+        now                 = timezone.now()
+        genre.is_active     = False
+        genre.updated_by_id = user_id
+        genre.updated_at    = now
+        genre.save(update_fields=['is_active', 'updated_by', 'updated_at'])
+
+        return CustomResponse(
+            general_message=f'Genre "{genre.name}" deactivated successfully.',
+            response={'id': genre.id, 'is_active': False},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GENRE REINSTATE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class GenreReinstateView(APIView):
+    """
+    POST /muComics/comics/genres/<genre_id>/reinstate/
+    Reactivates a deactivated genre (is_active = True). Admin only.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Genre'],
+        description="Reinstate (reactivate) a deactivated genre. Sets is_active = True. Admin only.",
+        responses={200: inline_serializer(
+            name='GenreReinstateResponse',
+            fields={
+                'id':        s.CharField(),
+                'is_active': s.BooleanField(),
+            },
+        )},
+    )
+    @RoleRequired([RoleType.ADMIN])
+    def post(self, request, genre_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        # Admin needed — fetch any genre (active or inactive)
+        genre = Genre.objects.filter(id=genre_id).first()
+        if not genre:
+            return CustomResponse(general_message='Genre not found.').get_failure_response()
+
+        if genre.is_active:
+            return CustomResponse(
+                general_message=f'Genre "{genre.name}" is already active.'
+            ).get_failure_response()
+
+        now                 = timezone.now()
+        genre.is_active     = True
+        genre.updated_by_id = user_id
+        genre.updated_at    = now
+        genre.save(update_fields=['is_active', 'updated_by', 'updated_at'])
+
+        return CustomResponse(
+            general_message=f'Genre "{genre.name}" reinstated successfully.',
+            response={'id': genre.id, 'is_active': True},
+        ).get_success_response()

--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -560,7 +560,7 @@ class ComicContributorDetailView(APIView):
 
         link.contributor_type = serializer.validated_data['role']
         try:
-            link.save()
+            link.save(update_fields=['contributor_type'])
         except IntegrityError:
             return CustomResponse(
                 general_message='Contributor with this role already exists.'
@@ -655,7 +655,12 @@ class ComicGenreListView(APIView):
                 general_message=serializer.errors
             ).get_failure_response()
 
-        link = serializer.save()
+        try:
+            link = serializer.save()
+        except IntegrityError:
+            return CustomResponse(
+                general_message='This genre is already assigned to this comic.'
+            ).get_failure_response()
 
         return CustomResponse(
             general_message=f'Genre "{link.genre.name}" assigned to comic "{comic.title}" successfully.',

--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -13,6 +13,7 @@ Endpoints:
 
 from django.utils import timezone
 from django.db.models import Q
+from django.db import IntegrityError
 
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers as s
@@ -22,11 +23,15 @@ from db.comic import Comic, ComicContributorLink
 from utils.permission import CustomizePermission, JWTUtils
 from utils.response import CustomResponse
 from utils.utils import CommonUtils
+from utils.types import RoleType
 
 from .serializers import (
     ComicListItemSerializer,
     ComicDetailSerializer,
     ComicWriteSerializer,
+    ContributorWriteSerializer,
+    ContributorRoleUpdateSerializer,
+    ContributorListSerializer,
 )
 
 
@@ -37,6 +42,16 @@ from .serializers import (
 def _get_active_comics():
     """Base queryset: exclude soft-deleted rows."""
     return Comic.objects.filter(deleted_at__isnull=True)
+
+
+def _is_creator_or_admin(user_id, comic, request):
+    """
+    True if the user is the comic's original creator
+    OR holds the platform Admin role in their JWT.
+    """
+    if comic.created_by_id == user_id:
+        return True
+    return RoleType.ADMIN.value in JWTUtils.fetch_role(request)
 
 
 def can_edit_comic(user_id, comic):
@@ -367,4 +382,185 @@ class ComicArchiveView(APIView):
         return CustomResponse(
             general_message=f'Comic "{comic.title}" archived successfully.',
             response={'id': comic.id, 'status': Comic.Status.ARCHIVED},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CONTRIBUTORS
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicContributorListView(APIView):
+    """
+    GET  /muComics/comics/<comic_id>/contributors/
+         → list all contributors for the comic (any authenticated user)
+
+    POST /muComics/comics/<comic_id>/contributors/
+         → add a contributor (comic creator or Admin only)
+         Request body: { "muid": "...", "role": "ARTIST" }
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics'],
+        description="List all contributors for a comic.",
+        responses={200: ContributorListSerializer(many=True)},
+    )
+    def get(self, request, comic_id):
+        comic = _get_active_comics().filter(id=comic_id).first()
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        role_filter = request.query_params.get('role')
+        links = ComicContributorLink.objects.filter(comic=comic)
+        
+        if role_filter:
+            links = links.filter(contributor_type=role_filter)
+            
+        links = links.select_related('user', 'comic')
+        
+        if not links:
+            if role_filter:
+                return CustomResponse(general_message=f'No {role_filter} contributor found for this comic.', response=[]).get_success_response()
+            return CustomResponse(general_message='There are no contributors for this comic.', response=[]).get_success_response()
+            
+        serializer = ContributorListSerializer(links, many=True)
+        return CustomResponse(response=serializer.data).get_success_response()
+
+    @extend_schema(
+        tags=['muComics'],
+        description="Add a contributor to a comic by muid and role. Only the comic creator or an Admin may call this. The CREATOR role cannot be assigned via this endpoint.",
+        request=ContributorWriteSerializer,
+        responses={200: inline_serializer(
+            name='ContributorAddResponse',
+            fields={'message': s.CharField()},
+        )},
+    )
+    def post(self, request, comic_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic   = _get_active_comics().filter(id=comic_id).first()
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        if not _is_creator_or_admin(user_id, comic, request):
+            return CustomResponse(
+                general_message='Only the comic creator or an admin can add contributors.'
+            ).get_unauthorized_response()
+
+        serializer = ContributorWriteSerializer(
+            data=request.data,
+            context={'comic': comic, 'user_id': user_id},
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        try:
+            serializer.save()
+        except IntegrityError:
+            return CustomResponse(
+                general_message='Contributor with this role already exists.'
+            ).get_failure_response()
+
+        # muid comes from validated_data['muid'] which is a User object after validate_muid
+        muid = serializer.validated_data['muid'].muid
+        role = serializer.validated_data['role']
+        return CustomResponse(
+            general_message=f'{role} {muid} added successfully.'
+        ).get_success_response()
+
+
+class ComicContributorDetailView(APIView):
+    """
+    PATCH  /muComics/comics/<comic_id>/contributors/<contributor_id>/
+           → update a contributor's role (comic creator or Admin only)
+
+    DELETE /muComics/comics/<comic_id>/contributors/<contributor_id>/
+           → remove a contributor (comic creator or Admin only)
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_link_or_error(self, comic, contributor_id):
+        """Fetch a ComicContributorLink by PK scoped to the given comic."""
+        link = (
+            ComicContributorLink.objects
+            .filter(id=contributor_id, comic=comic)
+            .select_related('user')
+            .first()
+        )
+        if not link:
+            return None, 'Contributor not found.'
+        return link, None
+
+    @extend_schema(
+        tags=['muComics'],
+        description="Update a contributor's role. Only the comic creator or an Admin may call this. The CREATOR role cannot be assigned.",
+        request=ContributorRoleUpdateSerializer,
+        responses={200: inline_serializer(
+            name='ContributorUpdateResponse',
+            fields={'message': s.CharField()},
+        )},
+    )
+    def patch(self, request, comic_id, contributor_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic   = _get_active_comics().filter(id=comic_id).first()
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        if not _is_creator_or_admin(user_id, comic, request):
+            return CustomResponse(
+                general_message='Only the comic creator or an admin can update contributors.'
+            ).get_unauthorized_response()
+
+        link, error = self._get_link_or_error(comic, contributor_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response()
+
+        serializer = ContributorRoleUpdateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        link.contributor_type = serializer.validated_data['role']
+        try:
+            link.save()
+        except IntegrityError:
+            return CustomResponse(
+                general_message='Contributor with this role already exists.'
+            ).get_failure_response()
+
+        return CustomResponse(
+            general_message=f'{link.contributor_type} {link.user.muid} updated.'
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['muComics'],
+        description="Remove a contributor from a comic. Only the comic creator or an Admin may call this.",
+        responses={200: inline_serializer(
+            name='ContributorRemoveResponse',
+            fields={'message': s.CharField()},
+        )},
+    )
+    def delete(self, request, comic_id, contributor_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic   = _get_active_comics().filter(id=comic_id).first()
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        if not _is_creator_or_admin(user_id, comic, request):
+            return CustomResponse(
+                general_message='Only the comic creator or an admin can remove contributors.'
+            ).get_unauthorized_response()
+
+        link, error = self._get_link_or_error(comic, contributor_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response()
+
+        muid = link.user.muid
+        role=link.contributor_type
+        link.delete()
+
+        return CustomResponse(
+            general_message=f'{role} {muid} removed.'
         ).get_success_response()

--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -19,7 +19,7 @@ from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers as s
 from rest_framework.views import APIView
 
-from db.comic import Comic, ComicContributorLink
+from db.comic import Comic, ComicContributorLink, ComicGenreLink, Genre
 from utils.permission import CustomizePermission, JWTUtils
 from utils.response import CustomResponse
 from utils.utils import CommonUtils
@@ -32,6 +32,7 @@ from .serializers import (
     ContributorWriteSerializer,
     ContributorRoleUpdateSerializer,
     ContributorListSerializer,
+    ComicGenreAssignSerializer,
 )
 
 
@@ -564,3 +565,115 @@ class ComicContributorDetailView(APIView):
         return CustomResponse(
             general_message=f'{role} {muid} removed.'
         ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMIC GENRE LINKS (assign / remove)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicGenreListView(APIView):
+    """
+    POST /muComics/comics/<comic_id>/genres/
+         Assign a genre to a comic.
+         Required role: Creator, Editor or Admin
+         Request body: { "genre_id": "<uuid>" }
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics'],
+        description="Assign a genre to a comic. Only the creator, an assigned editor, or an admin might perform this action.",
+        request=ComicGenreAssignSerializer,
+        responses={200: inline_serializer(
+            name='ComicGenreAssignResponse',
+            fields={
+                'link_id': s.CharField(),
+                'genre': inline_serializer(
+                    name='GenreMinimalObj',
+                    fields={
+                        'id': s.CharField(),
+                        'name': s.CharField(),
+                        'slug': s.CharField(),
+                    }
+                )
+            }
+        )},
+    )
+    def post(self, request, comic_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic = _get_active_comics().filter(id=comic_id).first()
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        # Permission role check: Creator, Editor or Admin
+        if not (can_edit_comic(user_id, comic) or RoleType.ADMIN.value in JWTUtils.fetch_role(request)):
+            return CustomResponse(
+                general_message='Only the comic creator, assigned editor, or an Admin can manage genres for this comic.'
+            ).get_unauthorized_response()
+
+        serializer = ComicGenreAssignSerializer(
+            data=request.data,
+            context={'comic': comic, 'user_id': user_id},
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        link = serializer.save()
+
+        return CustomResponse(
+            general_message=f'Genre "{link.genre.name}" assigned to comic "{comic.title}" successfully.',
+            response={
+                'link_id': link.id,
+                'genre': {
+                    'id': link.genre.id,
+                    'name': link.genre.name,
+                    'slug': link.genre.slug,
+                }
+            },
+        ).get_success_response()
+
+
+class ComicGenreDetailView(APIView):
+    """
+    DELETE /muComics/comics/<comic_id>/genres/<link_id>/
+           Remove a genre link from a comic.
+           Required role: Creator, Editor or Admin
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics'],
+        description="Remove a genre from a comic. Only the creator, an assigned editor, or an admin might perform this action.",
+        responses={200: inline_serializer(
+            name='ComicGenreRemoveResponse',
+            fields={'link_id': s.CharField()}
+        )},
+    )
+    def delete(self, request, comic_id, link_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic = _get_active_comics().filter(id=comic_id).first()
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        # Permission role check: Creator, Editor or Admin
+        if not (can_edit_comic(user_id, comic) or RoleType.ADMIN.value in JWTUtils.fetch_role(request)):
+            return CustomResponse(
+                general_message='Only the comic creator, assigned editor, or an Admin can manage genres for this comic.'
+            ).get_unauthorized_response()
+
+        link = ComicGenreLink.objects.filter(id=link_id, comic=comic).select_related('genre').first()
+        if not link:
+            return CustomResponse(
+                general_message='Genre link not found for this comic.'
+            ).get_failure_response()
+
+        genre_name = link.genre.name
+        link.delete()
+
+        return CustomResponse(
+            general_message=f'Genre "{genre_name}" removed from comic "{comic.title}" successfully.',
+            response={'link_id': link_id},
+        ).get_success_response()
+

--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -418,26 +418,49 @@ class ComicContributorListView(APIView):
         description="List all contributors for a comic.",
         responses={200: ContributorListSerializer(many=True)},
     )
+    # def get(self, request, comic_id):
+    #     comic = _get_active_comics().filter(id=comic_id).first()
+    #     if not comic:
+    #         return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+    #     role_filter = request.query_params.get('role')
+    #     links = ComicContributorLink.objects.filter(comic=comic)
+        
+    #     if role_filter:
+    #         links = links.filter(contributor_type=role_filter)
+            
+    #     links = links.select_related('user', 'comic')
+        
+    #     if not links:
+    #         if role_filter:
+    #             return CustomResponse(general_message=f'No {role_filter} contributor found for this comic.', response=[]).get_success_response()
+    #         return CustomResponse(general_message='There are no contributors for this comic.', response=[]).get_success_response()
+            
+    #     serializer = ContributorListSerializer(links, many=True)
+    #     return CustomResponse(response=serializer.data).get_success_response()
     def get(self, request, comic_id):
         comic = _get_active_comics().filter(id=comic_id).first()
         if not comic:
             return CustomResponse(general_message='Comic not found.').get_failure_response()
 
+        links = ComicContributorLink.objects.filter(comic=comic).select_related('user', 'comic')
+
         role_filter = request.query_params.get('role')
-        links = ComicContributorLink.objects.filter(comic=comic)
-        
         if role_filter:
             links = links.filter(contributor_type=role_filter)
-            
-        links = links.select_related('user', 'comic')
-        
-        if not links:
-            if role_filter:
-                return CustomResponse(general_message=f'No {role_filter} contributor found for this comic.', response=[]).get_success_response()
-            return CustomResponse(general_message='There are no contributors for this comic.', response=[]).get_success_response()
-            
-        serializer = ContributorListSerializer(links, many=True)
-        return CustomResponse(response=serializer.data).get_success_response()
+
+        paginated = CommonUtils.get_paginated_queryset(
+            links,
+            request,
+            search_fields=['user__full_name', 'contributor_type'],
+            sort_fields={'role': 'contributor_type'},
+        )
+
+        serializer = ContributorListSerializer(paginated['queryset'], many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
 
     @extend_schema(
         tags=['muComics'],

--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -97,8 +97,20 @@ class ComicListCreateView(APIView):
                 ).get_failure_response()
             queryset = queryset.filter(status=status_filter)
 
+        # Optional multi-genre filter: ?genre=action,horror
+        # Accepts one or more genre slugs (comma-separated).
+        # Returns comics that have at least one of the given active genres.
+        if genre_param := request.query_params.get('genre'):
+            genre_slugs = [s.strip() for s in genre_param.split(',') if s.strip()]
+          
+            if genre_slugs:
+                queryset = queryset.filter(
+                    genre_links__genre__slug__in=genre_slugs,
+                    genre_links__genre__is_active=True,
+                ).distinct()
+
         paginated = CommonUtils.get_paginated_queryset(
-            queryset.select_related('created_by'),
+            queryset.select_related('created_by').prefetch_related('genre_links__genre'),
             request,
             search_fields=['title'],
             sort_fields={
@@ -655,7 +667,7 @@ class ComicGenreDetailView(APIView):
         user_id = JWTUtils.fetch_user_id(request)
         comic = _get_active_comics().filter(id=comic_id).first()
         if not comic:
-            return CustomResponse(general_message='Comic not found.').get_failure_response()
+            return CustomResponse(general_message=f'Comic {comic_id} not found.').get_failure_response()
 
         # Permission role check: Creator, Editor or Admin
         if not (can_edit_comic(user_id, comic) or RoleType.ADMIN.value in JWTUtils.fetch_role(request)):

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -47,6 +47,7 @@ class ContributorSerializer(serializers.ModelSerializer):
 
 class ComicListItemSerializer(serializers.ModelSerializer):
     created_by = MinimalUserSerializer(read_only=True)
+    genres     = serializers.SerializerMethodField()
 
     class Meta:
         model = Comic
@@ -54,7 +55,12 @@ class ComicListItemSerializer(serializers.ModelSerializer):
             'id', 'title', 'slug', 'cover_image_key',
             'status', 'like_count', 'comment_count', 'bookmark_count',
             'published_at', 'created_by', 'created_at',
+            'genres',
         ]
+
+    def get_genres(self, obj):
+        links = obj.genre_links.select_related('genre').filter(genre__is_active=True)
+        return MinimalGenreSerializer([link.genre for link in links], many=True).data
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -48,7 +48,7 @@ class ContributorSerializer(serializers.ModelSerializer):
 class ComicListItemSerializer(serializers.ModelSerializer):
     created_by = MinimalUserSerializer(read_only=True)
     genres     = serializers.SerializerMethodField()
-
+ 
     class Meta:
         model = Comic
         fields = [
@@ -59,8 +59,10 @@ class ComicListItemSerializer(serializers.ModelSerializer):
         ]
 
     def get_genres(self, obj):
-        links = obj.genre_links.select_related('genre').filter(genre__is_active=True)
-        return MinimalGenreSerializer([link.genre for link in links], many=True).data
+        links = obj.genre_links.all()
+        active_genres = [link.genre for link in links if link.genre.is_active]
+        return MinimalGenreSerializer(active_genres, many=True).data
+
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -217,9 +219,9 @@ class ContributorWriteSerializer(serializers.Serializer):
 
     def validate_muid(self, value):
         try:
-            return User.objects.get(muid=value)
+            return User.objects.get(muid=value, is_active=True)
         except User.DoesNotExist:
-            raise serializers.ValidationError(f'User with muid "{value}" not found.')
+            raise serializers.ValidationError(f'No Active user with muid "{value}" not found.')
 
     def create(self, validated_data):
         comic   = self.context['comic']

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -79,7 +79,8 @@ class ComicDetailSerializer(serializers.ModelSerializer):
         ]
 
     def get_genres(self, obj):
-        links = obj.genre_links.select_related('genre').all()
+        # Option A: only active genres shown; inactive genre hides from comic detail
+        links = obj.genre_links.select_related('genre').filter(genre__is_active=True)
         return MinimalGenreSerializer(
             [link.genre for link in links], many=True
         ).data
@@ -250,3 +251,140 @@ class ContributorListSerializer(serializers.ModelSerializer):
     class Meta:
         model  = ComicContributorLink
         fields = ['contributor_id', 'user_id', 'role', 'name', 'comic_name']
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GENRE MANAGEMENT  (admin read / write)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class GenreReadSerializer(serializers.ModelSerializer):
+    """Output shape for genre list / detail responses."""
+
+    class Meta:
+        model  = Genre
+        fields = ['id', 'name', 'slug', 'is_active', 'created_at', 'updated_at']
+
+
+class GenreWriteSerializer(serializers.ModelSerializer):
+    """
+    Input serializer for POST /comics/genres/ and PATCH /comics/genres/<id>/.
+    Caller only sends `name`; slug and audit fields are set internally.
+    """
+
+    class Meta:
+        model  = Genre
+        fields = ['name']
+        extra_kwargs = {
+            'name': {
+                'required':    True,
+                'max_length':  75,
+                'allow_blank': False,
+            },
+        }
+
+    def validate_name(self, value):
+        if not value or not value.strip():
+            raise serializers.ValidationError('Name must not be blank.')
+        return value.strip()
+
+    def _generate_unique_slug(self, name):
+        """
+        URL-safe slug from name. Appends an incrementing counter on collision.
+        Truncated to 70 chars before suffix to stay within max_length=75.
+        On update, excludes the current genre's own slug from collision check.
+        """
+        base       = slugify(name)[:70]
+        slug       = base
+        counter    = 1
+        exclude_id = self.instance.id if self.instance else None
+
+        while True:
+            qs = Genre.objects.filter(slug=slug)
+            if exclude_id:
+                qs = qs.exclude(id=exclude_id)
+            if not qs.exists():
+                break
+            slug    = f'{base}-{counter}'
+            counter += 1
+        return slug
+
+    def create(self, validated_data):
+        user_id = self.context['user_id']
+        now     = timezone.now()
+
+        validated_data['id']            = str(uuid.uuid4())
+        validated_data['slug']          = self._generate_unique_slug(validated_data['name'])
+        validated_data['is_active']     = True
+        validated_data['created_by_id'] = user_id
+        validated_data['updated_by_id'] = user_id
+        validated_data['created_at']    = now
+        validated_data['updated_at']    = now
+
+        return Genre.objects.create(**validated_data)
+
+    def update(self, instance, validated_data):
+        user_id = self.context['user_id']
+        now     = timezone.now()
+
+        if 'name' in validated_data and validated_data['name'] != instance.name:
+            validated_data['slug'] = self._generate_unique_slug(validated_data['name'])
+
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+
+        instance.updated_by_id = user_id
+        instance.updated_at    = now
+
+        changed_fields = list(validated_data.keys())
+        if 'name' in changed_fields:
+            changed_fields.append('slug')
+        changed_fields += ['updated_by', 'updated_at']
+
+        instance.save(update_fields=changed_fields)
+        return instance
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMIC GENRE LINK MANAGEMENT
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicGenreAssignSerializer(serializers.Serializer):
+    """
+    Input serializer for POST /comics/{comicId}/genres/.
+    Validates that:
+    - The genre exists.
+    - The genre is active (is_active=True).
+    - The genre is not already assigned to this comic.
+    """
+    genre_id = serializers.CharField()
+
+    def validate_genre_id(self, value):
+        try:
+            genre = Genre.objects.get(id=value)
+        except Genre.DoesNotExist:
+            raise serializers.ValidationError(f"Genre with id '{value}' not found.")
+
+        if not genre.is_active:
+            raise serializers.ValidationError("Cannot assign an inactive genre.")
+
+        comic = self.context['comic']
+        if ComicGenreLink.objects.filter(comic=comic, genre=genre).exists():
+            raise serializers.ValidationError("This genre is already assigned to the comic.")
+
+        return genre
+
+    def create(self, validated_data):
+        comic   = self.context['comic']
+        genre   = validated_data['genre_id'] # This is a Genre instance populated in validate_genre_id
+        user_id = self.context['user_id']
+        now     = timezone.now()
+
+        return ComicGenreLink.objects.create(
+            id=str(uuid.uuid4()),
+            comic=comic,
+            genre=genre,
+            created_by_id=user_id,
+            created_at=now,
+        )
+
+

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -184,3 +184,69 @@ class ComicWriteSerializer(serializers.ModelSerializer):
 
         instance.save(update_fields=changed_fields)
         return instance
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CONTRIBUTOR MANAGEMENT  (add / list / update-role / remove)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Valid roles that can be assigned via the API.
+# CREATOR is intentionally excluded — it is tracked via comic.created_by.
+_ASSIGNABLE_CONTRIBUTOR_CHOICES = [
+    (ct.value, ct.label)
+    for ct in ComicContributorLink.ContributorType
+    if ct != ComicContributorLink.ContributorType.CREATOR
+]
+
+
+class ContributorWriteSerializer(serializers.Serializer):
+    """
+    Input for POST /comics/{comicId}/contributors/.
+    Resolves `muid` → User object during validation so create() receives a
+    ready-to-use User instance.
+    """
+    muid = serializers.CharField()
+    role = serializers.ChoiceField(choices=_ASSIGNABLE_CONTRIBUTOR_CHOICES)
+
+    def validate_muid(self, value):
+        try:
+            return User.objects.get(muid=value)
+        except User.DoesNotExist:
+            raise serializers.ValidationError(f'User with muid "{value}" not found.')
+
+    def create(self, validated_data):
+        comic   = self.context['comic']
+        user    = validated_data['muid']   # User object — resolved in validate_muid
+        role    = validated_data['role']
+        user_id = self.context['user_id']
+        now     = timezone.now()
+
+        return ComicContributorLink.objects.create(
+            id               = str(uuid.uuid4()),
+            comic            = comic,
+            user             = user,
+            contributor_type = role,
+            created_by_id    = user_id,
+            created_at       = now,
+        )
+
+
+class ContributorRoleUpdateSerializer(serializers.Serializer):
+    """Input for PATCH /comics/{comicId}/contributors/{contributorId}/."""
+    role = serializers.ChoiceField(choices=_ASSIGNABLE_CONTRIBUTOR_CHOICES)
+
+
+class ContributorListSerializer(serializers.ModelSerializer):
+    """
+    Output shape for GET /comics/{comicId}/contributors/.
+    Flattens the ComicContributorLink → User / Comic relations.
+    """
+    contributor_id = serializers.CharField(source='id')
+    user_id        = serializers.CharField(source='user.id')
+    role           = serializers.CharField(source='contributor_type')
+    name           = serializers.CharField(source='user.full_name')
+    comic_name     = serializers.CharField(source='comic.title')
+
+    class Meta:
+        model  = ComicContributorLink
+        fields = ['contributor_id', 'user_id', 'role', 'name', 'comic_name']

--- a/api/muComics/comic/urls.py
+++ b/api/muComics/comic/urls.py
@@ -1,17 +1,32 @@
 from django.urls import path
 
-from . import comic_views
+from . import comic_views, admin_views
 
 urlpatterns = [
+    # ── Genre management (Admin) ──────────────────────────────────────────────
+    # IMPORTANT: Must come BEFORE <str:comic_id>/ patterns to avoid shadowing.
+    path('genres/',
+         admin_views.GenreListCreateView.as_view(),
+         name='genre-list-create'),
+
+    path('genres/<str:genre_id>/',
+         admin_views.GenreDetailView.as_view(),
+         name='genre-detail'),
+
+    path('genres/<str:genre_id>/reinstate/',
+         admin_views.GenreReinstateView.as_view(),
+         name='genre-reinstate'),
+
+    # ── Comic CRUD ────────────────────────────────────────────────────────────
     # List + Create
-    path('',                         comic_views.ComicListCreateView.as_view(),  name='comic-list-create'),
+    path('', comic_views.ComicListCreateView.as_view(), name='comic-list-create'),
 
     # Detail + Update + Delete
-    path('<str:comic_id>/',          comic_views.ComicDetailView.as_view(),      name='comic-detail'),
+    path('<str:comic_id>/', comic_views.ComicDetailView.as_view(), name='comic-detail'),
 
     # Status workflow
-    path('<str:comic_id>/publish/',  comic_views.ComicPublishView.as_view(),     name='comic-publish'),
-    path('<str:comic_id>/archive/',  comic_views.ComicArchiveView.as_view(),     name='comic-archive'),
+    path('<str:comic_id>/publish/', comic_views.ComicPublishView.as_view(),  name='comic-publish'),
+    path('<str:comic_id>/archive/', comic_views.ComicArchiveView.as_view(),  name='comic-archive'),
 
     # Contributors
     path('<str:comic_id>/contributors/',
@@ -20,4 +35,13 @@ urlpatterns = [
     path('<str:comic_id>/contributors/<str:contributor_id>/',
          comic_views.ComicContributorDetailView.as_view(),
          name='comic-contributor-detail'),
+
+    # Comic Genre Links
+    path('<str:comic_id>/genres/',
+         comic_views.ComicGenreListView.as_view(),
+         name='comic-genre-assign'),
+    path('<str:comic_id>/genres/<str:link_id>/',
+         comic_views.ComicGenreDetailView.as_view(),
+         name='comic-genre-remove'),
 ]
+

--- a/api/muComics/comic/urls.py
+++ b/api/muComics/comic/urls.py
@@ -12,4 +12,12 @@ urlpatterns = [
     # Status workflow
     path('<str:comic_id>/publish/',  comic_views.ComicPublishView.as_view(),     name='comic-publish'),
     path('<str:comic_id>/archive/',  comic_views.ComicArchiveView.as_view(),     name='comic-archive'),
+
+    # Contributors
+    path('<str:comic_id>/contributors/',
+         comic_views.ComicContributorListView.as_view(),
+         name='comic-contributor-list'),
+    path('<str:comic_id>/contributors/<str:contributor_id>/',
+         comic_views.ComicContributorDetailView.as_view(),
+         name='comic-contributor-detail'),
 ]

--- a/db/comic.py
+++ b/db/comic.py
@@ -62,7 +62,7 @@ class Genre(models.Model):
     id         = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
     name       = models.CharField(max_length=75, unique=True)
     slug       = models.CharField(max_length=75, unique=True)
-
+    is_active= models.BooleanField(default=True)
     # Audit
     updated_by = models.ForeignKey(
         User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),


### PR DESCRIPTION
This pull request adds comprehensive admin and management endpoints for comic genres and contributors, and introduces robust logic for assigning and removing genres and contributors from comics. It also enhances filtering capabilities on comic listings. The main changes are grouped as follows:

**Genre Management Endpoints**  
* Added a new `admin_views.py` with full CRUD endpoints for comic genres, including soft deactivation and reactivation, with permissions enforced for admin-only actions.

**Comic Contributor Management**  
* Added endpoints to list, add, update, and remove comic contributors in `comic_views.py`, with permissions ensuring only the comic creator or admins can modify contributors.

**Comic Genre Assignment**  
* Added endpoints to assign and remove genres from comics, with access restricted to the comic creator, assigned editors, or admins.

**Filtering and Query Enhancements**  
* Enhanced the comics list endpoint to support filtering by one or more genre slugs (active genres only), and optimized queries with `prefetch_related` for genre data.

**Permission Helpers**  
* Introduced the `_is_creator_or_admin` helper function to centralize permission checks for creator/admin actions.

These changes significantly improve the API's flexibility and security for managing genres and contributors in the comics module.