### PR TITLE
feat: convert thinktank from URL to muid-based user field

### DIFF
--- a/api/dashboard/ig/dash_ig_serializer.py
+++ b/api/dashboard/ig/dash_ig_serializer.py
@@ -198,7 +198,7 @@ class InterestGroupSerializer(serializers.ModelSerializer):
                     pass  # leave as-is (plain string)
 
         # MUID fields — parse + enrich with user details
-        for field in ["leads"]:
+        for field in ["leads", "thinktank"]:
             val = data.get(field)
             if isinstance(val, str) and val:
                 try:

--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -27,7 +27,7 @@ from drf_spectacular.utils import extend_schema
 from api.notification.notifications_utils import NotificationUtils
 
 
-def _validate_muids(request_data, fields=("leads", "mentors")):
+def _validate_muids(request_data, fields=("leads", "mentors", "thinktank")):
     """
     Validate that every muid in the given fields actually exists in the User table.
     Returns (is_valid, error_message).
@@ -167,6 +167,7 @@ class InterestGroupAPI(APIView):
             "people_to_follow",
             "leads",
             "mentors",
+            "thinktank",
         ]:
             if fld in request_data and not isinstance(request_data.get(fld), str):
                 try:
@@ -258,6 +259,7 @@ class InterestGroupAPI(APIView):
             "people_to_follow",
             "leads",
             "mentors",
+            "thinktank",
         ]:
             if fld in request_data and not isinstance(request_data.get(fld), str):
                 try:
@@ -431,6 +433,7 @@ class InterestGroupGetAPI(APIView):
             "people_to_follow",
             "leads",
             "mentors",
+            "thinktank",
         ]:
             if fld in request_data and not isinstance(request_data.get(fld), str):
                 try:
@@ -729,6 +732,7 @@ class InterestGroupRequestAPI(APIView):
             "people_to_follow",
             "leads",
             "mentors",
+            "thinktank",
         ]:
             if fld in request_data and not isinstance(request_data.get(fld), str):
                 try:


### PR DESCRIPTION
## Summary
Converts the `thinktank` field in Interest Groups from a plain URL text input 
to a muid-based user search field — same pattern as `leads` and `mentors`.

## Changes

api/dashboard/ig/dash_ig_view.py
api/dashboard/ig/dash_ig_serializer.py