### PR TITLE
fix(campus): execom roster no longer leaks non-execom UserRoleLink rows

### DIFF
--- a/api/dashboard/campus/dash_campus_helper.py
+++ b/api/dashboard/campus/dash_campus_helper.py
@@ -130,14 +130,17 @@ def assign_ig_campus_lead(chapter, new_lead, acting_user_id):
         {
             "title": ig_name,
             "description": f"{ig_name} Interest Group Member",
+            "is_execom_role": False,
         },
         {
             "title": RoleType.IG_CAMPUS_LEAD_ROLE(ig_code),
             "description": f"{ig_name} Interest Group Campus Lead",
+            "is_execom_role": True,
         },
         {
             "title": RoleType.IG_LEAD_ROLE(ig_code),
             "description": f"{ig_name} Interest Group Lead",
+            "is_execom_role": False,
         },
     ]
 
@@ -149,6 +152,7 @@ def assign_ig_campus_lead(chapter, new_lead, acting_user_id):
                 "description": role_data["description"],
                 "created_by_id": acting_user_id,
                 "updated_by_id": acting_user_id,
+                "is_execom_role": role_data["is_execom_role"],
             }
         )
 

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -482,13 +482,18 @@ class CampusExecomRoleAPI(APIView):
 
         role = Role.objects.filter(title=role_title).first()
         if role:
+            if not role.is_execom_role:
+                return CustomResponse(
+                    general_message=f"'{role_title}' is already in use by another feature and cannot be created as an execom role"
+                ).get_failure_response()
             return CustomResponse(general_message="Role already exists").get_success_response()
 
         Role.objects.create(
             id=str(uuid.uuid4()),
             title=role_title,
             created_by_id=user_id,
-            updated_by_id=user_id
+            updated_by_id=user_id,
+            is_execom_role=True,
         )
 
         return CustomResponse(general_message="Role created successfully").get_success_response()

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -195,22 +195,9 @@ class CampusExecomAPI(APIView):
             is_alumni=False,
         ).values_list("user_id", flat=True)
 
-        # Extracted all non-execom system roles to properly support listing dynamic custom/IG roles
-        BLACKLIST_ROLES = [
-            RoleType.ADMIN.value, RoleType.FELLOW.value, RoleType.APPRAISER.value,
-            RoleType.ZONAL_CAMPUS_LEAD.value, RoleType.DISTRICT_CAMPUS_LEAD.value,
-            RoleType.MENTOR.value, RoleType.COMPANY.value, RoleType.BOT_DEV.value,
-            RoleType.TECH_TEAM.value, RoleType.CAMPUS_ACTIVATION_TEAM.value,
-            RoleType.DISCORD_MANAGER.value, RoleType.EX_OFFICIAL.value,
-            RoleType.INTERN.value, RoleType.PRE_MEMBER.value, RoleType.SUSPEND.value,
-            RoleType.MULEARNER.value, RoleType.STUDENT.value, RoleType.ASSOCIATE.value,
-            RoleType.IG_LEAD.value
-        ]
-
         execom_links = UserRoleLink.objects.filter(
-            user_id__in=campus_user_ids
-        ).exclude(
-            role__title__in=BLACKLIST_ROLES
+            user_id__in=campus_user_ids,
+            role__is_execom_role=True,
         ).select_related("user", "role")
 
         serializer = campus_serializers.ExecomMemberSerializer(
@@ -300,12 +287,17 @@ class CampusExecomAPI(APIView):
 
         # Fetch role by title
         role = Role.objects.filter(title=role_title).first()
+        if role is not None and not role.is_execom_role:
+            return CustomResponse(
+                general_message=f"'{role_title}' is already in use by another feature and cannot be assigned as an execom role"
+            ).get_failure_response()
         if role is None:
             role = Role.objects.create(
                 id=str(uuid.uuid4()),
                 title=role_title,
                 created_by_id=user_id,
-                updated_by_id=user_id
+                updated_by_id=user_id,
+                is_execom_role=True,
             )
 
         # Remove existing holder of this role in the campus

--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -191,14 +191,17 @@ class InterestGroupAPI(APIView):
                     {
                         "title": ig_name,
                         "description": f"{ig_name} Interest Group Member",
+                        "is_execom_role": False,
                     },
                     {
                         "title": RoleType.IG_CAMPUS_LEAD_ROLE(ig_code),
                         "description": f"{ig_name} Interest Group Campus Lead",
+                        "is_execom_role": True,
                     },
                     {
                         "title": RoleType.IG_LEAD_ROLE(ig_code),
                         "description": f"{ig_name} Interest Group Lead",
+                        "is_execom_role": False,
                     },
                 ]
 
@@ -210,6 +213,7 @@ class InterestGroupAPI(APIView):
                             "description": role_data["description"],
                             "created_by_id": request_data.get("created_by"),
                             "updated_by_id": request_data.get("updated_by"),
+                            "is_execom_role": role_data["is_execom_role"],
                         }
                     )
 

--- a/db/user.py
+++ b/db/user.py
@@ -284,6 +284,7 @@ class Role(models.Model):
     created_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column='created_by',
                                    related_name='role_created_by')
     created_at = models.DateTimeField(auto_now_add=True)
+    is_execom_role = models.BooleanField(default=False)
 
     class Meta:
         managed = False


### PR DESCRIPTION
## Summary
- The "Current Execom Roster" API (`CampusExecomAPI.get`) built its result with a denylist of ~19 known non-execom role titles, so any UserRoleLink from an unrelated feature (Launchpad levels, IG member roles, mentor/intern roles, etc.) leaked through and rendered as a fake leadership appointment. Deleting one of these from the roster would silently delete the unrelated feature's data.
- Adds `Role.is_execom_role` (boolean, default False) as an explicit provenance flag, set only where a role is genuinely meant to appear on the roster: custom titles created via `CampusExecomAPI.post()`, and the `IG_CAMPUS_LEAD_ROLE` entry in the IG role-bootstrap flows. The roster query now filters on this flag instead of excluding known-bad titles.
- Also closes a title-collision hole in `CampusExecomAPI.post()`: assigning a custom title that matches an existing non-execom role (e.g. a Launchpad level string) now returns a clear error instead of silently reusing/relabeling that shared role.