### PR TITLE
fix(campus): campus dashboard was hiding members (and the lead) via a broken verified filter

### DIFF
--- a/api/dashboard/campus/analytics_views.py
+++ b/api/dashboard/campus/analytics_views.py
@@ -57,7 +57,6 @@ class CampusKarmaTrendAPI(APIView):
         
         qs = KarmaActivityLog.objects.filter(
             user__user_organization_link_user__org=org,
-            user__user_organization_link_user__verified=True,
             created_at__gte=start_date,
             appraiser_approved=True,
         ).annotate(
@@ -121,10 +120,10 @@ class CampusGrowthAPI(APIView):
         previous_window_start = now - timedelta(days=60)
 
         current_members = UserOrganizationLink.objects.filter(
-            org=org, is_alumni=False, verified=True, created_at__gte=current_window_start
+            org=org, is_alumni=False, created_at__gte=current_window_start
         ).count()
         prev_members = UserOrganizationLink.objects.filter(
-            org=org, is_alumni=False, verified=True,
+            org=org, is_alumni=False,
             created_at__gte=previous_window_start, created_at__lt=current_window_start,
         ).count()
 

--- a/api/dashboard/campus/campus_views.py
+++ b/api/dashboard/campus/campus_views.py
@@ -186,7 +186,6 @@ class CampusStudentInEachLevelAPI(APIView):
                 filter=Q(
                     user_lvl_link_level__user__user_organization_link_user__org=org,
                     user_lvl_link_level__user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                    user_lvl_link_level__user__user_organization_link_user__verified=True,
                 ),
                 distinct=True,
             )
@@ -224,12 +223,10 @@ class CampusStudentDetailsAPI(APIView):
         wallet_filters = Q(
             user__user_organization_link_user__org=user_org_link.org,
             user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user__user_organization_link_user__verified=True,
         )
         user_filters = Q(
             user_organization_link_user__org=user_org_link.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user_organization_link_user__verified=True,
         )
 
         if is_alumni is not None:
@@ -349,12 +346,10 @@ class CampusStudentDetailsCSVAPI(APIView):
         wallet_filters = Q(
             user__user_organization_link_user__org=user_org_link.org,
             user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user__user_organization_link_user__verified=True,
         )
         user_filters = Q(
             user_organization_link_user__org=user_org_link.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user_organization_link_user__verified=True,
         )
 
         if is_alumni is not None:
@@ -860,7 +855,6 @@ class CampusStudentLeaderboardAPI(APIView):
             Wallet.objects.filter(
                 user__user_organization_link_user__org=org,
                 user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                user__user_organization_link_user__verified=True,
             )
             .distinct()
             .order_by("-karma","-created_at")
