### PR TITLE
feat(muComics): implement chapter and page management APIs

### DIFF
--- a/alter-scripts/alter-1.63.py
+++ b/alter-scripts/alter-1.63.py
@@ -1,0 +1,97 @@
+import os
+import sys
+from pathlib import Path
+from decouple import config
+import django
+
+from connection import execute
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+os.chdir(BASE_DIR)
+sys.path.append(str(BASE_DIR))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mulearnbackend.settings')
+django.setup()
+
+DB_NAME = config('DATABASE_NAME')
+
+
+def table_exists(table_name: str) -> bool:
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.TABLES
+        WHERE TABLE_SCHEMA = '{DB_NAME}'
+          AND TABLE_NAME = '{table_name}';
+    """
+    result = execute(query)
+    return result and result[0][0] > 0
+
+
+def create_chapter_tables():
+    if not table_exists('chapter'):
+        execute(
+            """
+            CREATE TABLE `chapter` (
+              `id` varchar(36) NOT NULL,
+              `comic_id` varchar(36) NOT NULL,
+              `title` varchar(150) NOT NULL,
+              `slug` varchar(75) NOT NULL,
+              `description` text DEFAULT NULL,
+              `chapter_number` decimal(6,2) NOT NULL,
+              `cover_image_key` varchar(255) DEFAULT NULL,
+              `status` varchar(10) NOT NULL DEFAULT 'draft',
+              `published_at` datetime DEFAULT NULL,
+              `deleted_at` datetime DEFAULT NULL,
+              `deleted_by` varchar(36) DEFAULT NULL,
+              `updated_by` varchar(36) NOT NULL,
+              `updated_at` datetime NOT NULL,
+              `created_by` varchar(36) NOT NULL,
+              `created_at` datetime NOT NULL,
+              PRIMARY KEY (`id`),
+              UNIQUE KEY `slug` (`slug`),
+              UNIQUE KEY `uq_comic_chapter_number` (`comic_id`,`chapter_number`),
+              KEY `idx_chapter_status_created` (`status`,`created_at`),
+              KEY `idx_chapter_comic_status` (`comic_id`,`status`),
+              CONSTRAINT `fk_chapter_ref_comic_id` FOREIGN KEY (`comic_id`) REFERENCES `comic` (`id`) ON DELETE CASCADE,
+              CONSTRAINT `fk_chapter_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL,
+              CONSTRAINT `fk_chapter_ref_upd_by` FOREIGN KEY (`updated_by`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+              CONSTRAINT `fk_chapter_ref_cre_by` FOREIGN KEY (`created_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+            """
+        )
+        print("[alter-1.63] Created table 'chapter'.")
+    else:
+        print("[alter-1.63] Table 'chapter' already exists.")
+
+    if not table_exists('chapter_page'):
+        execute(
+            """
+            CREATE TABLE `chapter_page` (
+              `id` varchar(36) NOT NULL,
+              `chapter_id` varchar(36) NOT NULL,
+              `page_number` int unsigned NOT NULL,
+              `image_key` varchar(255) NOT NULL,
+              `deleted_at` datetime DEFAULT NULL,
+              `deleted_by` varchar(36) DEFAULT NULL,
+              `updated_by` varchar(36) NOT NULL,
+              `updated_at` datetime NOT NULL,
+              `created_by` varchar(36) NOT NULL,
+              `created_at` datetime NOT NULL,
+              PRIMARY KEY (`id`),
+              UNIQUE KEY `uq_chapter_page_number` (`chapter_id`,`page_number`),
+              KEY `idx_chapter_page_order` (`chapter_id`,`page_number`),
+              CONSTRAINT `fk_chapter_page_ref_chapter_id` FOREIGN KEY (`chapter_id`) REFERENCES `chapter` (`id`) ON DELETE CASCADE,
+              CONSTRAINT `fk_chapter_page_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL,
+              CONSTRAINT `fk_chapter_page_ref_upd_by` FOREIGN KEY (`updated_by`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+              CONSTRAINT `fk_chapter_page_ref_cre_by` FOREIGN KEY (`created_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+            """
+        )
+        print("[alter-1.63] Created table 'chapter_page'.")
+    else:
+        print("[alter-1.63] Table 'chapter_page' already exists.")
+
+
+if __name__ == '__main__':
+    create_chapter_tables()
+    execute("UPDATE system_setting SET value = '1.63', updated_at = now() WHERE `key` = 'db.version';")
+    print("[alter-1.63] Updated database version to 1.63.")

--- a/alter-scripts/alter-1.63.py
+++ b/alter-scripts/alter-1.63.py
@@ -5,6 +5,7 @@ from decouple import config
 import django
 
 from connection import execute
+from django.db import connection as django_connection
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 os.chdir(BASE_DIR)
@@ -16,14 +17,18 @@ DB_NAME = config('DATABASE_NAME')
 
 
 def table_exists(table_name: str) -> bool:
-    query = f"""
-        SELECT COUNT(*)
-        FROM information_schema.TABLES
-        WHERE TABLE_SCHEMA = '{DB_NAME}'
-          AND TABLE_NAME = '{table_name}';
-    """
-    result = execute(query)
-    return result and result[0][0] > 0
+    with django_connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*)
+            FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = %s
+              AND TABLE_NAME = %s;
+            """,
+            [DB_NAME, table_name]
+        )
+        row = cursor.fetchone()
+    return row and row[0] > 0
 
 
 def create_chapter_tables():

--- a/api/muComics/chapter/__init__.py
+++ b/api/muComics/chapter/__init__.py
@@ -1,0 +1,1 @@
+# Initialize the chapter API package.

--- a/api/muComics/chapter/chapter_views.py
+++ b/api/muComics/chapter/chapter_views.py
@@ -23,6 +23,19 @@ from .serializers import (
 )
 
 
+def check_chapter_archived(chapter):
+    """
+    Helper function to check if a chapter is archived.
+    If it is archived, returns a CustomResponse failure response.
+    Otherwise, returns None.
+    """
+    if chapter.status == Comic.Status.ARCHIVED:
+        return CustomResponse(
+            general_message='Archived chapters cannot be edited.'
+        ).get_failure_response()
+    return None
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # CHAPTER LIST + CREATE
 # ─────────────────────────────────────────────────────────────────────────────
@@ -174,10 +187,8 @@ class ChapterDetailView(APIView):
             ).get_unauthorized_response()
 
         # Archived chapters cannot be edited
