### PR TITLE
feat: Add serializers, views, and models for impact projects management

### DIFF
--- a/api/dashboard/ig/impact_project_serializer.py
+++ b/api/dashboard/ig/impact_project_serializer.py
@@ -1,0 +1,67 @@
+from rest_framework import serializers
+
+from db.impact_project import ImpactProject, ImpactProjectLink, ImpactProjectUserLink
+
+
+class ImpactProjectTeamMemberSerializer(serializers.ModelSerializer):
+    muid = serializers.CharField(source="user.muid")
+    name = serializers.CharField(source="user.full_name")
+
+    class Meta:
+        model = ImpactProjectUserLink
+        fields = ["muid", "name", "is_lead"]
+
+
+class ImpactProjectLinkSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ImpactProjectLink
+        fields = ["label", "url"]
+
+
+class ImpactProjectSerializer(serializers.ModelSerializer):
+    ig_id = serializers.CharField(source="ig.id", read_only=True)
+    team = serializers.SerializerMethodField()
+    links = serializers.SerializerMethodField()
+    image = serializers.CharField(read_only=True)
+    created_by = serializers.CharField(source="created_by.full_name", read_only=True)
+    updated_by = serializers.CharField(source="updated_by.full_name", read_only=True)
+
+    class Meta:
+        model = ImpactProject
+        fields = [
+            "id", "ig_id", "title", "image", "description", "team", "links",
+            "created_by", "updated_by", "created_at", "updated_at",
+        ]
+
+    def get_team(self, obj):
+        links = obj.impact_project_user_link_project.select_related("user").all()
+        return ImpactProjectTeamMemberSerializer(links, many=True).data
+
+    def get_links(self, obj):
+        links = obj.impact_project_link_project.all()
+        return ImpactProjectLinkSerializer(links, many=True).data
+
+
+class ImpactProjectCreateUpdateSerializer(serializers.ModelSerializer):
+    # Declared so the repo-wide strict-serializer patch (mulearnbackend/__init__.py,
+    # which rejects any request key not in self.fields) doesn't 400 on these — they
+    # are not model fields, actual persistence is handled by the view via
+    # request_data["team"]/["links"], not validated_data.
+    team = serializers.ListField(child=serializers.DictField(), required=False, write_only=True)
+    links = serializers.ListField(child=serializers.DictField(), required=False, write_only=True)
+
+    class Meta:
+        model = ImpactProject
+        fields = ["ig", "title", "description", "created_by", "updated_by", "team", "links"]
+
+    def validate(self, attrs):
+        attrs.pop("team", None)
+        attrs.pop("links", None)
+        team = self.initial_data.get("team", [])
+        if isinstance(team, list) and team:
+            leads = [member for member in team if member.get("is_lead")]
+            if len(leads) != 1:
+                raise serializers.ValidationError(
+                    "Exactly one team member must be marked as lead."
+                )
+        return attrs

--- a/api/dashboard/ig/impact_project_serializer.py
+++ b/api/dashboard/ig/impact_project_serializer.py
@@ -57,11 +57,7 @@ class ImpactProjectCreateUpdateSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         attrs.pop("team", None)
         attrs.pop("links", None)
-        team = self.initial_data.get("team", [])
-        if isinstance(team, list) and team:
-            leads = [member for member in team if member.get("is_lead")]
-            if len(leads) != 1:
-                raise serializers.ValidationError(
-                    "Exactly one team member must be marked as lead."
-                )
+        # A project may now have zero, one, or multiple leads — no count restriction.
+        # Actual muid resolution (including rejecting entries missing a muid) is
+        # enforced in the view via _resolve_team, since it needs a DB lookup.
         return attrs

--- a/api/dashboard/ig/impact_project_view.py
+++ b/api/dashboard/ig/impact_project_view.py
@@ -22,16 +22,22 @@ MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
 def _resolve_team(team_data):
