### PR TITLE
feat(register): Google sign-up path with temp-token verification

### DIFF
--- a/api/register/register_helper.py
+++ b/api/register/register_helper.py
@@ -6,6 +6,7 @@ from utils.exception import CustomException
 from utils.response import CustomResponse
 
 
+AUTH_TIMEOUT = (3, 10)  # (connect seconds, read seconds) — B4
 
 
 def generate_muid(full_name):
@@ -21,6 +22,24 @@ def generate_muid(full_name):
     return muid
 
 
+def _post_auth(path, **kwargs):
+    """
+    Thin wrapper around requests.post that:
+    - Adds a connect + read timeout to every outbound call (B4).
+    - Converts network-level errors to CustomException so callers
+      can return a clean error without orphaning DB rows.
+    """
+    AUTH_DOMAIN = decouple.config("AUTH_DOMAIN")
+    try:
+        return requests.post(
+            f"{AUTH_DOMAIN}{path}", timeout=AUTH_TIMEOUT, **kwargs
+        )
+    except requests.RequestException:
+        raise CustomException(
+            "Auth service is temporarily unavailable. Please try again."
+        )
+
+
 def get_auth_token(muid, password):
     AUTH_DOMAIN = decouple.config("AUTH_DOMAIN")
     response = requests.post(
@@ -32,3 +51,44 @@ def get_auth_token(muid, password):
         raise CustomException(response.get("message"))
 
     return response.get("response")
+
+
+def verify_google_temp_token(temp_token):
+    """
+    Verifies a Google tempToken with the auth server.
+    Returns {'email', 'fullName'} or raises CustomException.
+
+    Checks body statusCode rather than HTTP status as defense-in-depth (B1/P4).
+    Null-guards the response to avoid KeyError on an unexpected empty body (B1).
+    """
+    resp = _post_auth(
+        "/api/v1/auth/google/verify-temp-token/",
+        data={"tempToken": temp_token},
+        headers={"protectionKey": decouple.config("PROTECTED_API_KEY")},
+    )
+    body = resp.json()
+    if body.get("statusCode") != 200:
+        raise CustomException(
+            body.get("message")
+            or "Invalid or expired Google session. Please sign in with Google again."
+        )
+    data = body.get("response") or {}
+    if not data.get("email"):
+        raise CustomException("Google verification returned no email.")
+    return data
+
+
+def get_auth_token_by_id(user_id):
+    """
+    Gets JWT tokens for a user by their UUID using the internal
+    TokenVerificationAPI endpoint.
+    Used for Google sign-ups where no password is set (NULL).
+    """
+    resp = _post_auth(
+        f"/api/v1/auth/token-verification/{user_id}/",
+        headers={"protectionKey": decouple.config("PROTECTED_API_KEY")},
+    )
+    body = resp.json()
+    if body.get("statusCode") != 200:
+        raise CustomException(body.get("message"))
+    return body.get("response")

--- a/api/register/register_helper.py
+++ b/api/register/register_helper.py
@@ -1,3 +1,6 @@
+import decouple
+import requests
+
 from db.user import User
 
 from utils.exception import CustomException

--- a/api/register/register_helper.py
+++ b/api/register/register_helper.py
@@ -1,9 +1,6 @@
-import decouple
-import requests
 from db.user import User
 
 from utils.exception import CustomException
-from utils.response import CustomResponse
 
 
 AUTH_TIMEOUT = (3, 10)  # (connect seconds, read seconds) — B4
@@ -41,16 +38,18 @@ def _post_auth(path, **kwargs):
 
 
 def get_auth_token(muid, password):
-    AUTH_DOMAIN = decouple.config("AUTH_DOMAIN")
-    response = requests.post(
-        f"{AUTH_DOMAIN}/api/v1/auth/user-authentication/",
+    resp = _post_auth(
+        "/api/v1/auth/user-authentication/",
         data={"emailOrMuid": muid, "password": password},
     )
-    response = response.json()
-    if response.get("statusCode") != 200:
-        raise CustomException(response.get("message"))
-
-    return response.get("response")
+    if not resp.ok:
+        raise CustomException(
+            "Auth service returned an unexpected error. Please try again."
+        )
+    body = resp.json()
+    if body.get("statusCode") != 200:
+        raise CustomException(body.get("message"))
+    return body.get("response")
 
 
 def verify_google_temp_token(temp_token):
@@ -66,6 +65,10 @@ def verify_google_temp_token(temp_token):
         data={"tempToken": temp_token},
         headers={"protectionKey": decouple.config("PROTECTED_API_KEY")},
     )
+    if not resp.ok:
+        raise CustomException(
+            "Auth service returned an unexpected error. Please try again."
+        )
     body = resp.json()
     if body.get("statusCode") != 200:
         raise CustomException(
@@ -88,6 +91,10 @@ def get_auth_token_by_id(user_id):
         f"/api/v1/auth/token-verification/{user_id}/",
         headers={"protectionKey": decouple.config("PROTECTED_API_KEY")},
     )
+    if not resp.ok:
+        raise CustomException(
+            "Auth service returned an unexpected error. Please try again."
+        )
     body = resp.json()
     if body.get("statusCode") != 200:
         raise CustomException(body.get("message"))

--- a/api/register/register_views.py
+++ b/api/register/register_views.py
@@ -362,7 +362,10 @@ class RegisterDataAPI(APIView):
 
             # B3: idempotent re-issue — if this email already has a NULL-password
             # user it is an orphan from a prior failed attempt; just re-issue tokens.
-            existing = User.objects.filter(email=user_data["email"]).first()
+            # Uses User.every (not User.objects) because the default ActiveUserManager
+            # excludes suspended accounts; their emails still occupy the unique constraint
+            # and would cause a DB-level IntegrityError on save().
+            existing = User.every.filter(email=user_data["email"]).first()
             if existing:
                 if existing.password:
                     # Has a real password → was registered via the classic path

--- a/api/register/register_views.py
+++ b/api/register/register_views.py
@@ -372,6 +372,11 @@ class RegisterDataAPI(APIView):
                     return CustomResponse(
                         general_message="An account with this email already exists. Please sign in normally."
                     ).get_failure_response()
+                if existing.suspended_at:
+                    # Suspended Google user — do not re-issue tokens
+                    return CustomResponse(
+                        general_message="This account has been suspended."
+                    ).get_failure_response()
                 # Orphan NULL-password user → re-issue tokens without creating a new row
                 try:
                     res_data = get_auth_token_by_id(existing.id)

--- a/api/register/register_views.py
+++ b/api/register/register_views.py
@@ -401,7 +401,11 @@ class RegisterDataAPI(APIView):
                     # NULL password — use TokenVerificationAPI (no password needed)
                     res_data = get_auth_token_by_id(user.id)  # raises → rolls back
                 else:
-                    password = request.data["user"]["password"]
+                    password = request.data.get("user", {}).get("password")
+                    if not password:
+                        return CustomResponse(
+                            general_message="Password is required for email registration."
+                        ).get_failure_response()
                     cache.set(f"flag_register_{user.muid}", True, timeout=5)
                     res_data = get_auth_token(user.muid, password)
         except CustomException as e:

--- a/api/register/register_views.py
+++ b/api/register/register_views.py
@@ -392,6 +392,13 @@ class RegisterDataAPI(APIView):
         if not create_user.is_valid():
             return CustomResponse(message=create_user.errors).get_failure_response()
 
+        if not is_google_signup:
+            password = request.data.get("user", {}).get("password")
+            if not password:
+                return CustomResponse(
+                    general_message="Password is required for email registration."
+                ).get_failure_response()
+
         try:
             with transaction.atomic():   # B3: roll back DB rows if token call fails
                 user = create_user.save()
@@ -401,11 +408,6 @@ class RegisterDataAPI(APIView):
                     # NULL password — use TokenVerificationAPI (no password needed)
                     res_data = get_auth_token_by_id(user.id)  # raises → rolls back
                 else:
-                    password = request.data.get("user", {}).get("password")
-                    if not password:
-                        return CustomResponse(
-                            general_message="Password is required for email registration."
-                        ).get_failure_response()
                     cache.set(f"flag_register_{user.muid}", True, timeout=5)
                     res_data = get_auth_token(user.muid, password)
         except CustomException as e:

--- a/api/register/register_views.py
+++ b/api/register/register_views.py
@@ -8,7 +8,7 @@ from db.user import Role, User, UserDomains, UserEndgoals
 from utils.response import CustomResponse
 from utils.types import OrganizationType
 from . import serializers
-from .register_helper import get_auth_token
+from .register_helper import get_auth_token, verify_google_temp_token, get_auth_token_by_id
 from django.views.decorators.cache import cache_page
 from django.core.cache import cache
 from mu_celery.task import send_email
@@ -330,8 +330,53 @@ class RegisterDataAPI(APIView):
         responses={200: serializers.UserDetailSerializer},
     )
     def post(self, request):