@@ -886,7 +880,6 @@ class CampusStudentLeaderboardAPI(APIView):
             User.objects.filter(
                 user_organization_link_user__org=org,
                 user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                user_organization_link_user__verified=True,
             )
             .distinct()
             .annotate(
@@ -935,7 +928,7 @@ class CampusStudentLeaderboardAPI(APIView):
             qs = qs.filter(
                 user_organization_link_user__is_alumni=is_alumni_bool
             )
-        # No default is_alumni filter: every verified campus member (alumni
+        # No default is_alumni filter: every campus member (alumni
         # included) appears on the leaderboard unless ?is_alumni= is passed.
         if search:
             qs = qs.filter(
@@ -1043,7 +1036,6 @@ class CampusKarmaByClusterAPI(APIView):
             User.objects.filter(
                 user_organization_link_user__org=org,
                 user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                user_organization_link_user__verified=True,
             )
             .annotate(
                 user_karma=Subquery(wallet_karma_sq),

--- a/api/dashboard/campus/dashboard_views.py
+++ b/api/dashboard/campus/dashboard_views.py
@@ -38,15 +38,13 @@ def _period_start(request, default_days=30):
 
 def _member_funnel(org):
     registered = UserOrganizationLink.objects.filter(org=org).count()
-    onboarded = UserOrganizationLink.objects.filter(org=org, verified=True).count()
+    onboarded = registered
     active = UserOrganizationLink.objects.filter(
         org=org,
-        verified=True,
         user__wallet_user__karma_last_updated_at__gte=timezone.now() - timedelta(days=30),
     ).count()
     level_2_plus = UserOrganizationLink.objects.filter(
         org=org,
-        verified=True,
         user__user_lvl_link_user__level__level_order__gte=2,
     ).count()
     circle_leads = UserCircleLink.objects.filter(
@@ -120,13 +118,12 @@ def _recent_activity(org, limit):
 
 
 def _campus_stats(org, since):
-    members = UserOrganizationLink.objects.filter(org=org,verified=True)
+    members = UserOrganizationLink.objects.filter(org=org)
     active_members = members.filter(user__wallet_user__karma_last_updated_at__gte=since).count()
     total_karma = members.aggregate(total=Sum("user__wallet_user__karma")).get("total") or 0
     active_circles = LearningCircle.objects.filter(org=org).count()
     period_karma = KarmaActivityLog.objects.filter(
         user__user_organization_link_user__org=org,
-        user__user_organization_link_user__verified=True,
         created_at__gte=since,
         appraiser_approved=True,
     ).aggregate(total=Sum("karma")).get("total") or 0

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -53,20 +53,17 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
         return None
 
     def get_total_members(self, obj):
-        return obj.user_organization_link_org.filter(verified=True).values('user').distinct().count()
+        return obj.user_organization_link_org.values('user').distinct().count()
 
     def get_active_members(self, obj):
         return obj.user_organization_link_org.filter(
-            verified=True,
             user__discord_id__isnull=False,
             user__exist_in_guild=True
         ).values('user').distinct().count()
 
     def get_total_karma(self, obj):
         from db.task import Wallet
-        users_in_org = obj.user_organization_link_org.filter(
-            verified=True
-        ).values_list('user', flat=True)
+        users_in_org = obj.user_organization_link_org.values_list('user', flat=True)
         return Wallet.objects.filter(
             user__in=users_in_org
         ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
@@ -78,7 +75,6 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
         rows = (
             UserOrganizationLink.objects.filter(
                 org__org_type=OrganizationType.COLLEGE.value,
-                verified=True,
             )
             .values("org", "user", "user__wallet_user__karma")
             .distinct()
@@ -152,7 +148,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         campus_lead = User.objects.filter(
             user_organization_link_user__org=obj.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user_organization_link_user__verified=True,
             user_role_link_user__role__title=RoleType.CAMPUS_LEAD.value,
         ).first()
         if campus_lead:
@@ -161,7 +156,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         enabler = User.objects.filter(
             user_organization_link_user__org=obj.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user_organization_link_user__verified=True,
             user_role_link_user__role__title=RoleType.LEAD_ENABLER.value,
         ).first()
         if enabler:
@@ -179,7 +173,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
    
 
     def get_total_members(self, obj):
-        return obj.org.user_organization_link_org.filter(verified=True).values('user').distinct().count()
+        return obj.org.user_organization_link_org.values('user').distinct().count()
 
     def get_active_members(self, obj):
         from db.task import Wallet
@@ -187,23 +181,20 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         last_month = DateTimeUtils.get_current_utc_time() - timedelta(
             weeks=26
         )  # 6months
-        verified_user_ids = obj.org.user_organization_link_org.filter(
-            verified=True
-        ).values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
         return Wallet.objects.filter(
-            user_id__in=verified_user_ids,
+            user_id__in=member_user_ids,
             karma_last_updated_at__gte=last_month,
         ).count()
 
     def get_total_karma(self, obj):
         from db.task import Wallet
 
-        verified_user_ids = obj.org.user_organization_link_org.filter(
+        member_user_ids = obj.org.user_organization_link_org.filter(
             org__org_type=OrganizationType.COLLEGE.value,
-            verified=True,
         ).values_list("user_id", flat=True).distinct()
         return Wallet.objects.filter(
-            user_id__in=verified_user_ids
+            user_id__in=member_user_ids
         ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
 
     def get_rank(self, obj):
@@ -213,7 +204,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         rows = (
             UserOrganizationLink.objects.filter(
                 org__org_type=OrganizationType.COLLEGE.value,
-                verified=True,
             )
             .values("org", "user", "user__wallet_user__karma")
             .distinct()
@@ -235,12 +225,10 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
             return position + 1
     def get_karma_last_7_days(self, obj):
         seven_days_ago = DateTimeUtils.get_current_utc_time() - timedelta(days=7)
-        verified_user_ids = obj.org.user_organization_link_org.filter(
-            verified=True
-        ).values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
         return (
             KarmaActivityLog.objects.filter(
-                user_id__in=verified_user_ids,
+                user_id__in=member_user_ids,
                 created_at__gte=seven_days_ago,
                 appraiser_approved=True,
             ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
@@ -248,12 +236,10 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
 
     def get_karma_last_30_days(self, obj):
         thirty_days_ago = DateTimeUtils.get_current_utc_time() - timedelta(days=30)
-        verified_user_ids = obj.org.user_organization_link_org.filter(
-            verified=True
-        ).values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
         return (
             KarmaActivityLog.objects.filter(
-                user_id__in=verified_user_ids,
+                user_id__in=member_user_ids,
                 created_at__gte=thirty_days_ago,
                 appraiser_approved=True,
             ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
@@ -262,7 +248,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         return (
             InterestGroup.objects.filter(
                 user_ig_link_ig__user__user_organization_link_user__org=obj.org,
-                user_ig_link_ig__user__user_organization_link_user__verified=True,
                 status="active",
             )
             .distinct()
@@ -332,13 +317,11 @@ class WeeklyKarmaSerializer(serializers.ModelSerializer):
         today = DateTimeUtils.get_current_utc_time().date()
         date_range = [today - timedelta(days=i) for i in range(7)]
 
-        verified_user_ids = instance.user_organization_link_org.filter(
-            verified=True
-        ).values_list("user_id", flat=True).distinct()
+        member_user_ids = instance.user_organization_link_org.values_list("user_id", flat=True).distinct()
 
         for date in date_range:
             karma_logs = KarmaActivityLog.objects.filter(
-                user_id__in=verified_user_ids,
+                user_id__in=member_user_ids,
                 created_at__date=date,
                 appraiser_approved=True,
             ).aggregate(
@@ -533,7 +516,6 @@ class CampusIGChapterListSerializer(serializers.ModelSerializer):
             is_active=True,
             assignment_type=UserIgLink.AssignmentType.LEARNER,
             user__user_organization_link_user__org=obj.org,
-            user__user_organization_link_user__verified=True,
         ).values('user').distinct().count()
 
 


### PR DESCRIPTION
## Summary
- Campus lead reported some students missing from their campus dashboard, and that they themselves didn't show up as the campus lead.
- Root cause: every campus-facing listing/counting query required `user_organization_link.verified=True`. Tracing every code path that writes `UserOrganizationLink` showed **no current flow ever creates a "pending" college membership** — every write sets `verified=True` at creation. The only place that ever flips it to `False` is a Mentor-role-revocation cleanup (`api/dashboard/roles/dash_roles_views.py:403-428`): when an admin revokes a user's Mentor role, it marks `UserOrganizationLink` unverified for any `CAMPUS_MENTOR`/`COMPANY_MENTOR` org tied to that revocation — including, if that org happens to be the person's own college, their ordinary student/lead membership.
- `serializers.py`'s `get_lead()` specifically looks up the `Campus Lead` role holder filtered by `verified=True` on their own org link — this is the exact mechanism behind the campus lead not appearing.
- Removed the `verified=True` requirement from every campus listing/counting query: member rosters, CSV export, per-level student counts, leaderboard, karma-by-cluster, karma trend/growth analytics, campus overview stats (total members, active members, karma, rank, lead/enabler lookup, IG member counts).
- Left `ig_views.py`'s "must be a verified college member to join/lead an IG chapter" checks untouched — that's an authorization decision, not a display bug, and changing it wasn't asked for.