-    """Resolve muids to users, deduping repeats. Raises ValueError on any unknown muid
-    so the caller can 400 instead of silently saving a team missing its lead."""
+    """Resolve muids to users, deduping repeats. Raises ValueError on any missing or
+    unknown muid so the caller 400s instead of silently dropping a team member (which
+    previously let an entry pass "has a lead" validation and then vanish on save)."""
     seen_muids = set()
     resolved = []
     for member in team_data:
         muid = member.get("muid")
-        if not muid or muid in seen_muids:
+        if not muid:
+            raise ValueError("Each team member requires a 'muid'.")
+        if muid in seen_muids:
             continue
         seen_muids.add(muid)
-        user = User.objects.filter(muid=muid).first()
+        # User.objects is ActiveUserManager and excludes suspended users — a team that
+        # already includes a suspended member must still resolve here on PATCH, else an
+        # unrelated edit to the same project would spuriously 400.
+        user = User.every.filter(muid=muid).first()
         if not user:
             raise ValueError(f"No user found with muid '{muid}'")
         resolved.append((user, bool(member.get("is_lead"))))

--- a/api/dashboard/ig/impact_project_view.py
+++ b/api/dashboard/ig/impact_project_view.py
@@ -1,0 +1,230 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.files.storage import FileSystemStorage
+from django.core.validators import URLValidator
+from django.db import transaction
+from rest_framework.views import APIView
+
+from db.impact_project import ImpactProject, ImpactProjectLink, ImpactProjectUserLink
+from db.task import InterestGroup
+from db.user import User
+from utils.permission import CustomizePermission, JWTUtils
+from utils.response import CustomResponse
+
+from .dash_ig_view import _can_manage_ig
+from .impact_project_serializer import (
+    ImpactProjectCreateUpdateSerializer,
+    ImpactProjectSerializer,
+)
+
+MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
+
+
+def _resolve_team(team_data):
+    """Resolve muids to users, deduping repeats. Raises ValueError on any unknown muid
+    so the caller can 400 instead of silently saving a team missing its lead."""
+    seen_muids = set()
+    resolved = []
+    for member in team_data:
+        muid = member.get("muid")
+        if not muid or muid in seen_muids:
+            continue
+        seen_muids.add(muid)
+        user = User.objects.filter(muid=muid).first()
+        if not user:
+            raise ValueError(f"No user found with muid '{muid}'")
+        resolved.append((user, bool(member.get("is_lead"))))
+    return resolved
+
+
+def _validate_links(links_data):
+    validator = URLValidator()
+    for link in links_data:
+        label, url = link.get("label"), link.get("url")
+        if not label or not url:
+            raise ValueError("Each link requires both a 'label' and a 'url'.")
+        if len(label) > 50:
+            raise ValueError(f"Link label '{label}' exceeds 50 characters.")
+        if len(url) > 500:
+            raise ValueError(f"Link url for '{label}' exceeds 500 characters.")
+        try:
+            validator(url)
+        except DjangoValidationError:
+            raise ValueError(f"'{url}' is not a valid URL.")
+
+
+def _sync_links(project, links_data):
+    _validate_links(links_data)
+    ImpactProjectLink.objects.filter(project=project).delete()
+    for link in links_data:
+        ImpactProjectLink.objects.create(project=project, label=link["label"], url=link["url"])
+
+
+class ImpactProjectListCreateAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    def get(self, request, ig_id):
+        ig = InterestGroup.objects.filter(id=ig_id).first()
+        if not ig:
+            return CustomResponse(general_message="Interest Group Does Not Exist").get_failure_response()
+
+        projects = ImpactProject.objects.filter(ig=ig).select_related("created_by", "updated_by")
+        serializer = ImpactProjectSerializer(projects, many=True)
+        return CustomResponse(response={"impactProjects": serializer.data}).get_success_response()
+
+    @transaction.atomic
+    def post(self, request, ig_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+
+        ig = InterestGroup.objects.filter(id=ig_id).first()
+        if not ig:
+            return CustomResponse(general_message="Interest Group Does Not Exist").get_failure_response()
+
+        if not _can_manage_ig(roles, ig):
+            return CustomResponse(
+                general_message="You do not have permission to manage this Interest Group"
+            ).get_failure_response()
+
+        request_data = request.data.copy()
+        request_data["ig"] = ig.id
+        request_data["created_by"] = request_data["updated_by"] = user_id
+
+        serializer = ImpactProjectCreateUpdateSerializer(data=request_data)
+        if not serializer.is_valid():
+            return CustomResponse(message=serializer.errors).get_failure_response()
+
+        try:
+            resolved_team = _resolve_team(request_data.get("team", []))
+            _validate_links(request_data.get("links", []))
+        except ValueError as exc:
+            return CustomResponse(general_message=str(exc)).get_failure_response()
+
+        project = serializer.save()
+        ImpactProjectUserLink.objects.filter(project=project).delete()
+        for user, is_lead in resolved_team:
+            ImpactProjectUserLink.objects.create(project=project, user=user, is_lead=is_lead)
+        _sync_links(project, request_data.get("links", []))
+
+        return CustomResponse(
+            response={"impactProject": ImpactProjectSerializer(project).data}
+        ).get_success_response()
+
+
+class ImpactProjectDetailAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    def _get_project(self, ig_id, project_id):
+        return ImpactProject.objects.filter(id=project_id, ig_id=ig_id).first()
+
+    @transaction.atomic
+    def patch(self, request, ig_id, project_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        roles = JWTUtils.fetch_role(request)
+
+        ig = InterestGroup.objects.filter(id=ig_id).first()
+        if not ig:
+            return CustomResponse(general_message="Interest Group Does Not Exist").get_failure_response()
+
+        if not _can_manage_ig(roles, ig):
+            return CustomResponse(
+                general_message="You do not have permission to manage this Interest Group"
+            ).get_failure_response()
+
+        project = self._get_project(ig_id, project_id)
+        if not project:
+            return CustomResponse(general_message="Impact Project Does Not Exist").get_failure_response()
+
+        request_data = request.data.copy()
+        request_data["updated_by"] = user_id
+        # ig and created_by are immutable via this endpoint — an IG lead must not be able
+        # to reassign a project to another IG or forge its original creator.
+        request_data.pop("ig", None)
+        request_data.pop("created_by", None)
+
+        serializer = ImpactProjectCreateUpdateSerializer(
+            data=request_data, instance=project, partial=True
+        )
+        if not serializer.is_valid():
+            return CustomResponse(message=serializer.errors).get_failure_response()
+
+        try:
+            if "team" in request_data:
+                resolved_team = _resolve_team(request_data.get("team", []))
+            if "links" in request_data:
+                _validate_links(request_data.get("links", []))
+        except ValueError as exc:
+            return CustomResponse(general_message=str(exc)).get_failure_response()
+
+        project = serializer.save()
+        if "team" in request_data:
+            ImpactProjectUserLink.objects.filter(project=project).delete()
+            for user, is_lead in resolved_team:
+                ImpactProjectUserLink.objects.create(project=project, user=user, is_lead=is_lead)
+        if "links" in request_data:
+            _sync_links(project, request_data.get("links", []))
+
+        return CustomResponse(
+            response={"impactProject": ImpactProjectSerializer(project).data}
+        ).get_success_response()
+
+    def delete(self, request, ig_id, project_id):
+        roles = JWTUtils.fetch_role(request)
+
+        ig = InterestGroup.objects.filter(id=ig_id).first()
+        if not ig:
+            return CustomResponse(general_message="Interest Group Does Not Exist").get_failure_response()
+
+        if not _can_manage_ig(roles, ig):
+            return CustomResponse(
+                general_message="You do not have permission to manage this Interest Group"
+            ).get_failure_response()
+
+        project = self._get_project(ig_id, project_id)
+        if not project:
+            return CustomResponse(general_message="Impact Project Does Not Exist").get_failure_response()
+
+        fs = FileSystemStorage()
+        image_path = f"impact_project/image/{project.id}.png"
+        if fs.exists(image_path):
+            fs.delete(image_path)
+
+        project.delete()
+        return CustomResponse(general_message="Impact Project deleted successfully").get_success_response()
+
+
+class ImpactProjectImageAPI(APIView):
+    authentication_classes = [CustomizePermission]
+
+    def post(self, request, ig_id, project_id):
+        roles = JWTUtils.fetch_role(request)
+
+        ig = InterestGroup.objects.filter(id=ig_id).first()
+        if not ig:
+            return CustomResponse(general_message="Interest Group Does Not Exist").get_failure_response()
+
+        if not _can_manage_ig(roles, ig):
+            return CustomResponse(
+                general_message="You do not have permission to manage this Interest Group"
+            ).get_failure_response()
+
+        project = ImpactProject.objects.filter(id=project_id, ig_id=ig_id).first()
+        if not project:
+            return CustomResponse(general_message="Impact Project Does Not Exist").get_failure_response()
+
+        image = request.FILES.get("image")
+        if image is None:
+            return CustomResponse(general_message="No image provided").get_failure_response()
+
+        if not image.content_type.startswith("image/"):
+            return CustomResponse(general_message="Expected an image file").get_failure_response()
+
+        if image.size > MAX_IMAGE_SIZE_BYTES:
+            return CustomResponse(general_message="Image must be under 5 MB").get_failure_response()
+
+        fs = FileSystemStorage()
+        filename = f"impact_project/image/{project.id}.png"
+        if fs.exists(filename):
+            fs.delete(filename)
+        fs.save(filename, image)
+
+        return CustomResponse(response={"image": project.image}).get_success_response()

--- a/api/dashboard/ig/impact_project_view.py
+++ b/api/dashboard/ig/impact_project_view.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.storage import FileSystemStorage
 from django.core.validators import URLValidator
 from django.db import transaction
+from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 
 from db.impact_project import ImpactProject, ImpactProjectLink, ImpactProjectUserLink
@@ -9,6 +10,7 @@ from db.task import InterestGroup
 from db.user import User
 from utils.permission import CustomizePermission, JWTUtils
 from utils.response import CustomResponse
+from utils.utils import CommonUtils
 
 from .dash_ig_view import _can_manage_ig
 from .impact_project_serializer import (
@@ -62,15 +64,37 @@ def _sync_links(project, links_data):
 class ImpactProjectListCreateAPI(APIView):
     authentication_classes = [CustomizePermission]
 
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="List Impact Projects for an Interest Group.",
+        responses={200: ImpactProjectSerializer},
+    )
     def get(self, request, ig_id):
         ig = InterestGroup.objects.filter(id=ig_id).first()
         if not ig:
             return CustomResponse(general_message="Interest Group Does Not Exist").get_failure_response()
 
-        projects = ImpactProject.objects.filter(ig=ig).select_related("created_by", "updated_by")
-        serializer = ImpactProjectSerializer(projects, many=True)
-        return CustomResponse(response={"impactProjects": serializer.data}).get_success_response()
+        projects = (
+            ImpactProject.objects.filter(ig=ig)
+            .select_related("created_by", "updated_by")
+            .prefetch_related("impact_project_user_link_project__user", "impact_project_link_project")
+            .order_by("-created_at")
+        )
+        paginated_queryset = CommonUtils.get_paginated_queryset(
+            projects, request, ["title", "description"],
+            {"title": "title", "created_on": "created_at", "updated_on": "updated_at"},
+        )
+        serializer = ImpactProjectSerializer(paginated_queryset.get("queryset"), many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data, pagination=paginated_queryset.get("pagination")
+        )
 
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="Create an Impact Project scoped to an Interest Group.",
+        request=ImpactProjectCreateUpdateSerializer,
+        responses={200: ImpactProjectSerializer},
+    )
     @transaction.atomic
     def post(self, request, ig_id):
         user_id = JWTUtils.fetch_user_id(request)
@@ -116,6 +140,12 @@ class ImpactProjectDetailAPI(APIView):
     def _get_project(self, ig_id, project_id):
         return ImpactProject.objects.filter(id=project_id, ig_id=ig_id).first()
 
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="Update an Impact Project.",
+        request=ImpactProjectCreateUpdateSerializer,
+        responses={200: ImpactProjectSerializer},
+    )
     @transaction.atomic
     def patch(self, request, ig_id, project_id):
         user_id = JWTUtils.fetch_user_id(request)
