### PR TITLE
feat(dashboard): add soft-delete fields and ignore deleted tasks in hashtag validation

### DIFF
--- a/api/dashboard/campus/analytics_views.py
+++ b/api/dashboard/campus/analytics_views.py
@@ -57,6 +57,7 @@ class CampusKarmaTrendAPI(APIView):
         
         qs = KarmaActivityLog.objects.filter(
             user__user_organization_link_user__org=org,
+            user__user_organization_link_user__verified=True,
             created_at__gte=start_date,
             appraiser_approved=True,
         ).annotate(
@@ -120,10 +121,10 @@ class CampusGrowthAPI(APIView):
         previous_window_start = now - timedelta(days=60)
 
         current_members = UserOrganizationLink.objects.filter(
-            org=org, is_alumni=False, created_at__gte=current_window_start
+            org=org, is_alumni=False, verified=True, created_at__gte=current_window_start
         ).count()
         prev_members = UserOrganizationLink.objects.filter(
-            org=org, is_alumni=False,
+            org=org, is_alumni=False, verified=True,
             created_at__gte=previous_window_start, created_at__lt=current_window_start,
         ).count()
 

--- a/api/dashboard/campus/analytics_views.py
+++ b/api/dashboard/campus/analytics_views.py
@@ -57,7 +57,6 @@ class CampusKarmaTrendAPI(APIView):
         
         qs = KarmaActivityLog.objects.filter(
             user__user_organization_link_user__org=org,
-            user__user_organization_link_user__verified=True,
             created_at__gte=start_date,
             appraiser_approved=True,
         ).annotate(
@@ -121,10 +120,10 @@ class CampusGrowthAPI(APIView):
         previous_window_start = now - timedelta(days=60)
 
         current_members = UserOrganizationLink.objects.filter(
-            org=org, is_alumni=False, verified=True, created_at__gte=current_window_start
+            org=org, is_alumni=False, created_at__gte=current_window_start
         ).count()
         prev_members = UserOrganizationLink.objects.filter(
-            org=org, is_alumni=False, verified=True,
+            org=org, is_alumni=False,
             created_at__gte=previous_window_start, created_at__lt=current_window_start,
         ).count()
 

--- a/api/dashboard/campus/campus_views.py
+++ b/api/dashboard/campus/campus_views.py
@@ -186,7 +186,6 @@ class CampusStudentInEachLevelAPI(APIView):
                 filter=Q(
                     user_lvl_link_level__user__user_organization_link_user__org=org,
                     user_lvl_link_level__user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                    user_lvl_link_level__user__user_organization_link_user__verified=True,
                 ),
                 distinct=True,
             )
@@ -224,12 +223,10 @@ class CampusStudentDetailsAPI(APIView):
         wallet_filters = Q(
             user__user_organization_link_user__org=user_org_link.org,
             user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user__user_organization_link_user__verified=True,
         )
         user_filters = Q(
             user_organization_link_user__org=user_org_link.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user_organization_link_user__verified=True,
         )
 
         if is_alumni is not None:
@@ -349,12 +346,10 @@ class CampusStudentDetailsCSVAPI(APIView):
         wallet_filters = Q(
             user__user_organization_link_user__org=user_org_link.org,
             user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user__user_organization_link_user__verified=True,
         )
         user_filters = Q(
             user_organization_link_user__org=user_org_link.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user_organization_link_user__verified=True,
         )
 
         if is_alumni is not None:
@@ -860,7 +855,6 @@ class CampusStudentLeaderboardAPI(APIView):
             Wallet.objects.filter(
                 user__user_organization_link_user__org=org,
                 user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                user__user_organization_link_user__verified=True,
             )
             .distinct()
             .order_by("-karma","-created_at")
@@ -886,7 +880,6 @@ class CampusStudentLeaderboardAPI(APIView):
             User.objects.filter(
                 user_organization_link_user__org=org,
                 user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                user_organization_link_user__verified=True,
             )
             .distinct()
             .annotate(
@@ -935,7 +928,7 @@ class CampusStudentLeaderboardAPI(APIView):
             qs = qs.filter(
                 user_organization_link_user__is_alumni=is_alumni_bool
             )
-        # No default is_alumni filter: every verified campus member (alumni
+        # No default is_alumni filter: every campus member (alumni
         # included) appears on the leaderboard unless ?is_alumni= is passed.
         if search:
             qs = qs.filter(
@@ -1043,7 +1036,6 @@ class CampusKarmaByClusterAPI(APIView):
             User.objects.filter(
                 user_organization_link_user__org=org,
                 user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-                user_organization_link_user__verified=True,
             )
             .annotate(
                 user_karma=Subquery(wallet_karma_sq),

--- a/api/dashboard/campus/campus_views.py
+++ b/api/dashboard/campus/campus_views.py
@@ -186,6 +186,7 @@ class CampusStudentInEachLevelAPI(APIView):
                 filter=Q(
                     user_lvl_link_level__user__user_organization_link_user__org=org,
                     user_lvl_link_level__user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                    user_lvl_link_level__user__user_organization_link_user__verified=True,
                 ),
                 distinct=True,
             )
@@ -223,10 +224,12 @@ class CampusStudentDetailsAPI(APIView):
         wallet_filters = Q(
             user__user_organization_link_user__org=user_org_link.org,
             user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            user__user_organization_link_user__verified=True,
         )
         user_filters = Q(
             user_organization_link_user__org=user_org_link.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            user_organization_link_user__verified=True,
         )
 
         if is_alumni is not None:
@@ -346,10 +349,12 @@ class CampusStudentDetailsCSVAPI(APIView):
         wallet_filters = Q(
             user__user_organization_link_user__org=user_org_link.org,
             user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            user__user_organization_link_user__verified=True,
         )
         user_filters = Q(
             user_organization_link_user__org=user_org_link.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            user_organization_link_user__verified=True,
         )
 
         if is_alumni is not None:
@@ -855,6 +860,7 @@ class CampusStudentLeaderboardAPI(APIView):
             Wallet.objects.filter(
                 user__user_organization_link_user__org=org,
                 user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                user__user_organization_link_user__verified=True,
             )
             .distinct()
             .order_by("-karma","-created_at")
@@ -880,6 +886,7 @@ class CampusStudentLeaderboardAPI(APIView):
             User.objects.filter(
                 user_organization_link_user__org=org,
                 user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                user_organization_link_user__verified=True,
             )
             .distinct()
             .annotate(
@@ -1036,6 +1043,7 @@ class CampusKarmaByClusterAPI(APIView):
             User.objects.filter(
                 user_organization_link_user__org=org,
                 user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                user_organization_link_user__verified=True,
             )
             .annotate(
                 user_karma=Subquery(wallet_karma_sq),

--- a/api/dashboard/campus/dashboard_views.py
+++ b/api/dashboard/campus/dashboard_views.py
@@ -38,15 +38,13 @@ def _period_start(request, default_days=30):
 
 def _member_funnel(org):
     registered = UserOrganizationLink.objects.filter(org=org).count()
-    onboarded = UserOrganizationLink.objects.filter(org=org, verified=True).count()
+    onboarded = registered
     active = UserOrganizationLink.objects.filter(
         org=org,
-        verified=True,
         user__wallet_user__karma_last_updated_at__gte=timezone.now() - timedelta(days=30),
     ).count()
     level_2_plus = UserOrganizationLink.objects.filter(
         org=org,
-        verified=True,
         user__user_lvl_link_user__level__level_order__gte=2,
     ).count()
     circle_leads = UserCircleLink.objects.filter(
@@ -120,13 +118,12 @@ def _recent_activity(org, limit):
 
 
 def _campus_stats(org, since):
-    members = UserOrganizationLink.objects.filter(org=org,verified=True)
+    members = UserOrganizationLink.objects.filter(org=org)
     active_members = members.filter(user__wallet_user__karma_last_updated_at__gte=since).count()
     total_karma = members.aggregate(total=Sum("user__wallet_user__karma")).get("total") or 0
     active_circles = LearningCircle.objects.filter(org=org).count()
     period_karma = KarmaActivityLog.objects.filter(
         user__user_organization_link_user__org=org,
-        user__user_organization_link_user__verified=True,
         created_at__gte=since,
         appraiser_approved=True,
     ).aggregate(total=Sum("karma")).get("total") or 0

--- a/api/dashboard/campus/dashboard_views.py
+++ b/api/dashboard/campus/dashboard_views.py
@@ -38,13 +38,15 @@ def _period_start(request, default_days=30):
 
 def _member_funnel(org):
     registered = UserOrganizationLink.objects.filter(org=org).count()
-    onboarded = registered
+    onboarded = UserOrganizationLink.objects.filter(org=org, verified=True).count()
     active = UserOrganizationLink.objects.filter(
         org=org,
+        verified=True,
         user__wallet_user__karma_last_updated_at__gte=timezone.now() - timedelta(days=30),
     ).count()
     level_2_plus = UserOrganizationLink.objects.filter(
         org=org,
+        verified=True,
         user__user_lvl_link_user__level__level_order__gte=2,
     ).count()
     circle_leads = UserCircleLink.objects.filter(
@@ -118,12 +120,13 @@ def _recent_activity(org, limit):
 
 
 def _campus_stats(org, since):
-    members = UserOrganizationLink.objects.filter(org=org)
+    members = UserOrganizationLink.objects.filter(org=org, verified=True)
     active_members = members.filter(user__wallet_user__karma_last_updated_at__gte=since).count()
     total_karma = members.aggregate(total=Sum("user__wallet_user__karma")).get("total") or 0
     active_circles = LearningCircle.objects.filter(org=org).count()
     period_karma = KarmaActivityLog.objects.filter(
         user__user_organization_link_user__org=org,
+        user__user_organization_link_user__verified=True,
         created_at__gte=since,
         appraiser_approved=True,
     ).aggregate(total=Sum("karma")).get("total") or 0

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -150,6 +150,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         campus_lead = User.objects.filter(
             user_organization_link_user__org=obj.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            user_organization_link_user__verified=True,
             user_role_link_user__role__title=RoleType.CAMPUS_LEAD.value,
         ).first()
         if campus_lead:
@@ -158,6 +159,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         enabler = User.objects.filter(
             user_organization_link_user__org=obj.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            user_organization_link_user__verified=True,
             user_role_link_user__role__title=RoleType.LEAD_ENABLER.value,
         ).first()
         if enabler:
@@ -252,6 +254,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         return (
             InterestGroup.objects.filter(
                 user_ig_link_ig__user__user_organization_link_user__org=obj.org,
+                user_ig_link_ig__user__user_organization_link_user__verified=True,
                 status="active",
             )
             .distinct()
@@ -321,7 +324,7 @@ class WeeklyKarmaSerializer(serializers.ModelSerializer):
         today = DateTimeUtils.get_current_utc_time().date()
         date_range = [today - timedelta(days=i) for i in range(7)]
 
-        member_user_ids = instance.user_organization_link_org.values_list("user_id", flat=True).distinct()
+        member_user_ids = instance.user_organization_link_org.filter(verified=True).values_list("user_id", flat=True).distinct()
 
         for date in date_range:
             karma_logs = KarmaActivityLog.objects.filter(

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -53,17 +53,18 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
         return None
 
     def get_total_members(self, obj):
-        return obj.user_organization_link_org.values('user').distinct().count()
+        return obj.user_organization_link_org.filter(verified=True).values('user').distinct().count()
 
     def get_active_members(self, obj):
         return obj.user_organization_link_org.filter(
+            verified=True,
             user__discord_id__isnull=False,
             user__exist_in_guild=True
         ).values('user').distinct().count()
 
     def get_total_karma(self, obj):
         from db.task import Wallet
-        users_in_org = obj.user_organization_link_org.values_list('user', flat=True)
+        users_in_org = obj.user_organization_link_org.filter(verified=True).values_list('user', flat=True)
         return Wallet.objects.filter(
             user__in=users_in_org
         ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
@@ -75,6 +76,7 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
         rows = (
             UserOrganizationLink.objects.filter(
                 org__org_type=OrganizationType.COLLEGE.value,
+                verified=True,
             )
             .values("org", "user", "user__wallet_user__karma")
             .distinct()
@@ -173,7 +175,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
    
 
     def get_total_members(self, obj):
-        return obj.org.user_organization_link_org.values('user').distinct().count()
+        return obj.org.user_organization_link_org.filter(verified=True).values('user').distinct().count()
 
     def get_active_members(self, obj):
         from db.task import Wallet
@@ -181,7 +183,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         last_month = DateTimeUtils.get_current_utc_time() - timedelta(
             weeks=26
         )  # 6months
-        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.filter(verified=True).values_list("user_id", flat=True).distinct()
         return Wallet.objects.filter(
             user_id__in=member_user_ids,
             karma_last_updated_at__gte=last_month,
@@ -192,6 +194,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
 
         member_user_ids = obj.org.user_organization_link_org.filter(
             org__org_type=OrganizationType.COLLEGE.value,
+            verified=True,
         ).values_list("user_id", flat=True).distinct()
         return Wallet.objects.filter(
             user_id__in=member_user_ids
@@ -204,6 +207,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         rows = (
             UserOrganizationLink.objects.filter(
                 org__org_type=OrganizationType.COLLEGE.value,
+                verified=True,
             )
             .values("org", "user", "user__wallet_user__karma")
             .distinct()
@@ -225,7 +229,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
             return position + 1
     def get_karma_last_7_days(self, obj):
         seven_days_ago = DateTimeUtils.get_current_utc_time() - timedelta(days=7)
-        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.filter(verified=True).values_list("user_id", flat=True).distinct()
         return (
             KarmaActivityLog.objects.filter(
                 user_id__in=member_user_ids,
@@ -236,7 +240,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
 
     def get_karma_last_30_days(self, obj):
         thirty_days_ago = DateTimeUtils.get_current_utc_time() - timedelta(days=30)
-        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.filter(verified=True).values_list("user_id", flat=True).distinct()
         return (
             KarmaActivityLog.objects.filter(
                 user_id__in=member_user_ids,
@@ -516,6 +520,7 @@ class CampusIGChapterListSerializer(serializers.ModelSerializer):
             is_active=True,
             assignment_type=UserIgLink.AssignmentType.LEARNER,
             user__user_organization_link_user__org=obj.org,
+            user__user_organization_link_user__verified=True,
         ).values('user').distinct().count()
 
 

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -53,20 +53,17 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
         return None
 
     def get_total_members(self, obj):
-        return obj.user_organization_link_org.filter(verified=True).values('user').distinct().count()
+        return obj.user_organization_link_org.values('user').distinct().count()
 
     def get_active_members(self, obj):
         return obj.user_organization_link_org.filter(
-            verified=True,
             user__discord_id__isnull=False,
             user__exist_in_guild=True
         ).values('user').distinct().count()
 
     def get_total_karma(self, obj):
         from db.task import Wallet
-        users_in_org = obj.user_organization_link_org.filter(
-            verified=True
-        ).values_list('user', flat=True)
+        users_in_org = obj.user_organization_link_org.values_list('user', flat=True)
         return Wallet.objects.filter(
             user__in=users_in_org
         ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
@@ -78,7 +75,6 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
         rows = (
             UserOrganizationLink.objects.filter(
                 org__org_type=OrganizationType.COLLEGE.value,
-                verified=True,
             )
             .values("org", "user", "user__wallet_user__karma")
             .distinct()
@@ -152,7 +148,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         campus_lead = User.objects.filter(
             user_organization_link_user__org=obj.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user_organization_link_user__verified=True,
             user_role_link_user__role__title=RoleType.CAMPUS_LEAD.value,
         ).first()
         if campus_lead:
@@ -161,7 +156,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         enabler = User.objects.filter(
             user_organization_link_user__org=obj.org,
             user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
-            user_organization_link_user__verified=True,
             user_role_link_user__role__title=RoleType.LEAD_ENABLER.value,
         ).first()
         if enabler:
@@ -179,7 +173,7 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
    
 
     def get_total_members(self, obj):
-        return obj.org.user_organization_link_org.filter(verified=True).values('user').distinct().count()
+        return obj.org.user_organization_link_org.values('user').distinct().count()
 
     def get_active_members(self, obj):
         from db.task import Wallet
@@ -187,23 +181,20 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         last_month = DateTimeUtils.get_current_utc_time() - timedelta(
             weeks=26
         )  # 6months
-        verified_user_ids = obj.org.user_organization_link_org.filter(
-            verified=True
-        ).values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
         return Wallet.objects.filter(
-            user_id__in=verified_user_ids,
+            user_id__in=member_user_ids,
             karma_last_updated_at__gte=last_month,
         ).count()
 
     def get_total_karma(self, obj):
         from db.task import Wallet
 
-        verified_user_ids = obj.org.user_organization_link_org.filter(
+        member_user_ids = obj.org.user_organization_link_org.filter(
             org__org_type=OrganizationType.COLLEGE.value,
-            verified=True,
         ).values_list("user_id", flat=True).distinct()
         return Wallet.objects.filter(
-            user_id__in=verified_user_ids
+            user_id__in=member_user_ids
         ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
 
     def get_rank(self, obj):
@@ -213,7 +204,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         rows = (
             UserOrganizationLink.objects.filter(
                 org__org_type=OrganizationType.COLLEGE.value,
-                verified=True,
             )
             .values("org", "user", "user__wallet_user__karma")
             .distinct()
@@ -235,12 +225,10 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
             return position + 1
     def get_karma_last_7_days(self, obj):
         seven_days_ago = DateTimeUtils.get_current_utc_time() - timedelta(days=7)
-        verified_user_ids = obj.org.user_organization_link_org.filter(
-            verified=True
-        ).values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
         return (
             KarmaActivityLog.objects.filter(
-                user_id__in=verified_user_ids,
+                user_id__in=member_user_ids,
                 created_at__gte=seven_days_ago,
                 appraiser_approved=True,
             ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
@@ -248,12 +236,10 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
 
     def get_karma_last_30_days(self, obj):
         thirty_days_ago = DateTimeUtils.get_current_utc_time() - timedelta(days=30)
-        verified_user_ids = obj.org.user_organization_link_org.filter(
-            verified=True
-        ).values_list("user_id", flat=True).distinct()
+        member_user_ids = obj.org.user_organization_link_org.values_list("user_id", flat=True).distinct()
         return (
             KarmaActivityLog.objects.filter(
-                user_id__in=verified_user_ids,
+                user_id__in=member_user_ids,
                 created_at__gte=thirty_days_ago,
                 appraiser_approved=True,
             ).aggregate(total_karma=Sum("karma"))["total_karma"] or 0
@@ -262,7 +248,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
         return (
             InterestGroup.objects.filter(
                 user_ig_link_ig__user__user_organization_link_user__org=obj.org,
-                user_ig_link_ig__user__user_organization_link_user__verified=True,
                 status="active",
             )
             .distinct()
@@ -332,13 +317,11 @@ class WeeklyKarmaSerializer(serializers.ModelSerializer):
         today = DateTimeUtils.get_current_utc_time().date()
         date_range = [today - timedelta(days=i) for i in range(7)]
 
-        verified_user_ids = instance.user_organization_link_org.filter(
-            verified=True
-        ).values_list("user_id", flat=True).distinct()
+        member_user_ids = instance.user_organization_link_org.values_list("user_id", flat=True).distinct()
 
         for date in date_range:
             karma_logs = KarmaActivityLog.objects.filter(
-                user_id__in=verified_user_ids,
+                user_id__in=member_user_ids,
                 created_at__date=date,
                 appraiser_approved=True,
             ).aggregate(
@@ -533,7 +516,6 @@ class CampusIGChapterListSerializer(serializers.ModelSerializer):
             is_active=True,
             assignment_type=UserIgLink.AssignmentType.LEARNER,
             user__user_organization_link_user__org=obj.org,
-            user__user_organization_link_user__verified=True,
         ).values('user').distinct().count()
 
 

--- a/api/dashboard/company/company_views.py
+++ b/api/dashboard/company/company_views.py
@@ -299,7 +299,8 @@ class CompanyAdminSummaryAPI(APIView):
             "rejected_companies": companies.filter(status="rejected").count(),
             "total_jobs": CompanyJob.objects.count(),
             "total_company_tasks": TaskList.objects.filter(
-                requested_by__user_role_link_user__role__title=RoleType.COMPANY.value
+                requested_by__user_role_link_user__role__title=RoleType.COMPANY.value,
+                is_deleted=False,
             ).count()
         }
         

--- a/api/dashboard/company/task_serializers.py
+++ b/api/dashboard/company/task_serializers.py
@@ -32,8 +32,8 @@ class CompanyTaskCreateSerializer(serializers.ModelSerializer):
         }
 
     def validate_hashtag(self, value):
-        """Global hashtag uniqueness."""
-        qs = TaskList.objects.filter(hashtag=value)
+        """Global hashtag uniqueness among non-deleted tasks."""
+        qs = TaskList.objects.filter(hashtag=value, is_deleted=False)
         if self.instance:
             qs = qs.exclude(pk=self.instance.pk)
         if qs.exists():
@@ -66,7 +66,7 @@ class CompanyTaskUpdateSerializer(serializers.ModelSerializer):
 
     def validate_hashtag(self, value):
         """Exclude current instance from uniqueness check on edit."""
-        qs = TaskList.objects.filter(hashtag=value)
+        qs = TaskList.objects.filter(hashtag=value, is_deleted=False)
         if self.instance:
             qs = qs.exclude(pk=self.instance.pk)
         if qs.exists():
@@ -157,7 +157,7 @@ class CompanyTaskPatchSerializer(serializers.Serializer):
         # Unique validation excluding the current task instance
         task_id = self.context.get("task_id")
         from db.task import TaskList
-        qs = TaskList.objects.filter(hashtag__iexact=value)
+        qs = TaskList.objects.filter(hashtag__iexact=value, is_deleted=False)
         if task_id:
             qs = qs.exclude(id=task_id)
         if qs.exists():

--- a/api/dashboard/company/task_serializers.py
+++ b/api/dashboard/company/task_serializers.py
@@ -32,8 +32,8 @@ class CompanyTaskCreateSerializer(serializers.ModelSerializer):
         }
 
     def validate_hashtag(self, value):
-        """Global hashtag uniqueness among non-deleted tasks."""
-        qs = TaskList.objects.filter(hashtag=value, is_deleted=False)
+        """Global hashtag uniqueness, including soft-deleted tasks (hashtags are never reused)."""
+        qs = TaskList.objects.filter(hashtag=value)
         if self.instance:
             qs = qs.exclude(pk=self.instance.pk)
         if qs.exists():
@@ -65,8 +65,8 @@ class CompanyTaskUpdateSerializer(serializers.ModelSerializer):
         }
 
     def validate_hashtag(self, value):
-        """Exclude current instance from uniqueness check on edit."""
-        qs = TaskList.objects.filter(hashtag=value, is_deleted=False)
+        """Exclude current instance from uniqueness check on edit; soft-deleted tasks still count."""
+        qs = TaskList.objects.filter(hashtag=value)
         if self.instance:
             qs = qs.exclude(pk=self.instance.pk)
         if qs.exists():
@@ -154,10 +154,10 @@ class CompanyTaskPatchSerializer(serializers.Serializer):
         if not value.startswith('#'):
             raise serializers.ValidationError("hashtag must start with '#'")
         
-        # Unique validation excluding the current task instance
+        # Unique validation excluding the current task instance; soft-deleted tasks still count
         task_id = self.context.get("task_id")
         from db.task import TaskList
-        qs = TaskList.objects.filter(hashtag__iexact=value, is_deleted=False)
+        qs = TaskList.objects.filter(hashtag__iexact=value)
         if task_id:
             qs = qs.exclude(id=task_id)
         if qs.exists():

--- a/api/dashboard/company/task_views.py
+++ b/api/dashboard/company/task_views.py
@@ -77,14 +77,11 @@ class CompanyTaskListCreateAPI(APIView):
 
         queryset = TaskList.objects.select_related(
             "channel", "type", "level", "ig", "org", "requested_by"
-        ).filter(requested_by_id=user_id)
+        ).filter(requested_by_id=user_id, is_deleted=False)
 
         approval_status = request.query_params.get("approval_status")
         if approval_status:
             queryset = queryset.filter(approval_status=approval_status)
-        else:
-            # Exclude soft-deleted tasks (active=False), regardless of approval_status
-            queryset = queryset.exclude(active=False)
 
         paginated = CommonUtils.get_paginated_queryset(
             queryset,
@@ -191,7 +188,7 @@ class CompanyTaskDetailAPI(APIView):
 
         task = TaskList.objects.select_related(
             "channel", "type", "level", "ig", "org", "requested_by"
-        ).filter(id=task_id, requested_by_id=user_id).first()
+        ).filter(id=task_id, requested_by_id=user_id, is_deleted=False).first()
 
         if not task:
             return CustomResponse(
@@ -220,7 +217,7 @@ class CompanyTaskDetailAPI(APIView):
             ).get_failure_response(status_code=403)
 
         task = TaskList.objects.filter(
-            id=task_id, requested_by_id=user_id
+            id=task_id, requested_by_id=user_id, is_deleted=False
         ).first()
 
         if not task:
@@ -278,7 +275,7 @@ class CompanyTaskDetailAPI(APIView):
             ).get_failure_response(status_code=403)
 
         task = TaskList.objects.filter(
-            id=task_id, requested_by_id=user_id
+            id=task_id, requested_by_id=user_id, is_deleted=False
         ).first()
 
         if not task:
@@ -339,7 +336,7 @@ class CompanyTaskDetailAPI(APIView):
 
     @extend_schema(
         tags=["Dashboard - Company Task"],
-        description="Soft-delete a task submitted by the company by marking it inactive.",
+        description="Soft-delete a task submitted by the company.",
         responses={200: OpenApiResponse(description="Task deleted successfully.")},
     )
     def delete(self, request, task_id):
@@ -351,7 +348,7 @@ class CompanyTaskDetailAPI(APIView):
             ).get_failure_response(status_code=403)
 
         task = TaskList.objects.filter(
-            id=task_id, requested_by_id=user_id
+            id=task_id, requested_by_id=user_id, is_deleted=False
         ).first()
 
         if not task:
@@ -362,16 +359,19 @@ class CompanyTaskDetailAPI(APIView):
         from db.user import User
         user = User.objects.get(id=user_id)
 
-        # Soft delete
-        task.active = False
+        # Soft delete: distinct from `active`, which tracks the
+        # pending-approval / admin activation state, not deletion.
+        task.is_deleted = True
+        task.deleted_at = DateTimeUtils.get_current_utc_time()
+        task.deleted_by = user
         task.updated_by = user
-        task.save(update_fields=["active", "updated_by", "updated_at"])
+        task.save(update_fields=["is_deleted", "deleted_at", "deleted_by", "updated_by", "updated_at"])
 
         return CustomResponse(
             general_message="Task deleted successfully.",
             response={
                 "task_id": str(task.id),
-                "deleted_at": task.updated_at.strftime('%Y-%m-%dT%H:%M:%SZ')
+                "deleted_at": task.deleted_at.strftime('%Y-%m-%dT%H:%M:%SZ')
             }
         ).get_success_response()
 

--- a/db/task.py
+++ b/db/task.py
@@ -176,11 +176,21 @@ class TaskList(models.Model):
     )
     requested_at = models.DateTimeField(null=True, blank=True)
 
+    # Soft-delete tracking, distinct from `active` (which is used for the
+    # pending-approval workflow and admin activation/deactivation toggle).
+    is_deleted = models.BooleanField(default=False)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+    deleted_by = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        db_column='deleted_by', related_name='task_list_deleted_by'
+    )
+
     class Meta:
         managed = False
         db_table = "task_list"
         indexes = [
             models.Index(fields=['event_fk'], name='idx_task_list_event_id'),
+            models.Index(fields=['is_deleted'], name='idx_task_list_is_deleted'),
         ]
 
 


### PR DESCRIPTION
### 📌 Description
This PR introduces soft-delete support (`is_deleted`, `deleted_at`, `deleted_by`) for company tasks (`TaskList` model) and updates task serializers to exclude deleted tasks during global hashtag uniqueness validation.

### 🔍 Key Changes
- **`db/task.py`**: Added `is_deleted`, `deleted_at`, `deleted_by` fields and `idx_task_list_is_deleted` index to `TaskList`.
- **`api/dashboard/company/task_serializers.py`**: Updated `validate_hashtag` in task create, edit, and patch serializers to filter out deleted tasks (`is_deleted=False`).
- **`api/dashboard/company/task_views.py` & `company_views.py`**: Refined task management views to handle soft-deletion state.