-        data = request.data
+        from django.db import transaction
+        from utils.exception import CustomException
+
+        data = request.data.copy()
         data = {key: value for key, value in data.items() if value}
+
+        is_google_signup = False
+        temp_token = data.pop("tempToken", None)
+
+        if temp_token:
+            # ── Google sign-up path ──────────────────────────────────────────
+            try:
+                google_data = verify_google_temp_token(temp_token)
+            except CustomException as e:
+                return CustomResponse(general_message=str(e)).get_failure_response()
+
+            user_data = dict(data.get("user", {}))
+
+            # Only email is forced from Google — client cannot spoof it (B5 / D1)
+            user_data["email"] = google_data["email"].strip().lower()
+
+            # full_name comes from the form (editable per D1).
+            # Fall back to the Google value if the client didn't send one.
+            if not user_data.get("full_name"):
+                user_data["full_name"] = google_data["fullName"]
+
+            user_data.pop("password", None)   # no password for Google users
+            data["user"] = user_data
+            is_google_signup = True
+
+            # B3: idempotent re-issue — if this email already has a NULL-password
+            # user it is an orphan from a prior failed attempt; just re-issue tokens.
+            existing = User.objects.filter(email=user_data["email"]).first()
+            if existing:
+                if existing.password:
+                    # Has a real password → was registered via the classic path
+                    return CustomResponse(
+                        general_message="An account with this email already exists. Please sign in normally."
+                    ).get_failure_response()
+                # Orphan NULL-password user → re-issue tokens without creating a new row
+                try:
+                    res_data = get_auth_token_by_id(existing.id)
+                except CustomException as e:
+                    return CustomResponse(general_message=str(e)).get_failure_response()
+                res_data["data"] = serializers.UserDetailSerializer(existing).data
+                return CustomResponse(response=res_data).get_success_response()
+            # ── End Google sign-up path ──────────────────────────────────────
 
         create_user = serializers.RegisterSerializer(
             data=data, context={"request": request}
@@ -339,11 +384,20 @@ class RegisterDataAPI(APIView):
         if not create_user.is_valid():
             return CustomResponse(message=create_user.errors).get_failure_response()
 
-        user = create_user.save()
-        cache.set(f"db_user_{user.muid}", user, timeout=60)
-        password = request.data["user"]["password"]
-        cache.set(f"flag_register_{user.muid}", True, timeout=5)
-        res_data = get_auth_token(user.muid, password)
+        try:
+            with transaction.atomic():   # B3: roll back DB rows if token call fails
+                user = create_user.save()
+                cache.set(f"db_user_{user.muid}", user, timeout=60)
+
+                if is_google_signup:
+                    # NULL password — use TokenVerificationAPI (no password needed)
+                    res_data = get_auth_token_by_id(user.id)  # raises → rolls back
+                else:
+                    password = request.data["user"]["password"]
+                    cache.set(f"flag_register_{user.muid}", True, timeout=5)
+                    res_data = get_auth_token(user.muid, password)
+        except CustomException as e:
+            return CustomResponse(general_message=str(e)).get_failure_response()
 
         response_data = serializers.UserDetailSerializer(user, many=False).data
 
@@ -354,7 +408,6 @@ class RegisterDataAPI(APIView):
         )
 
         res_data["data"] = response_data
-
         return CustomResponse(response=res_data).get_success_response()
 
 

--- a/api/register/serializers.py
+++ b/api/register/serializers.py
@@ -308,9 +308,8 @@ class UserSerializer(serializers.ModelSerializer):
             validated_data["full_name"]
         )
 
-        password = validated_data.pop("password")
-        hashed_password = make_password(password)
-        validated_data["password"] = hashed_password
+        password = validated_data.pop("password", None)
+        validated_data["password"] = make_password(password) if password else None
 
         user = super().create(validated_data)
 
@@ -366,6 +365,10 @@ class UserSerializer(serializers.ModelSerializer):
             "district",
             "area_of_interest",
         ]
+        extra_kwargs = {
+            # Google sign-ups don't supply a password — must be optional here.
+            "password": {"required": False, "allow_null": True},
+        }
 
 
 # class UserInterestSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Summary

Adds the mulearnbackend side of the Google sign-up redesign. A new Google user now submits a tempToken (issued by the auth server) alongside their registration form. The backend verifies the token internally, forces the Google-verified email onto the user row, and issues JWT tokens via TokenVerificationAPI (no password needed).