@@ -167,6 +197,10 @@ class ImpactProjectDetailAPI(APIView):
             response={"impactProject": ImpactProjectSerializer(project).data}
         ).get_success_response()
 
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="Delete an Impact Project.",
+    )
     def delete(self, request, ig_id, project_id):
         roles = JWTUtils.fetch_role(request)
 
@@ -195,6 +229,10 @@ class ImpactProjectDetailAPI(APIView):
 class ImpactProjectImageAPI(APIView):
     authentication_classes = [CustomizePermission]
 
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="Upload or replace an Impact Project's image.",
+    )
     def post(self, request, ig_id, project_id):
         roles = JWTUtils.fetch_role(request)
 

--- a/api/dashboard/ig/urls.py
+++ b/api/dashboard/ig/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from . import dash_ig_view
+from . import dash_ig_view, impact_project_view
 
 urlpatterns = [
     path('', dash_ig_view.InterestGroupAPI.as_view()),  # for get data and create new interest groups
@@ -8,6 +8,9 @@ urlpatterns = [
     path('request/<str:pk>/', dash_ig_view.InterestGroupRequestAPI.as_view()),  # PATCH: admin status update | DELETE: cancel request
     path('list/', dash_ig_view.InterestGroupListApi.as_view()),  # for public listing without admin permission
     path('csv/', dash_ig_view.InterestGroupCSV.as_view()),  # for IG data CSV download
+    path('<str:ig_id>/impact-projects/', impact_project_view.ImpactProjectListCreateAPI.as_view()),
+    path('<str:ig_id>/impact-projects/<str:project_id>/', impact_project_view.ImpactProjectDetailAPI.as_view()),
+    path('<str:ig_id>/impact-projects/<str:project_id>/image/', impact_project_view.ImpactProjectImageAPI.as_view()),
     path('<str:pk>/', dash_ig_view.InterestGroupAPI.as_view()),  # for edit and delete
     path('get/<str:pk>/', dash_ig_view.InterestGroupGetAPI.as_view()),  # for edit and delete
     path('<str:pk>/join/', dash_ig_view.InterestGroupMembershipAPI.as_view()),

--- a/api_docs/Impact_Project_API.md
+++ b/api_docs/Impact_Project_API.md
@@ -1,0 +1,233 @@
+# Impact Project API — Manual Test Guide
+
+Base path: `/api/v1/dashboard/ig/<ig_id>/impact-projects/`
+
+Auth: `Authorization: Bearer <accessToken>` header on every request.
+- List (`GET`) works for any authenticated user.
+- Create/Update/Delete/Image-upload require the caller to be an `Admins`, `IG Lead`, or that specific IG's `<CODE> IGLead` role (checked via `_can_manage_ig`).
+
+---
+
+## 1. List impact projects for an IG
+
+`GET /api/v1/dashboard/ig/{ig_id}/impact-projects/`
+
+No body. Supports the standard pagination query params: `pageIndex` (default 1), `perPage` (default 10), `search` (matches `title`/`description`), `sortBy` (`title`, `created_on`, `updated_on`, prefix with `-` to reverse).
+
+**Response 200**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": [] },
+  "response": {
+    "data": [
+      {
+        "id": "b1f2c3d4-...",
+        "ig_id": "ig-uuid-here",
+        "title": "Community LMS",
+        "image": "https://<BE_DOMAIN_NAME>/muback-media/impact_project/image/b1f2c3d4-....png",
+        "description": "An online learning platform built for students and mentors.",
+        "team": [
+          { "muid": "alvin-dennis@mulearn", "name": "Alvin Dennis", "is_lead": true },
+          { "muid": "akhil-raj@mulearn", "name": "Akhil Raj", "is_lead": false }
+        ],
+        "links": [
+          { "label": "github", "url": "https://github.com/example/community-lms" },
+          { "label": "live", "url": "https://lms.example.com" }
+        ],
+        "created_by": "Full Name",
+        "updated_by": "Full Name",
+        "created_at": "2026-07-24T08:25:30Z",
+        "updated_at": "2026-07-24T08:25:30Z"
+      }
+    ],
+    "pagination": {
+      "count": 1,
+      "totalPages": 1,
+      "isNext": false,
+      "isPrev": false,
+      "nextPage": null
+    }
+  }
+}
+```
+
+**Response 400 — IG not found**
+```json
+{
+  "hasError": true,
+  "statusCode": 400,
+  "message": { "general": ["Interest Group Does Not Exist"] },
+  "response": {}
+}
+```
+
+---
+
+## 2. Create an impact project
+
+`POST /api/v1/dashboard/ig/{ig_id}/impact-projects/`
+`Content-Type: application/json`
+
+`team[].muid` is required for every team member and must match an existing user's `muid`. `is_lead` may be `true` for zero, one, or multiple members — there is no restriction on lead count. `links` is optional and open-ended — any `label` is allowed, not just github/live/figma.
+
+**Request body**
+```json
+{
+  "title": "Community LMS",
+  "description": "An online learning platform built for students and mentors.",
+  "team": [
+    { "muid": "alvin-dennis@mulearn", "is_lead": true },
+    { "muid": "akhil-raj@mulearn", "is_lead": false }
+  ],
+  "links": [
+    { "label": "github", "url": "https://github.com/example/community-lms" },
+    { "label": "live", "url": "https://lms.example.com" },
+    { "label": "figma", "url": "https://figma.com/file/example" }
+  ]
+}
+```
+
+**Response 200**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": [] },
+  "response": {
+    "impactProject": {
+      "id": "b1f2c3d4-...",
+      "ig_id": "ig-uuid-here",
+      "title": "Community LMS",
+      "image": null,
+      "description": "An online learning platform built for students and mentors.",
+      "team": [
+        { "muid": "alvin-dennis@mulearn", "name": "Alvin Dennis", "is_lead": true },
+        { "muid": "akhil-raj@mulearn", "name": "Akhil Raj", "is_lead": false }
+      ],
+      "links": [
+        { "label": "github", "url": "https://github.com/example/community-lms" },
+        { "label": "live", "url": "https://lms.example.com" },
+        { "label": "figma", "url": "https://figma.com/file/example" }
+      ],
+      "created_by": "Your Full Name",
+      "updated_by": "Your Full Name",
+      "created_at": "2026-07-24T08:25:30Z",
+      "updated_at": "2026-07-24T08:25:30Z"
+    }
+  }
+}
+```
+
+**Error cases to try:**
+
+a) Not a lead/admin of this IG → `400`
+```json
+{ "hasError": true, "statusCode": 400, "message": { "general": ["You do not have permission to manage this Interest Group"] }, "response": {} }
+```
+
+b) A team entry missing `muid` → `400`
+```json
+{ "hasError": true, "statusCode": 400, "message": { "general": ["Each team member requires a 'muid'."] }, "response": {} }
+```
+
+c) `team[].muid` doesn't exist → `400`
+```json
+{ "hasError": true, "statusCode": 400, "message": { "general": ["No user found with muid 'no-such-muid'"] }, "response": {} }
+```
+
+d) Bad URL in `links` → `400`
+```json
+{ "hasError": true, "statusCode": 400, "message": { "general": ["'not-a-url' is not a valid URL."] }, "response": {} }
+```
+
+---
+
+## 3. Update an impact project
+
+`PATCH /api/v1/dashboard/ig/{ig_id}/impact-projects/{project_id}/`
+`Content-Type: application/json`
+
+Partial update — send only the fields you want to change. Omitting `team`/`links` leaves them untouched; including either one **replaces the entire list** (not a merge). `ig` and `created_by` are silently ignored if sent — a project can't be reassigned to another IG or have its creator forged through this endpoint.
+
+**Request body (rename + replace team)**
+```json
+{
+  "title": "Community LMS v2",
+  "team": [
+    { "muid": "alvin-dennis@mulearn", "is_lead": true }
+  ]
+}
+```
+
+**Response 200** — same shape as create's response, under `"impactProject"`.
+
+---
+
+## 4. Delete an impact project
+
+`DELETE /api/v1/dashboard/ig/{ig_id}/impact-projects/{project_id}/`
+
+No body.
+
+**Response 200**
+```json
+{ "hasError": false, "statusCode": 200, "message": { "general": ["Impact Project deleted successfully"] }, "response": {} }
+```
+
+---
+
+## 5. Upload / replace the project image
+
+`POST /api/v1/dashboard/ig/{ig_id}/impact-projects/{project_id}/image/`
+`Content-Type: multipart/form-data`
+
+**Form fields**
+| key | value |
+|---|---|
+| `image` | (file) a `.png`/`.jpg` under 5 MB |
+
+**Response 200**
+```json
+{
+  "hasError": false,
+  "statusCode": 200,
+  "message": { "general": [] },
+  "response": { "image": "https://<BE_DOMAIN_NAME>/muback-media/impact_project/image/b1f2c3d4-....png" }
+}
+```
+
+**Error cases:**
+- No file attached → `400` `"No image provided"`
+- Non-image file → `400` `"Expected an image file"`
+- File over 5 MB → `400` `"Image must be under 5 MB"`
+
+---
+
+## Quick curl examples
+
+```bash
+# List
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/v1/dashboard/ig/<ig_id>/impact-projects/
+
+# Create
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"title":"Community LMS","description":"desc","team":[{"muid":"<some-existing-muid>","is_lead":true}],"links":[{"label":"github","url":"https://github.com/example/lms"}]}' \
+  http://localhost:8000/api/v1/dashboard/ig/<ig_id>/impact-projects/
+
+# Update
+curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"title":"Renamed"}' \
+  http://localhost:8000/api/v1/dashboard/ig/<ig_id>/impact-projects/<project_id>/
+
+# Delete
+curl -X DELETE -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/v1/dashboard/ig/<ig_id>/impact-projects/<project_id>/
+
+# Image upload
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -F "image=@/path/to/photo.png" \
+  http://localhost:8000/api/v1/dashboard/ig/<ig_id>/impact-projects/<project_id>/image/
+```

