### PR TITLE
fix: Refactor company model to link with organization via foreign key

### DIFF
--- a/api/dashboard/company/company_views.py
+++ b/api/dashboard/company/company_views.py
@@ -397,12 +397,7 @@ class CompanyMentorListAPI(APIView):
                 general_message="Verified company profile not found."
             ).get_failure_response(status_code=404)
 
-        from db.organization import Organization
-        from utils.types import OrganizationType
-        org = Organization.objects.filter(
-            title=company.name,
-            org_type=OrganizationType.COMPANY.value,
-        ).first()
+        org = company.org
 
         if not org:
             return CustomResponse(

--- a/api/dashboard/company/serializers.py
+++ b/api/dashboard/company/serializers.py
@@ -197,10 +197,19 @@ class CompanyUpdateSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         validated_data['updated_at'] = DateTimeUtils.get_current_utc_time()
         validated_data['updated_by'] = self.context.get("user_id", instance.company_user_id)
-        
+
+        new_name = validated_data.get("name")
+        rename = new_name and new_name != instance.name
+
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
         instance.save()
+
+        if rename and instance.org:
+            instance.org.title = new_name
+            instance.org.updated_at = DateTimeUtils.get_current_utc_time()
+            instance.org.save(update_fields=["title", "updated_at"])
+
         return instance
 
 class CompanyListSerializer(serializers.ModelSerializer):

--- a/api/dashboard/company/serializers.py
+++ b/api/dashboard/company/serializers.py
@@ -262,7 +262,7 @@ class CompanyVerifySerializer(serializers.Serializer):
             instance.rejection_reason = None
 
             # ── Ensure the company's Organization row exists ─────────────────
-            org = Organization.objects.filter(
+            org = instance.org or Organization.objects.filter(
                 title=instance.name,
                 org_type=OrganizationType.COMPANY.value,
             ).first()
@@ -278,6 +278,7 @@ class CompanyVerifySerializer(serializers.Serializer):
                     created_at=DateTimeUtils.get_current_utc_time(),
                     updated_at=DateTimeUtils.get_current_utc_time(),
                 )
+            instance.org = org
 
             # ── Link the company creator to the org ──────────────────────────
             from db.organization import UserOrganizationLink
@@ -377,10 +378,7 @@ class CompanyMentorNominateSerializer(serializers.Serializer):
             )
 
         # ── Resolve company → Organization row ──────────────────────────────
-        org = Organization.objects.filter(
-            title=company.name,
-            org_type=OrganizationType.COMPANY.value,
-        ).first()
+        org = company.org
         if not org:
             raise serializers.ValidationError(
                 "Company organization record not found. Ensure the company is verified."

--- a/api/dashboard/company/serializers.py
+++ b/api/dashboard/company/serializers.py
@@ -1,5 +1,6 @@
 import uuid
 from rest_framework import serializers
+from django.db import transaction
 from django.utils.text import slugify
 
 from db.company import Company
@@ -203,12 +204,14 @@ class CompanyUpdateSerializer(serializers.ModelSerializer):
 
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
-        instance.save()
 
-        if rename and instance.org:
-            instance.org.title = new_name
-            instance.org.updated_at = DateTimeUtils.get_current_utc_time()
-            instance.org.save(update_fields=["title", "updated_at"])
+        with transaction.atomic():
+            instance.save()
+
+            if rename and instance.org:
+                instance.org.title = new_name
+                instance.org.updated_at = DateTimeUtils.get_current_utc_time()
+                instance.org.save(update_fields=["title", "updated_at"])
 
         return instance
 

--- a/api/dashboard/company/task_views.py
+++ b/api/dashboard/company/task_views.py
@@ -83,9 +83,8 @@ class CompanyTaskListCreateAPI(APIView):
         if approval_status:
             queryset = queryset.filter(approval_status=approval_status)
         else:
-            # Exclude soft-deleted tasks (active=False after being previously approved)
-            # Only exclude tasks that are inactive AND already approved/rejected (not pending)
-            queryset = queryset.exclude(active=False, approval_status="approved")
+            # Exclude soft-deleted tasks (active=False), regardless of approval_status
+            queryset = queryset.exclude(active=False)
 
         paginated = CommonUtils.get_paginated_queryset(
             queryset,

--- a/api/dashboard/events/manage_views.py
+++ b/api/dashboard/events/manage_views.py
@@ -67,13 +67,9 @@ def _get_user_company_org_ids(user_id, roles):
 
     if RoleType.COMPANY.value in roles:
         from db.company import Company
-        from db.organization import Organization
-        from utils.types import OrganizationType
         company = Company.objects.filter(company_user_id=user_id, status="verified").first()
-        if company:
-            org = Organization.objects.filter(title=company.name, org_type=OrganizationType.COMPANY.value).first()
-            if org:
-                company_org_ids.add(org.id)
+        if company and company.org:
+            company_org_ids.add(company.org_id)
 
     if RoleType.MENTOR.value in roles:
         from db.user import MentorScopeGrant

--- a/api/dashboard/events/meta_views.py
+++ b/api/dashboard/events/meta_views.py
@@ -180,15 +180,15 @@ class OrganizerOptionsAPI(APIView):
         # Company: user with Company role in a company org or UserMentor with COMPANY_MENTOR
         company_options = {}
         if RoleType.COMPANY.value in roles:
-            user_orgs = UserOrganizationLink.objects.filter(
-                user_id=user_id, verified=True
-            ).select_related('org')
-            for link in user_orgs:
-                if link.org.org_type == 'Company':
-                    company_options[link.org.id] = {
-                        'id': link.org.id,
-                        'title': link.org.title,
-                    }
+            from db.company import Company
+            company = Company.objects.filter(
+                company_user_id=user_id, status="verified"
+            ).select_related('org').first()
+            if company and company.org:
+                company_options[company.org.id] = {
+                    'id': company.org.id,
+                    'title': company.org.title,
+                }
                     
         if RoleType.MENTOR.value in roles:
             from db.user import MentorScopeGrant

--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -672,6 +672,9 @@ class InterestGroupRequestAPI(APIView):
                     general_message=f"Invalid status. Must be one of: {', '.join(valid_statuses)}"
                 ).get_failure_response()
             ig_queryset = ig_queryset.filter(status=status_filter)
+        else:
+            # Default ("All") view excludes cancelled requests; use ?status=cancelled to see them.
+            ig_queryset = ig_queryset.exclude(status='cancelled')
 
         paginated_queryset = CommonUtils.get_paginated_queryset(
             ig_queryset,

--- a/db/company.py
+++ b/db/company.py
@@ -4,6 +4,7 @@ from django.db import models
 class Company(models.Model):
     id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
     company_user = models.OneToOneField('User', on_delete=models.CASCADE, related_name='company_profile')
+    org = models.ForeignKey('Organization', on_delete=models.SET_NULL, null=True, blank=True, related_name='companies')
     name = models.CharField(max_length=75, unique=True)
     logo = models.TextField(null=True, blank=True)
     description = models.TextField()


### PR DESCRIPTION
## Description
This PR builds on the recent foreign key integration by ensuring the linked `Organization` title remains synchronized when a company is renamed, and continues refactoring legacy name-based lookups to use the new direct `org` relation.

This also introduces data-consistency improvements for company updates and simplifies the default visibility rules for company tasks.

This cleans up the default view for Interest Group (IG) requests by hiding cancelled requests, ensuring administrators and reviewers aren't overwhelmed by aborted applications.