-        if chapter.status == Comic.Status.ARCHIVED:
-            return CustomResponse(
-                general_message='Archived chapters cannot be edited.'
-            ).get_failure_response()
+        if error_response := check_chapter_archived(chapter):
+            return error_response
 
         serializer = ChapterWriteSerializer(
             chapter, data=request.data,
@@ -378,6 +389,10 @@ class ChapterPageListCreateAPI(APIView):
         if not chapter:
             return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
 
+        # Archived chapters cannot be edited
+        if error_response := check_chapter_archived(chapter):
+            return error_response
+
         # Permission: creator or assigned editor of the comic
         if not can_edit_comic(user_id, chapter.comic):
             return CustomResponse(
@@ -438,6 +453,10 @@ class ChapterPageDetailAPI(APIView):
         if error:
             return CustomResponse(general_message=error).get_failure_response(status_code=404, http_status_code=404)
 
+        # Archived chapters cannot be edited
+        if error_response := check_chapter_archived(page.chapter):
+            return error_response
+
         # Permission: creator or assigned editor of the comic
         if not can_edit_comic(user_id, page.chapter.comic):
             return CustomResponse(
@@ -477,6 +496,10 @@ class ChapterPageDetailAPI(APIView):
         page, error = self._get_page_or_error(page_id)
         if error:
             return CustomResponse(general_message=error).get_failure_response(status_code=404, http_status_code=404)
+
+        # Archived chapters cannot be edited
+        if error_response := check_chapter_archived(page.chapter):
+            return error_response
 
         # Permission: creator or assigned editor of the comic
         if not can_edit_comic(user_id, page.chapter.comic):
@@ -534,6 +557,10 @@ class ChapterPageReorderAPI(APIView):
         chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
         if not chapter:
             return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
+
+        # Archived chapters cannot be edited
+        if error_response := check_chapter_archived(chapter):
+            return error_response
 
         # Permission: creator or assigned editor of the comic
         if not can_edit_comic(user_id, chapter.comic):
@@ -718,6 +745,10 @@ class ChapterRegisterImagesAPI(APIView):
         chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
         if not chapter:
             return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
+
+        # Archived chapters cannot be edited
+        if error_response := check_chapter_archived(chapter):
+            return error_response
 
         # Permission: creator or assigned editor of the comic
         if not can_edit_comic(user_id, chapter.comic):

--- a/api/muComics/chapter/chapter_views.py
+++ b/api/muComics/chapter/chapter_views.py
@@ -73,7 +73,7 @@ class ChapterListCreateView(APIView):
             },
         )
 
-        serializer = ChapterListSerializer(paginated['queryset'], many=True)
+        serializer = ChapterListSerializer(paginated['queryset'], many=True, context={'request': request})
         return CustomResponse().paginated_response(
             data=serializer.data,
             pagination=paginated['pagination'],
@@ -118,7 +118,7 @@ class ChapterListCreateView(APIView):
         chapter = serializer.save()
         return CustomResponse(
             general_message=f'Chapter "{chapter.title}" created successfully.',
-            response=ChapterDetailSerializer(chapter).data,
+            response=ChapterDetailSerializer(chapter, context={'request': request}).data,
         ).get_success_response()
 
 
@@ -135,7 +135,7 @@ class ChapterDetailView(APIView):
     authentication_classes = [CustomizePermission]
 
     def _get_chapter_or_error(self, chapter_id):
-        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
+        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic', 'created_by', 'updated_by').first()
         if not chapter:
             return None, 'Chapter not found.'
         return chapter, None
@@ -152,7 +152,7 @@ class ChapterDetailView(APIView):
 
         return CustomResponse(
             general_message=f'Chapter "{chapter.title}" retrieved successfully.',
-            response=ChapterDetailSerializer(chapter).data,
+            response=ChapterDetailSerializer(chapter, context={'request': request}).data,
         ).get_success_response()
 
     @extend_schema(
@@ -192,7 +192,7 @@ class ChapterDetailView(APIView):
         chapter = serializer.save()
         return CustomResponse(
             general_message=f'Chapter "{chapter.title}" updated successfully.',
-            response=ChapterDetailSerializer(chapter).data,
+            response=ChapterDetailSerializer(chapter, context={'request': request}).data,
         ).get_success_response()
 
     @extend_schema(
@@ -348,12 +348,23 @@ class ChapterPageListCreateAPI(APIView):
         if not chapter:
             return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
 
-        pages = ChapterPage.objects.filter(chapter_id=chapter_id, deleted_at__isnull=True).order_by('page_number')
-        serializer = ChapterPageSerializer(pages, many=True)
-        return CustomResponse(
-            general_message='Pages retrieved successfully.',
-            response=serializer.data,
-        ).get_success_response()
+        pages = ChapterPage.objects.filter(chapter_id=chapter_id, deleted_at__isnull=True)
+        
+        paginated = CommonUtils.get_paginated_queryset(
+            pages,
+            request,
+            search_fields=[],
+            sort_fields={
+                'page_number': 'page_number',
+                'created_at': 'created_at',
+            },
+        )
+
+        serializer = ChapterPageSerializer(paginated['queryset'], many=True, context={'request': request})
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
 
     @extend_schema(
         tags=['muComics - Pages'],
@@ -394,7 +405,7 @@ class ChapterPageListCreateAPI(APIView):
 
         return CustomResponse(
             general_message='Page added successfully.',
-            response=ChapterPageSerializer(page).data,
+            response=ChapterPageSerializer(page, context={'request': request}).data,
         ).get_success_response()
 
 
@@ -450,7 +461,7 @@ class ChapterPageDetailAPI(APIView):
 
         return CustomResponse(
             general_message='Page updated successfully.',
-            response=ChapterPageSerializer(page).data,
+            response=ChapterPageSerializer(page, context={'request': request}).data,
         ).get_success_response()
 
     @extend_schema(
@@ -574,16 +585,21 @@ class ChapterPageReorderAPI(APIView):
             ).get_failure_response()
 
         now = timezone.now()
+        updated_pages = []
+        for item in page_orders:
+            page_id = item['id']
+            new_num = item['page_number']
+            page = pages_dict[page_id]
+            page.page_number = new_num
+            page.updated_by_id = user_id
+            page.updated_at = now
+            updated_pages.append(page)
+
         with transaction.atomic():
-            # Update each page number individually using update_fields
-            for item in page_orders:
-                page_id = item['id']
-                new_num = item['page_number']
-                page = pages_dict[page_id]
-                page.page_number = new_num
-                page.updated_by_id = user_id
-                page.updated_at = now
-                page.save(update_fields=['page_number', 'updated_by', 'updated_at'])
+            ChapterPage.objects.bulk_update(
+                updated_pages,
+                fields=['page_number', 'updated_by', 'updated_at']
+            )
 
         return CustomResponse(
             general_message='Pages reordered successfully.',

--- a/api/muComics/chapter/chapter_views.py
+++ b/api/muComics/chapter/chapter_views.py
@@ -1,0 +1,747 @@
+import os
+import uuid
+
+from decouple import config as decouple_config
+from django.core.files.storage import FileSystemStorage
+from django.utils import timezone
+from django.db import transaction
+from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers as s
+
+from db.comic import Comic, Chapter, ChapterPage
+from utils.permission import CustomizePermission, JWTUtils
+from utils.response import CustomResponse
+from utils.utils import CommonUtils
+
+from api.muComics.comic.comic_views import can_edit_comic
+from .serializers import (
+    ChapterListSerializer,
+    ChapterDetailSerializer,
+    ChapterWriteSerializer,
+    ChapterPageSerializer,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CHAPTER LIST + CREATE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterListCreateView(APIView):
+    """
+    GET  /muComics/chapters/?comic_id=<comic_id>  → List chapters of a comic
+    POST /muComics/chapters/                      → Create a chapter
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Chapters'],
+        description="List all active (non-deleted) chapters for a comic. Supports status filter and search by title.",
+        responses={200: ChapterListSerializer(many=True)},
+    )
+    def get(self, request):
+        comic_id = request.query_params.get('comic_id')
+        if not comic_id:
+            return CustomResponse(
+                general_message='comic_id query parameter is required.'
+            ).get_failure_response()
+
+        # Check if comic exists and is active
+        comic = Comic.objects.filter(id=comic_id, deleted_at__isnull=True).first()
+        if not comic:
+            return CustomResponse(
+                general_message='Comic not found.'
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        queryset = Chapter.objects.filter(comic_id=comic_id, deleted_at__isnull=True)
+
+        # Optional status filter: ?status=draft|published|archived
+        if status_filter := request.query_params.get('status'):
+            if status_filter not in Comic.Status.values:
+                return CustomResponse(
+                    general_message=f'Invalid status. Allowed: {", ".join(Comic.Status.values)}.'
+                ).get_failure_response()
+            queryset = queryset.filter(status=status_filter)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            queryset,
+            request,
+            search_fields=['title'],
+            sort_fields={
+                'chapter_number': 'chapter_number',
+                'created_at': 'created_at',
+            },
+        )
+
+        serializer = ChapterListSerializer(paginated['queryset'], many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+    @extend_schema(
+        tags=['muComics - Chapters'],
+        description="Create a new chapter inside a comic. Only creator or editors of the comic can create.",
+        request=ChapterWriteSerializer,
+        responses={200: ChapterDetailSerializer},
+    )
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic_id = request.data.get('comic')
+        
+        if not comic_id:
+            return CustomResponse(
+                general_message='comic is required.'
+            ).get_failure_response()
+
+        comic = Comic.objects.filter(id=comic_id, deleted_at__isnull=True).first()
+        if not comic:
+            return CustomResponse(
+                general_message='Comic not found.'
+            ).get_failure_response(status_code=404, http_status_code=404)
+
+        # Permission: creator or assigned editor of the comic
+        if not can_edit_comic(user_id, comic):
+            return CustomResponse(
+                general_message='You do not have permission to add a chapter to this comic.'
+            ).get_unauthorized_response()
+
+        serializer = ChapterWriteSerializer(
+            data=request.data,
+            context={'user_id': user_id},
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        chapter = serializer.save()
+        return CustomResponse(
+            general_message=f'Chapter "{chapter.title}" created successfully.',
+            response=ChapterDetailSerializer(chapter).data,
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CHAPTER DETAIL — GET / PATCH / DELETE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterDetailView(APIView):
+    """
+    GET    /muComics/chapters/<chapter_id>/   → detail
+    PATCH  /muComics/chapters/<chapter_id>/   → update
+    DELETE /muComics/chapters/<chapter_id>/   → soft delete (comic creator only)
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_chapter_or_error(self, chapter_id):
+        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
+        if not chapter:
+            return None, 'Chapter not found.'
+        return chapter, None
+
+    @extend_schema(
+        tags=['muComics - Chapters'],
+        description="Retrieve full detail of a chapter including pages.",
+        responses={200: ChapterDetailSerializer},
+    )
+    def get(self, request, chapter_id):
+        chapter, error = self._get_chapter_or_error(chapter_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response(status_code=404, http_status_code=404)
+
+        return CustomResponse(
+            general_message=f'Chapter "{chapter.title}" retrieved successfully.',
+            response=ChapterDetailSerializer(chapter).data,
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['muComics - Chapters'],
+        description="Update chapter details. Requires comic creator or editor permissions. Archived chapters cannot be edited.",
+        request=ChapterWriteSerializer,
+        responses={200: ChapterDetailSerializer},
+    )
+    def patch(self, request, chapter_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        chapter, error = self._get_chapter_or_error(chapter_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response(status_code=404, http_status_code=404)
+
+        # Permission: creator or assigned editor of the comic
+        if not can_edit_comic(user_id, chapter.comic):
+            return CustomResponse(
+                general_message='You do not have permission to edit this chapter.'
+            ).get_unauthorized_response()
+
+        # Archived chapters cannot be edited
+        if chapter.status == Comic.Status.ARCHIVED:
+            return CustomResponse(
+                general_message='Archived chapters cannot be edited.'
+            ).get_failure_response()
+
+        serializer = ChapterWriteSerializer(
+            chapter, data=request.data,
+            partial=True,
+            context={'user_id': user_id},
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        chapter = serializer.save()
+        return CustomResponse(
+            general_message=f'Chapter "{chapter.title}" updated successfully.',
+            response=ChapterDetailSerializer(chapter).data,
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['muComics - Chapters'],
+        description="Soft delete a chapter. Only the comic creator can delete a chapter.",
+        responses={200: inline_serializer(
+            name='ChapterDeleteResponse',
+            fields={'id': s.CharField()},
+        )},
+    )
+    def delete(self, request, chapter_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        chapter, error = self._get_chapter_or_error(chapter_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response(status_code=404, http_status_code=404)
+
+        # Only the comic creator can delete a chapter
+        if chapter.comic.created_by_id != user_id:
+            return CustomResponse(
+                general_message='Only the comic creator can delete this chapter.'
+            ).get_unauthorized_response()
+
+        now = timezone.now()
+        with transaction.atomic():
+            chapter.deleted_at = now
+            chapter.deleted_by_id = user_id
+            chapter.updated_by_id = user_id
+            chapter.updated_at = now
+            chapter.save(update_fields=['deleted_at', 'deleted_by', 'updated_by', 'updated_at'])
+
+            # Soft delete all linked pages too
+            ChapterPage.objects.filter(chapter=chapter, deleted_at__isnull=True).update(
+                deleted_at=now,
+                deleted_by_id=user_id,
+                updated_by_id=user_id,
+                updated_at=now
+            )
+
+        return CustomResponse(
+            general_message=f'Chapter "{chapter.title}" deleted successfully.',
+            response={'id': chapter.id},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CHAPTER STATUS ACTIONS (PUBLISH / ARCHIVE)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterPublishView(APIView):
+    """
+    POST /muComics/chapters/<chapter_id>/publish/  → Transition chapter status draft → published
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Chapters'],
+        description="Publish a chapter. Comic creator only.",
+        responses={200: inline_serializer(
+            name='ChapterPublishResponse',
+            fields={'id': s.CharField(), 'status': s.CharField()},
+        )},
+    )
+    def post(self, request, chapter_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
+        if not chapter:
+            return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
+
+        # Only comic creator can publish
+        if chapter.comic.created_by_id != user_id:
+            return CustomResponse(
+                general_message='Only the comic creator can publish this chapter.'
+            ).get_unauthorized_response()
+
+        if chapter.status == Comic.Status.PUBLISHED:
+            return CustomResponse(general_message='Chapter is already published.').get_failure_response()
+
+        if chapter.status == Comic.Status.ARCHIVED:
+            return CustomResponse(general_message='Archived chapters cannot be published.').get_failure_response()
+
+        now = timezone.now()
+        chapter.status = Comic.Status.PUBLISHED
+        chapter.published_at = now
+        chapter.updated_by_id = user_id
+        chapter.updated_at = now
+        chapter.save(update_fields=['status', 'published_at', 'updated_by', 'updated_at'])
+
+        return CustomResponse(
+            general_message=f'Chapter "{chapter.title}" published successfully.',
+            response={'id': chapter.id, 'status': Comic.Status.PUBLISHED},
+        ).get_success_response()
+
+
+class ChapterArchiveView(APIView):
+    """
+    POST /muComics/chapters/<chapter_id>/archive/  → Transition chapter status published/draft → archived
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Chapters'],
+        description="Archive a chapter. Comic creator only.",
+        responses={200: inline_serializer(
+            name='ChapterArchiveResponse',
+            fields={'id': s.CharField(), 'status': s.CharField()},
+        )},
+    )
+    def post(self, request, chapter_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
+        if not chapter:
+            return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
+
+        # Only comic creator can archive
+        if chapter.comic.created_by_id != user_id:
+            return CustomResponse(
+                general_message='Only the comic creator can archive this chapter.'
+            ).get_unauthorized_response()
+
+        if chapter.status == Comic.Status.ARCHIVED:
+            return CustomResponse(general_message='Chapter is already archived.').get_failure_response()
+
+        now = timezone.now()
+        chapter.status = Comic.Status.ARCHIVED
+        chapter.updated_by_id = user_id
+        chapter.updated_at = now
+        chapter.save(update_fields=['status', 'updated_by', 'updated_at'])
+
+        return CustomResponse(
+            general_message=f'Chapter "{chapter.title}" archived successfully.',
+            response={'id': chapter.id, 'status': Comic.Status.ARCHIVED},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PAGE LIST + ADD (CREATE)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterPageListCreateAPI(APIView):
+    """
+    GET  /muComics/chapters/<chapter_id>/pages/  → List pages of a chapter
+    POST /muComics/chapters/<chapter_id>/pages/  → Add a single page to a chapter
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Pages'],
+        description="List all active pages of a chapter, ordered by page number.",
+        responses={200: ChapterPageSerializer(many=True)},
+    )
+    def get(self, request, chapter_id):
+        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).first()
+        if not chapter:
+            return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
+
+        pages = ChapterPage.objects.filter(chapter_id=chapter_id, deleted_at__isnull=True).order_by('page_number')
+        serializer = ChapterPageSerializer(pages, many=True)
+        return CustomResponse(
+            general_message='Pages retrieved successfully.',
+            response=serializer.data,
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['muComics - Pages'],
+        description="Add a single page to a chapter. Comic creators or editors only.",
+        request=ChapterPageSerializer,
+        responses={200: ChapterPageSerializer},
+    )
+    def post(self, request, chapter_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
+        if not chapter:
+            return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
+
+        # Permission: creator or assigned editor of the comic
+        if not can_edit_comic(user_id, chapter.comic):
+            return CustomResponse(
+                general_message='You do not have permission to add a page to this chapter.'
+            ).get_unauthorized_response()
+
+        # Inject the chapter into request data
+        data = request.data.copy()
+        data['chapter'] = chapter_id
+
+        serializer = ChapterPageSerializer(data=data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        now = timezone.now()
+        page = serializer.save(
+            id=str(uuid.uuid4()),
+            created_by_id=user_id,
+            updated_by_id=user_id,
+            created_at=now,
+            updated_at=now,
+        )
+
+        return CustomResponse(
+            general_message='Page added successfully.',
+            response=ChapterPageSerializer(page).data,
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PAGE DETAIL (UPDATE / DELETE)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterPageDetailAPI(APIView):
+    """
+    PATCH  /muComics/pages/<page_id>/   → Update page details
+    DELETE /muComics/pages/<page_id>/   → Delete page (soft delete)
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_page_or_error(self, page_id):
+        page = ChapterPage.objects.filter(id=page_id, deleted_at__isnull=True).select_related('chapter__comic').first()
+        if not page:
+            return None, 'Page not found.'
+        return page, None
+
+    @extend_schema(
+        tags=['muComics - Pages'],
+        description="Update page information (e.g. page_number or image_key). Comic creators or editors only.",
+        request=ChapterPageSerializer,
+        responses={200: ChapterPageSerializer},
+    )
+    def patch(self, request, page_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        page, error = self._get_page_or_error(page_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response(status_code=404, http_status_code=404)
+
+        # Permission: creator or assigned editor of the comic
+        if not can_edit_comic(user_id, page.chapter.comic):
+            return CustomResponse(
+                general_message='You do not have permission to update this page.'
+            ).get_unauthorized_response()
+
+        serializer = ChapterPageSerializer(
+            page, data=request.data,
+            partial=True,
+        )
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message=serializer.errors
+            ).get_failure_response()
+
+        now = timezone.now()
+        page = serializer.save(
+            updated_by_id=user_id,
+            updated_at=now,
+        )
+
+        return CustomResponse(
+            general_message='Page updated successfully.',
+            response=ChapterPageSerializer(page).data,
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['muComics - Pages'],
+        description="Delete a page (soft delete). Comic creators or editors only.",
+        responses={200: inline_serializer(
+            name='PageDeleteResponse',
+            fields={'id': s.CharField()},
+        )},
+    )
+    def delete(self, request, page_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        page, error = self._get_page_or_error(page_id)
+        if error:
+            return CustomResponse(general_message=error).get_failure_response(status_code=404, http_status_code=404)
+
+        # Permission: creator or assigned editor of the comic
+        if not can_edit_comic(user_id, page.chapter.comic):
+            return CustomResponse(
+                general_message='You do not have permission to delete this page.'
+            ).get_unauthorized_response()
+
+        now = timezone.now()
+        page.deleted_at = now
+        page.deleted_by_id = user_id
+        page.updated_by_id = user_id
+        page.updated_at = now
+        page.save(update_fields=['deleted_at', 'deleted_by', 'updated_by', 'updated_at'])
+
+        return CustomResponse(
+            general_message='Page deleted successfully.',
+            response={'id': page.id},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PAGE REORDER (BULK UPDATE)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterPageReorderAPI(APIView):
+    """
+    POST /muComics/chapters/<chapter_id>/pages/reorder/  → Bulk update page order
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Pages'],
+        description="Bulk reorder page numbers in a chapter. Comic creators or editors only.",
+        request=inline_serializer(
+            name='PageReorderRequest',
+            fields={
+                'page_orders': s.ListField(
+                    child=inline_serializer(
+                        name='PageOrderItem',
+                        fields={
+                            'id': s.CharField(),
+                            'page_number': s.IntegerField(),
+                        }
+                    )
+                )
+            }
+        ),
+        responses={200: inline_serializer(
+            name='PageReorderResponse',
+            fields={'success': s.BooleanField()},
+        )},
+    )
+    def post(self, request, chapter_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
+        if not chapter:
+            return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
+
+        # Permission: creator or assigned editor of the comic
+        if not can_edit_comic(user_id, chapter.comic):
+            return CustomResponse(
+                general_message='You do not have permission to reorder pages.'
+            ).get_unauthorized_response()
+
+        page_orders = request.data.get('page_orders', [])
+        if not isinstance(page_orders, list) or not page_orders:
+            return CustomResponse(
+                general_message='page_orders must be a non-empty list of page ordering objects.'
+            ).get_failure_response()
+
+        # Validate duplicate page numbers or duplicate IDs in request
+        for item in page_orders:
+            if not isinstance(item, dict) or 'id' not in item or 'page_number' not in item:
+                return CustomResponse(
+                    general_message='Each page order item must be an object containing both "id" and "page_number".'
+                ).get_failure_response()
+
+        ids = [item['id'] for item in page_orders]
+        numbers = [item['page_number'] for item in page_orders]
+
+
+        if len(ids) != len(set(ids)):
+            return CustomResponse(general_message='Duplicate page IDs in request.').get_failure_response()
+        if len(numbers) != len(set(numbers)):
+            return CustomResponse(general_message='Duplicate page numbers in request.').get_failure_response()
+
+        # Check positive page numbers
+        if any(num < 1 for num in numbers):
+            return CustomResponse(general_message='Page numbers must be positive integers starting from 1.').get_failure_response()
+
+        # Load all pages in chapter to verify IDs belong to this chapter
+        pages_qs = ChapterPage.objects.filter(chapter_id=chapter_id, deleted_at__isnull=True)
+        pages_dict = {str(page.id): page for page in pages_qs}
+
+        # Verify all input IDs belong to the chapter
+        for page_id in ids:
+            if page_id not in pages_dict:
+                return CustomResponse(
+                    general_message=f'Page ID {page_id} does not exist in this chapter.'
+                ).get_failure_response(status_code=404, http_status_code=404)
+
+        # Verify all pages in DB are accounted for in the reorder request
+        if len(ids) != len(pages_dict):
+            return CustomResponse(
+                general_message='All active pages in the chapter must be included in the reorder request.'
+            ).get_failure_response()
+
+        now = timezone.now()
+        with transaction.atomic():
+            # Update each page number individually using update_fields
+            for item in page_orders:
+                page_id = item['id']
+                new_num = item['page_number']
+                page = pages_dict[page_id]
+                page.page_number = new_num
+                page.updated_by_id = user_id
+                page.updated_at = now
+                page.save(update_fields=['page_number', 'updated_by', 'updated_at'])
+
+        return CustomResponse(
+            general_message='Pages reordered successfully.',
+            response={'success': True},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# UPLOAD APIS (PRESIGNED UPLOAD URL & REGISTER PAGES)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterUploadURLAPI(APIView):
+    """
+    POST /muComics/chapters/upload-url/  → Direct file upload (images and PDFs) to local storage.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Uploads'],
+        description="Upload a media file (Image or PDF) to local storage.",
+        request={
+            'multipart/form-data': inline_serializer(
+                name='ChapterUploadRequest',
+                fields={
+                    'file': s.FileField(),
+                }
+            )
+        },
+        responses={200: inline_serializer(
+            name='UploadURLResponse',
+            fields={
+                'upload_url': s.CharField(),
+                'image_key': s.CharField(),
+            }
+        )},
+    )
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        file_obj = request.FILES.get('file')
+
+        if file_obj is None:
+            return CustomResponse(
+                general_message='No file provided.'
+            ).get_failure_response()
+
+        content_type = file_obj.content_type or ''
+        file_name = file_obj.name or ''
+        ext = os.path.splitext(file_name)[1].lower()
+
+        is_image = content_type.startswith("image/") or ext in ['.jpg', '.jpeg', '.png', '.webp', '.gif']
+        is_pdf = content_type == "application/pdf" or ext == ".pdf"
+
+        if not (is_image or is_pdf):
+            return CustomResponse(
+                general_message='Unsupported file type. Only images and PDFs are allowed.'
+            ).get_failure_response()
+
+        if is_image:
+            if file_obj.size > 5 * 1024 * 1024:
+                return CustomResponse(
+                    general_message='Image file must be under 5 MB.'
+                ).get_failure_response()
+            try:
+                from PIL import Image
+                img = Image.open(file_obj)
+                img.verify()
+                file_obj.seek(0)
+            except Exception:
+                return CustomResponse(
+                    general_message='Invalid or corrupted image file.'
+                ).get_failure_response()
+
+        elif is_pdf:
+            if file_obj.size > 20 * 1024 * 1024:
+                return CustomResponse(
+                    general_message='PDF file must be under 20 MB.'
+                ).get_failure_response()
+
+        fs = FileSystemStorage()
+        unique_id = uuid.uuid4()
+        image_key = f"comics/chapters/{unique_id}{ext}"
+        
+        fs.save(image_key, file_obj)
+
+        be_domain = decouple_config("BE_DOMAIN_NAME")
+        upload_url = f"{be_domain}{fs.url(image_key)}"
+
+        return CustomResponse(
+            general_message='File uploaded successfully.',
+            response={
+                'upload_url': upload_url,
+                'image_key': image_key,
+            }
+        ).get_success_response()
+
+
+class ChapterRegisterImagesAPI(APIView):
+    """
+    POST /muComics/chapters/<chapter_id>/pages/register/  → Register uploaded local media paths as chapter pages
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics - Uploads'],
+        description="Register multiple uploaded local media paths as sequential pages inside a chapter. Creator/editors only.",
+        request=inline_serializer(
+            name='RegisterImagesRequest',
+            fields={
+                'image_keys': s.ListField(child=s.CharField())
+            }
+        ),
+        responses={200: ChapterPageSerializer(many=True)},
+    )
+    def post(self, request, chapter_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        chapter = Chapter.objects.filter(id=chapter_id, deleted_at__isnull=True).select_related('comic').first()
+        if not chapter:
+            return CustomResponse(general_message='Chapter not found.').get_failure_response(status_code=404, http_status_code=404)
+
+        # Permission: creator or assigned editor of the comic
+        if not can_edit_comic(user_id, chapter.comic):
+            return CustomResponse(
+                general_message='You do not have permission to register pages in this chapter.'
+            ).get_unauthorized_response()
+
+        image_keys = request.data.get('image_keys', [])
+        if not isinstance(image_keys, list) or not image_keys:
+            return CustomResponse(
+                general_message='image_keys must be a non-empty list of string paths.'
+            ).get_failure_response()
+
+        # Validate string image keys
+        if not all(isinstance(k, str) and k.strip() for k in image_keys):
+            return CustomResponse(
+                general_message='Each image key must be a non-empty string.'
+            ).get_failure_response()
+
+        now = timezone.now()
+        with transaction.atomic():
+            # Get the current maximum page number in the chapter
+            max_page = ChapterPage.objects.filter(chapter_id=chapter_id, deleted_at__isnull=True).order_by('-page_number').first()
+            start_num = max_page.page_number if max_page else 0
+
+            created_pages = []
+            for i, image_key in enumerate(image_keys, start=1):
+                page = ChapterPage.objects.create(
+                    id=str(uuid.uuid4()),
+                    chapter=chapter,
+                    page_number=start_num + i,
+                    image_key=image_key,
+                    created_by_id=user_id,
+                    updated_by_id=user_id,
+                    created_at=now,
+                    updated_at=now,
+                )
+                created_pages.append(page)
+
+        return CustomResponse(
+            general_message=f'Registered {len(created_pages)} pages successfully.',
+            response=ChapterPageSerializer(created_pages, many=True, context={'request': request}).data,
+        ).get_success_response()

--- a/api/muComics/chapter/serializers.py
+++ b/api/muComics/chapter/serializers.py
@@ -1,0 +1,233 @@
+import uuid
+
+from django.utils.text import slugify
+from django.utils import timezone
+from rest_framework import serializers
+
+from db.comic import Chapter, ChapterPage, Comic
+from api.muComics.comic.serializers import MinimalUserSerializer
+from api.dashboard.media_content.image_utils import resolve_image_url
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CHAPTER PAGE SERIALIZER
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterPageSerializer(serializers.ModelSerializer):
+    """
+    Serializer representing individual pages in a chapter.
+    """
+    class Meta:
+        model = ChapterPage
+        fields = ['id', 'chapter', 'page_number', 'image_key', 'created_at']
+        read_only_fields = ['id', 'created_at']
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if data.get('image_key'):
+            data['image_key'] = resolve_image_url(data['image_key'], self.context.get('request'))
+        return data
+
+    def validate_page_number(self, value):
+        if value < 1:
+            raise serializers.ValidationError("Page number must be a positive integer starting from 1.")
+        return value
+
+    def validate_image_key(self, value):
+        value = value.strip() if value else ""
+        if not value:
+            raise serializers.ValidationError("Image key must not be blank.")
+        return value
+
+    def validate(self, attrs):
+        chapter = attrs.get('chapter') or (self.instance.chapter if self.instance else None)
+        page_number = attrs.get('page_number') or (self.instance.page_number if self.instance else None)
+
+        if chapter and page_number is not None:
+            # Check unique constraint on (chapter, page_number) excluding deleted pages
+            qs = ChapterPage.objects.filter(chapter=chapter, page_number=page_number, deleted_at__isnull=True)
+            if self.instance:
+                qs = qs.exclude(id=self.instance.id)
+            if qs.exists():
+                raise serializers.ValidationError({
+                    'page_number': 'A page with this number already exists in this chapter.'
+                })
+        return attrs
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CHAPTER LIST (lean - for paginated lists/feeds)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterListSerializer(serializers.ModelSerializer):
+    """
+    Lean serializer for listing chapters (e.g. comic chapter index).
+    """
+    class Meta:
+        model = Chapter
+        fields = [
+            'id', 'comic', 'title', 'slug', 'chapter_number',
+            'cover_image_key', 'status', 'published_at', 'created_at',
+        ]
+        read_only_fields = fields
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if data.get('cover_image_key'):
+            data['cover_image_key'] = resolve_image_url(data['cover_image_key'], self.context.get('request'))
+        return data
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CHAPTER DETAIL (full - detail, create, or update responses)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterDetailSerializer(serializers.ModelSerializer):
+    """
+    Full serializer for chapter retrieval.
+    """
+    created_by = MinimalUserSerializer(read_only=True)
+    updated_by = MinimalUserSerializer(read_only=True)
+    pages      = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Chapter
+        fields = [
+            'id', 'comic', 'title', 'slug', 'description', 'chapter_number',
+            'cover_image_key', 'status', 'published_at',
+            'pages',
+            'created_by', 'created_at',
+            'updated_by', 'updated_at',
+        ]
+        read_only_fields = fields
+
+    def get_pages(self, obj):
+        active_pages = obj.pages.filter(deleted_at__isnull=True).order_by('page_number')
+        return ChapterPageSerializer(active_pages, many=True, context=self.context).data
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if data.get('cover_image_key'):
+            data['cover_image_key'] = resolve_image_url(data['cover_image_key'], self.context.get('request'))
+        return data
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CHAPTER WRITE (create / update input)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ChapterWriteSerializer(serializers.ModelSerializer):
+    """
+    Input serializer for POST /chapters/ and PATCH /chapters/<id>/.
+    Caller never directly specifies slug, status, published_at, or audit fields.
+    """
+    class Meta:
+        model = Chapter
+        fields = ['comic', 'title', 'description', 'chapter_number', 'cover_image_key']
+        extra_kwargs = {
+            'title': {
+                'required': True,
+                'max_length': 150,
+            },
+            'chapter_number': {
+                'required': True,
+            },
+            'description': {
+                'required': False,
+                'allow_null': True,
+                'allow_blank': True,
+            },
+            'cover_image_key': {
+                'required': False,
+                'allow_null': True,
+                'allow_blank': True,
+                'max_length': 255,
+            },
+        }
+
+    def validate_title(self, value):
+        if not value or not value.strip():
+            raise serializers.ValidationError('Title must not be blank.')
+        return value.strip()
+
+    def validate_chapter_number(self, value):
+        if value < 0:
+            raise serializers.ValidationError('Chapter number must not be negative.')
+        return value
+
+    def _generate_unique_slug(self, title):
+        """
+        Generates a URL-safe slug from title.
+        Appends an incrementing counter if the base slug already exists.
+        Slug is truncated to 70 chars before suffix to stay within max_length=75.
+        """
+        base = slugify(title)[:70]
+        slug = base
+        counter = 1
+        exclude_id = self.instance.id if self.instance else None
+        while True:
+            qs = Chapter.objects.filter(slug=slug)
+            if exclude_id:
+                qs = qs.exclude(id=exclude_id)
+            if not qs.exists():
+                break
+            slug = f'{base}-{counter}'
+            counter += 1
+        return slug
+
+    def validate(self, attrs):
+        comic = attrs.get('comic') or (self.instance.comic if self.instance else None)
+        chapter_number = attrs.get('chapter_number') or (self.instance.chapter_number if self.instance else None)
+
+        if comic and chapter_number is not None:
+            # Check unique constraint on (comic, chapter_number) excluding deleted chapters
+            qs = Chapter.objects.filter(comic=comic, chapter_number=chapter_number, deleted_at__isnull=True)
+            if self.instance:
+                qs = qs.exclude(id=self.instance.id)
+            if qs.exists():
+                raise serializers.ValidationError({
+                    'chapter_number': 'A chapter with this number already exists for this comic.'
+                })
+        return attrs
+
+    def create(self, validated_data):
+        user_id = self.context['user_id']
+        now     = timezone.now()
+
+        validated_data['id']            = str(uuid.uuid4())
+        validated_data['slug']          = self._generate_unique_slug(validated_data['title'])
+        validated_data['created_by_id'] = user_id
+        validated_data['updated_by_id'] = user_id
+        validated_data['created_at']    = now
+        validated_data['updated_at']    = now
+        return Chapter.objects.create(**validated_data)
+
+    def update(self, instance, validated_data):
+        user_id = self.context['user_id']
+        now     = timezone.now()
+
+        # Chapter parent comic cannot be modified on update
+        if 'comic' in validated_data:
+            if validated_data['comic'] != instance.comic:
+                raise serializers.ValidationError({'comic': 'Chapter parent comic cannot be modified.'})
+            validated_data.pop('comic')
+
+        # Re-generate slug only when title changes
+        if 'title' in validated_data and validated_data['title'] != instance.title:
+            validated_data['slug'] = self._generate_unique_slug(validated_data['title'])
+
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+
+        instance.updated_by_id = user_id
+        instance.updated_at    = now
+
+        # Only write columns this PATCH actually touched.
+        changed_fields = list(validated_data.keys())
+        if 'title' in changed_fields:
+            changed_fields.append('slug')
+        changed_fields += ['updated_by', 'updated_at']
+
+        instance.save(update_fields=changed_fields)
+        return instance
+

--- a/api/muComics/chapter/serializers.py
+++ b/api/muComics/chapter/serializers.py
@@ -40,8 +40,8 @@ class ChapterPageSerializer(serializers.ModelSerializer):
         return value
 
     def validate(self, attrs):
-        chapter = attrs.get('chapter') or (self.instance.chapter if self.instance else None)
-        page_number = attrs.get('page_number') or (self.instance.page_number if self.instance else None)
+        chapter = attrs.get('chapter') if 'chapter' in attrs else (self.instance.chapter if self.instance else None)
+        page_number = attrs.get('page_number') if 'page_number' in attrs else (self.instance.page_number if self.instance else None)
 
         if chapter and page_number is not None:
             # Check unique constraint on (chapter, page_number) excluding deleted pages
@@ -176,8 +176,8 @@ class ChapterWriteSerializer(serializers.ModelSerializer):
         return slug
 
     def validate(self, attrs):
-        comic = attrs.get('comic') or (self.instance.comic if self.instance else None)
-        chapter_number = attrs.get('chapter_number') or (self.instance.chapter_number if self.instance else None)
+        comic = attrs.get('comic') if 'comic' in attrs else (self.instance.comic if self.instance else None)
+        chapter_number = attrs.get('chapter_number') if 'chapter_number' in attrs else (self.instance.chapter_number if self.instance else None)
 
         if comic and chapter_number is not None:
             # Check unique constraint on (comic, chapter_number) excluding deleted chapters

--- a/api/muComics/chapter/urls.py
+++ b/api/muComics/chapter/urls.py
@@ -1,0 +1,30 @@
+from django.urls import path
+
+from . import chapter_views
+
+urlpatterns = [
+    # Upload helper API (positioned first to avoid conflict with chapter_id string parameter)
+    path('upload-url/',                                 chapter_views.ChapterUploadURLAPI.as_view(),     name='chapter-upload-url'),
+
+    # Chapters List + Create
+    path('',                                            chapter_views.ChapterListCreateView.as_view(),   name='chapter-list-create'),
+    
+    # Chapter Detail + Update + Delete
+    path('<str:chapter_id>/',                           chapter_views.ChapterDetailView.as_view(),       name='chapter-detail'),
+    
+    # Chapter Status actions
+    path('<str:chapter_id>/publish/',                   chapter_views.ChapterPublishView.as_view(),      name='chapter-publish'),
+    path('<str:chapter_id>/archive/',                   chapter_views.ChapterArchiveView.as_view(),      name='chapter-archive'),
+    
+    # Pages List + Add
+    path('<str:chapter_id>/pages/',                     chapter_views.ChapterPageListCreateAPI.as_view(), name='chapter-page-list-create'),
+    
+    # Reorder Pages
+    path('<str:chapter_id>/pages/reorder/',             chapter_views.ChapterPageReorderAPI.as_view(),   name='chapter-page-reorder'),
+    
+    # Register Uploaded Images as Pages
+    path('<str:chapter_id>/pages/register/',            chapter_views.ChapterRegisterImagesAPI.as_view(), name='chapter-page-register-images'),
+    
+    # Page Detail (Update / Delete)
+    path('pages/<str:page_id>/',                        chapter_views.ChapterPageDetailAPI.as_view(),     name='chapter-page-detail'),
+]

--- a/api/muComics/urls.py
+++ b/api/muComics/urls.py
@@ -3,4 +3,5 @@ from django.urls import path, include
 urlpatterns = [
     path('comics/', include('api.muComics.comic.urls')),
     path('comments/', include('api.muComics.comment.urls')),
+    path('chapters/', include('api.muComics.chapter.urls')),
 ]

--- a/db/comic.py
+++ b/db/comic.py
@@ -146,3 +146,90 @@ class ComicContributorLink(models.Model):
             models.Index(fields=['user'],                      name='idx_contributor_user'),
             models.Index(fields=['comic', 'contributor_type'], name='idx_contributor_comic_type'),
         ]
+
+
+class Chapter(models.Model):
+    id              = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    comic           = models.ForeignKey(
+        Comic, on_delete=models.CASCADE,
+        db_column='comic_id', related_name='chapters'
+    )
+    title           = models.CharField(max_length=150)
+    slug            = models.CharField(max_length=75, unique=True)
+    description     = models.TextField(blank=True, null=True)
+    chapter_number  = models.DecimalField(max_digits=6, decimal_places=2)
+    cover_image_key = models.CharField(max_length=255, blank=True, null=True)
+
+    status          = models.CharField(
+        max_length=10, choices=Comic.Status.choices, default=Comic.Status.DRAFT
+    )
+
+    published_at    = models.DateTimeField(blank=True, null=True)
+
+    # Soft delete
+    deleted_at      = models.DateTimeField(blank=True, null=True)
+    deleted_by      = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        db_column='deleted_by', related_name='chapter_deleted_by'
+    )
+
+    # Audit
+    updated_by      = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+        db_column='updated_by', related_name='chapter_updated_by'
+    )
+    updated_at      = models.DateTimeField()
+
+    created_by      = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+        db_column='created_by', related_name='chapter_created_by'
+    )
+    created_at      = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'chapter'
+        unique_together = [('comic', 'chapter_number')]
+        indexes = [
+            models.Index(fields=['status', 'created_at'], name='idx_chapter_status_created'),
+            models.Index(fields=['comic', 'status'],       name='idx_chapter_comic_status'),
+        ]
+
+
+class ChapterPage(models.Model):
+    id              = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    chapter         = models.ForeignKey(
+        Chapter, on_delete=models.CASCADE,
+        db_column='chapter_id', related_name='pages'
+    )
+    page_number     = models.PositiveIntegerField()
+    image_key       = models.CharField(max_length=255)
+
+    # Soft delete
+    deleted_at      = models.DateTimeField(blank=True, null=True)
+    deleted_by      = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        db_column='deleted_by', related_name='chapter_page_deleted_by'
+    )
+
+    # Audit
+    updated_by      = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+        db_column='updated_by', related_name='chapter_page_updated_by'
+    )
+    updated_at      = models.DateTimeField()
+
+    created_by      = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+        db_column='created_by', related_name='chapter_page_created_by'
+    )
+    created_at      = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'chapter_page'
+        unique_together = [('chapter', 'page_number')]
+        indexes = [
+            models.Index(fields=['chapter', 'page_number'], name='idx_chapter_page_order'),
+        ]
+

--- a/schema.sql
+++ b/schema.sql
@@ -2282,6 +2282,70 @@ CREATE TABLE `comic_comment` (
   CONSTRAINT `fk_comic_comment_ref_cre_by` FOREIGN KEY (`created_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `chapter`
+--
+
+DROP TABLE IF EXISTS `chapter`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `chapter` (
+  `id` varchar(36) NOT NULL,
+  `comic_id` varchar(36) NOT NULL,
+  `title` varchar(150) NOT NULL,
+  `slug` varchar(75) NOT NULL,
+  `description` text DEFAULT NULL,
+  `chapter_number` decimal(6,2) NOT NULL,
+  `cover_image_key` varchar(255) DEFAULT NULL,
+  `status` varchar(10) NOT NULL DEFAULT 'draft',
+  `published_at` datetime DEFAULT NULL,
+  `deleted_at` datetime DEFAULT NULL,
+  `deleted_by` varchar(36) DEFAULT NULL,
+  `updated_by` varchar(36) NOT NULL,
+  `updated_at` datetime NOT NULL,
+  `created_by` varchar(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `slug` (`slug`),
+  UNIQUE KEY `uq_comic_chapter_number` (`comic_id`,`chapter_number`),
+  KEY `idx_chapter_status_created` (`status`,`created_at`),
+  KEY `idx_chapter_comic_status` (`comic_id`,`status`),
+  CONSTRAINT `fk_chapter_ref_comic_id` FOREIGN KEY (`comic_id`) REFERENCES `comic` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_chapter_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_chapter_ref_upd_by` FOREIGN KEY (`updated_by`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_chapter_ref_cre_by` FOREIGN KEY (`created_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `chapter_page`
+--
+
+DROP TABLE IF EXISTS `chapter_page`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `chapter_page` (
+  `id` varchar(36) NOT NULL,
+  `chapter_id` varchar(36) NOT NULL,
+  `page_number` int unsigned NOT NULL,
+  `image_key` varchar(255) NOT NULL,
+  `deleted_at` datetime DEFAULT NULL,
+  `deleted_by` varchar(36) DEFAULT NULL,
+  `updated_by` varchar(36) NOT NULL,
+  `updated_at` datetime NOT NULL,
+  `created_by` varchar(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_chapter_page_number` (`chapter_id`,`page_number`),
+  KEY `idx_chapter_page_order` (`chapter_id`,`page_number`),
+  CONSTRAINT `fk_chapter_page_ref_chapter_id` FOREIGN KEY (`chapter_id`) REFERENCES `chapter` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_chapter_page_ref_del_by` FOREIGN KEY (`deleted_by`) REFERENCES `user` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_chapter_page_ref_upd_by` FOREIGN KEY (`updated_by`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_chapter_page_ref_cre_by` FOREIGN KEY (`created_by`) REFERENCES `user` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 SET @@SESSION.SQL_LOG_BIN = @MYSQLDUMP_TEMP_LOG_BIN;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 


### PR DESCRIPTION
## Summary

This PR introduces the Chapter Management module for MuComics, including complete CRUD operations for chapters and chapter pages, media upload support, and related API endpoints.

## Features Implemented

### Chapter Management
- Create chapter
- List chapters
- Retrieve chapter details
- Update chapter
- Delete chapter (soft delete)
- Publish chapter
- Archive chapter

### Chapter Page Management
- Add pages to a chapter
- List chapter pages
- Update page details
- Delete pages
- Reorder chapter pages
- Register uploaded images as pages

### Media Upload
- Upload helper endpoint
- Image validation
- PDF upload support
- File size validation
- Generated upload key handling

### Database
- Added `chapter` table
- Added `chapter_page` table
- Database alter script for schema creation

### API
- Added serializers for chapter and page operations
- Added request validation
- Permission checks for chapter management
- OpenAPI (`drf-spectacular`) documentation for all endpoints