--- a/db/impact_project.py
+++ b/db/impact_project.py
@@ -46,10 +46,6 @@ class ImpactProjectUserLink(models.Model):
     class Meta:
         managed = False
         db_table = "impact_project_user_link"
-        # Actual index (idx_ipul_project) lives in the raw DDL — see
-        # alter-scripts/alter-1.64.sql. Django never applies Meta.indexes for
-        # managed=False models, so it is intentionally not declared here.
-
 
 class ImpactProjectLink(models.Model):
     id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
@@ -62,6 +58,3 @@ class ImpactProjectLink(models.Model):
     class Meta:
         managed = False
         db_table = "impact_project_link"
-        # Actual index (idx_ipl_project) lives in the raw DDL — see
-        # alter-scripts/alter-1.64.sql. Django never applies Meta.indexes for
-        # managed=False models, so it is intentionally not declared here.

--- a/db/impact_project.py
+++ b/db/impact_project.py
@@ -1,0 +1,67 @@
+import uuid
+
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+from django.db import models
+
+from db.task import InterestGroup
+from db.user import User
+from decouple import config as decouple_config
+
+
+class ImpactProject(models.Model):
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    ig = models.ForeignKey(InterestGroup, on_delete=models.CASCADE, db_column="ig_id",
+                           related_name="impact_project_ig")
+    title = models.CharField(max_length=200)
+    description = models.TextField()
+    updated_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="updated_by",
+                                   related_name="impact_project_updated_by")
+    updated_at = models.DateTimeField(auto_now=True)
+    created_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="created_by",
+                                   related_name="impact_project_created_by")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        managed = False
+        db_table = "impact_project"
+
+    @property
+    def image(self):
+        fs = FileSystemStorage()
+        path = f"impact_project/image/{self.id}.png"
+        if fs.exists(path):
+            return f"{decouple_config('BE_DOMAIN_NAME')}{fs.url(path)}"
+
+
+class ImpactProjectUserLink(models.Model):
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    project = models.ForeignKey(ImpactProject, on_delete=models.CASCADE, db_column="project_id",
+                                related_name="impact_project_user_link_project")
+    user = models.ForeignKey(User, on_delete=models.CASCADE, db_column="user_id",
+                             related_name="impact_project_user_link_user")
+    is_lead = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        managed = False
+        db_table = "impact_project_user_link"
+        indexes = [
+            models.Index(fields=["project"], name="idx_ipul_project"),
+        ]
+
+
+class ImpactProjectLink(models.Model):
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    project = models.ForeignKey(ImpactProject, on_delete=models.CASCADE, db_column="project_id",
+                                related_name="impact_project_link_project")
+    label = models.CharField(max_length=50)
+    url = models.URLField(max_length=500)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        managed = False
+        db_table = "impact_project_link"
+        indexes = [
+            models.Index(fields=["project"], name="idx_ipl_project"),
+        ]

--- a/db/impact_project.py
+++ b/db/impact_project.py
@@ -46,9 +46,9 @@ class ImpactProjectUserLink(models.Model):
     class Meta:
         managed = False
         db_table = "impact_project_user_link"
-        indexes = [
-            models.Index(fields=["project"], name="idx_ipul_project"),
-        ]
+        # Actual index (idx_ipul_project) lives in the raw DDL — see
+        # alter-scripts/alter-1.64.sql. Django never applies Meta.indexes for
+        # managed=False models, so it is intentionally not declared here.
 
 
 class ImpactProjectLink(models.Model):
@@ -62,6 +62,6 @@ class ImpactProjectLink(models.Model):
     class Meta:
         managed = False
         db_table = "impact_project_link"
-        indexes = [
-            models.Index(fields=["project"], name="idx_ipl_project"),
-        ]
+        # Actual index (idx_ipl_project) lives in the raw DDL — see
+        # alter-scripts/alter-1.64.sql. Django never applies Meta.indexes for
+        # managed=False models, so it is intentionally not declared here.

--- a/db/models.py
+++ b/db/models.py
@@ -21,6 +21,7 @@ from db import (  # noqa: F401
     donor,
     events,
     hackathon,
+    impact_project,
     integrations,
     launchpad,
     learning_circle,


### PR DESCRIPTION
### Summary
Adds a new backend entity, ImpactProject, scoped one-to-many under InterestGroup, with full CRUD + image upload, so IG leads/mentors can showcase real projects built by their IG's members. 