### PR TITLE
Feat/company system

### DIFF
--- a/api/dashboard/company/analytics_views.py
+++ b/api/dashboard/company/analytics_views.py
@@ -388,7 +388,7 @@ class CompanyTalentPoolInsightsAPIView(APIView):
         description="Top-skills and top-colleges insights across the (optionally filtered) talent pool. Pass format=csv for a CSV download.",
         parameters=[
             OpenApiParameter("district_id", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False),
-            OpenApiParameter("format", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False, description="json (default) or csv"),
+            OpenApiParameter("export", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False, description="Pass export=csv for a downloadable CSV file (default: json)"),
         ],
     )
     def get(self, request):
@@ -438,7 +438,7 @@ class CompanyTalentPoolInsightsAPIView(APIView):
             .order_by("-learner_count")[:10]
         )
 
-        if request.query_params.get("format", "json").lower() == "csv":
+        if request.query_params.get("export", "").lower() == "csv":
             import csv
             from django.http import HttpResponse
 

--- a/api/dashboard/company/analytics_views.py
+++ b/api/dashboard/company/analytics_views.py
@@ -462,3 +462,145 @@ class CompanyTalentPoolInsightsAPIView(APIView):
             "top_colleges": top_colleges,
         }).get_success_response()
 
+
+
+
+import datetime
+from django.utils import timezone
+from django.db.models.functions import TruncQuarter
+
+class CompanyCampusTrendAPIView(APIView):
+    """
+    PRD §12 — Quarter-over-quarter campus engagement trend analytics.
+    High-performance bulk aggregation using TruncQuarter (3 DB queries total).
+    """
+    permission_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Company Analytics'],
+        description="Quarter-over-quarter engagement metrics for a specific campus.",
+        parameters=[
+            OpenApiParameter("campus_id", OpenApiTypes.STR, OpenApiParameter.QUERY, required=True),
+            OpenApiParameter("quarters", OpenApiTypes.INT, OpenApiParameter.QUERY, required=False),
+        ],
+    )
+    def get(self, request):
+        from db.task import KarmaActivityLog
+        from db.organization import Organization, UserOrganizationLink
+        from db.events import Event
+
+        user_id = JWTUtils.fetch_user_id(request)
+        company = _get_company_for_user(user_id)
+        if not company:
+            return CustomResponse(
+                general_message="Company profile not found or access denied."
+            ).get_failure_response(status_code=404)
+
+        campus_id = request.query_params.get("campus_id")
+        if not campus_id:
+            return CustomResponse(
+                general_message="campus_id query parameter is required."
+            ).get_failure_response(status_code=400)
+
+        campus = Organization.objects.filter(
+            id=campus_id, org_type=OrganizationType.COLLEGE.value
+        ).first()
+        if not campus:
+            return CustomResponse(
+                general_message="Campus organization not found."
+            ).get_failure_response(status_code=404)
+
+        try:
+            num_quarters = int(request.query_params.get("quarters", 4))
+        except ValueError:
+            num_quarters = 4
+
+        # Calculate overall start date (e.g. 4 quarters back)
+        now = timezone.now()
+        start_date = now - datetime.timedelta(days=90 * num_quarters)
+
+        # Pre-fetch all user IDs from this campus once
+        campus_user_ids = list(
+            UserOrganizationLink.objects.filter(org_id=campus_id).values_list("user_id", flat=True)
+        )
+
+        # BULK QUERY 1: Karma & Active Learners grouped by Quarter
+        karma_by_quarter = (
+            KarmaActivityLog.objects.filter(
+                user_id__in=campus_user_ids,
+                created_at__gte=start_date,
+            )
+            .annotate(q_start=TruncQuarter("created_at"))
+            .values("q_start")
+            .annotate(
+                karma_earned=Sum("karma"),
+                active_learners=Count("user_id", distinct=True)
+            )
+        )
+        karma_map = {
+            item["q_start"].strftime("%Y-%m-%d"): item for item in karma_by_quarter if item["q_start"]
+        }
+
+        # BULK QUERY 2: Job Applications grouped by Quarter
+        company_jobs = CompanyJob.objects.filter(company=company, is_deleted=False)
+        apps_by_quarter = (
+            UserJobApplication.objects.filter(
+                job__in=company_jobs,
+                user_id__in=campus_user_ids,
+                applied_at__gte=start_date,
+            )
+            .annotate(q_start=TruncQuarter("applied_at"))
+            .values("q_start")
+            .annotate(job_applicants=Count("user_id", distinct=True))
+        )
+        apps_map = {
+            item["q_start"].strftime("%Y-%m-%d"): item["job_applicants"] for item in apps_by_quarter if item["q_start"]
+        }
+
+        # BULK QUERY 3: Company Events grouped by Quarter
+        sessions_map = {}
+        if company.org_id:
+            events_by_quarter = (
+                Event.objects.filter(
+                    organiser_type=Event.OrganiserType.COMPANY,
+                    organiser_org_id=company.org_id,
+                    created_at__gte=start_date,
+                )
+                .annotate(q_start=TruncQuarter("created_at"))
+                .values("q_start")
+                .annotate(sessions_count=Count("id"))
+            )
+            sessions_map = {
+                item["q_start"].strftime("%Y-%m-%d"): item["sessions_count"] for item in events_by_quarter if item["q_start"]
+            }
+
+        # Build response payload by merging dictionary results
+        # (Zero loops over database queries!)
+        trend_data = []
+        # Calculate quarter boundaries for formatting output
+        current_year = now.year
+        current_quarter = (now.month - 1) // 3 + 1
+
+        for i in range(num_quarters - 1, -1, -1):
+            q_index = current_quarter - 1 - i
+            year_offset = q_index // 4
+            target_q = (q_index % 4) + 1
+            target_year = current_year + year_offset
+
+            q_month = (target_q - 1) * 3 + 1
+            q_key = f"{target_year}-{q_month:02d}-01"
+
+            karma_info = karma_map.get(q_key, {})
+            trend_data.append({
+                "quarter": f"Q{target_q} {target_year}",
+                "active_learners": karma_info.get("active_learners", 0),
+                "job_applicants": apps_map.get(q_key, 0),
+                "karma_earned": karma_info.get("karma_earned", 0),
+                "sessions_held": sessions_map.get(q_key, 0),
+            })
+
+        return CustomResponse(response={
+            "campus_id": str(campus.id),
+            "campus_name": campus.title,
+            "trend": trend_data,
+        }).get_success_response()

--- a/api/dashboard/company/company_views.py
+++ b/api/dashboard/company/company_views.py
@@ -132,6 +132,23 @@ class CompanyAdminLinkAcceptAPI(APIView):
         return CustomResponse(
             general_message=f"Invitation {'accepted' if accept else 'declined'} successfully."
         ).get_success_response()
+    def post(self, request, link_id):
+        from utils.utils import DateTimeUtils
+        user_id = JWTUtils.fetch_user_id(request)
+        accept = bool(request.data.get('accept', True))
+
+        link = CompanyAdminLink.objects.filter(id=link_id, user_id=user_id, status=CompanyAdminLink.Status.PENDING).first()
+        if not link:
+            return CustomResponse(general_message="Pending invitation not found.").get_failure_response(status_code=404)
+
+        link.status = CompanyAdminLink.Status.ACCEPTED if accept else CompanyAdminLink.Status.DECLINED
+        link.responded_at = DateTimeUtils.get_current_utc_time()
+        link.updated_by_id = user_id
+        link.save(update_fields=["status", "responded_at", "updated_by_id"])
+
+        return CustomResponse(
+            general_message=f"Invitation {'accepted' if accept else 'declined'} successfully."
+        ).get_success_response()
 
 
 class CompanyAdminLinkRevokeAPI(APIView):
@@ -364,13 +381,13 @@ class CompanyProfileAPI(APIView):
 
     @extend_schema(
         tags=['Dashboard - Company'],
-        description="Update the profile of the authenticated company (creator or approved company mentor).",
+        description="Update the profile of the authenticated company (creator only).",
         request=serializers.CompanyUpdateSerializer,
         responses={200: serializers.CompanyUpdateSerializer},
     )
     def patch(self, request):
         user_id = JWTUtils.fetch_user_id(request)
-        company = _get_company_for_user(user_id)
+        company = Company.objects.filter(company_user_id=user_id, status="verified").first()
         
         if not company:
             return CustomResponse(

--- a/api/dashboard/company/job_views.py
+++ b/api/dashboard/company/job_views.py
@@ -120,8 +120,23 @@ class CompanyJobDetailAPI(APIView):
         if not job:
             return CustomResponse(general_message="Job not found or access denied.").get_failure_response(status_code=404)
 
+        # Rejected jobs are permanently locked — create a new posting instead.
+        if job.status == CompanyJob.Status.REJECTED:
+            return CustomResponse(
+                general_message="A rejected job cannot be edited. Create a new posting instead."
+            ).get_failure_response(status_code=403)
+
         data = request.data.copy()
         requested_status = data.get('status')
+
+        # A job in Needs Revision going back to Active/Pending Approval = resubmit.
+        # Force it through Pending Approval regardless of who is patching.
+        if (
+            job.status == CompanyJob.Status.NEEDS_REVISION
+            and requested_status in (CompanyJob.Status.ACTIVE, CompanyJob.Status.PENDING_APPROVAL)
+        ):
+            data['status'] = CompanyJob.Status.PENDING_APPROVAL
+
         if requested_status == CompanyJob.Status.ACTIVE and not _is_company_owner(user_id, company):
             # Job publish gate (§3.1): only the owner may flip a job straight
             # to Active. A non-owner mentor should submit for approval
@@ -213,6 +228,54 @@ class CompanyJobApproveAPI(APIView):
             pass
 
         return CustomResponse(general_message="Job approved and published successfully.").get_success_response()
+class CompanyJobRequestChangesAPI(APIView):
+    """Owner-only: send a job back to the mentor for revision."""
+    permission_classes = [CustomizePermission]
+
+    def post(self, request, job_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        job = CompanyJob.objects.filter(
+            id=job_id, is_deleted=False, 
+            status=CompanyJob.Status.PENDING_APPROVAL,
+            company__status="verified"
+        ).first()
+        if not job:
+            return CustomResponse(
+                general_message="Job not found or not pending approval."
+            ).get_failure_response(status_code=404)
+
+        if not _is_company_owner(user_id, job.company):
+            return CustomResponse(
+                general_message="Only the company owner can request changes."
+            ).get_failure_response(status_code=403)
+
+        note = (request.data.get("note") or "").strip()
+        if not note:
+            return CustomResponse(
+                general_message="A revision note is required."
+            ).get_failure_response()
+
+        job.status = CompanyJob.Status.NEEDS_REVISION
+        job.rejection_reason = note   # reuse this field for the owner's note
+        job.save(update_fields=["status", "rejection_reason", "updated_at","updated_by_id"])
+
+        # Notify the mentor
+        try:
+            from api.notification.notifications_utils import NotificationUtils
+            from db.user import User
+            actor = User.every.filter(id=user_id).first()
+            if job.created_by and actor:
+               NotificationUtils.insert_notification(
+               user=job.created_by,
+               title="Job Posting Needs Revision",
+               description=f'Your job "{job.title}" needs changes: {note}',
+            button=None, url=None, created_by=actor,
+            )
+        except Exception:
+            pass  
+        return CustomResponse(
+            general_message="Revision requested. Mentor notified."
+        ).get_success_response()
 
 
 class CompanyJobRejectAPI(APIView):

--- a/api/dashboard/company/urls.py
+++ b/api/dashboard/company/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("jobs/<str:job_id>/",        job_views.CompanyJobDetailAPI.as_view()),
     path("jobs/<str:job_id>/approve/", job_views.CompanyJobApproveAPI.as_view()),
     path("jobs/<str:job_id>/reject/",  job_views.CompanyJobRejectAPI.as_view()),
+    path("jobs/<str:job_id>/request-changes/", job_views.CompanyJobRequestChangesAPI.as_view()),
     path("jobs/<str:job_id>/view/",   job_views.TrackJobViewAPIView.as_view()),
     path("jobs/<str:job_id>/analytics/", job_views.CompanyJobEngagementAnalyticsAPIView.as_view()),
     path("jobs/<str:job_id>/apply/",  job_views.JobApplicationAPI.as_view()),
@@ -29,6 +30,7 @@ urlpatterns = [
     path("analytics/gigs/",           analytics_views.CompanyGigAnalyticsAPI.as_view()),
     path("analytics/tasks/",          analytics_views.CompanyTaskAnalyticsAPI.as_view()),
     path("talent-pool/analytics/",    analytics_views.CompanyTalentPoolAnalyticsAPIView.as_view()),
+    path("analytics/campus/trend/",   analytics_views.CompanyCampusTrendAPIView.as_view()),
     path("analytics/campus/",         analytics_views.CompanyCampusAnalyticsAPIView.as_view()),
     path("talent-pool/insights/",     analytics_views.CompanyTalentPoolInsightsAPIView.as_view()),
 

--- a/db/job.py
+++ b/db/job.py
@@ -6,6 +6,7 @@ class CompanyJob(models.Model):
     class Status(models.TextChoices):
         DRAFT = 'Draft', 'Draft'
         PENDING_APPROVAL = 'Pending Approval', 'Pending Approval'
+        NEEDS_REVISION = "Needs Revision"  
         ACTIVE = 'Active', 'Active'
         CLOSED = 'Closed', 'Closed'
         EXPIRED = 'Expired', 'Expired'


### PR DESCRIPTION
This pull request introduces several important changes to the company dashboard API, focusing on improved job workflow controls, new analytics endpoints, and enhanced clarity in API usage. The most notable updates include adding a quarter-over-quarter campus engagement analytics API, refining job posting workflows with new statuses and endpoints, and clarifying query parameters for talent pool insights.

**New Features and Endpoints**

* Added `CompanyCampusTrendAPIView` to provide quarter-over-quarter engagement analytics for a specific campus, including metrics like active learners, job applicants, karma earned, and sessions held. This endpoint uses efficient bulk aggregation and is available at `analytics/campus/trend/`. [[1]](diffhunk://#diff-b085a94550b357c810ded26f85729b1892f4fcdbedfe25ac3203452d4610e271R465-R606) [[2]](diffhunk://#diff-a1b62aefe552e47a76b19624bdb4cca9a3e6d30385c28f8eb8c1a79915e0f769R33)
* Introduced `CompanyJobRequestChangesAPI` and the corresponding URL route (`jobs/<str:job_id>/request-changes/`) to allow company owners to send jobs back to mentors for revision, including notification logic and revision notes. [[1]](diffhunk://#diff-470ba08a1ad76a77f5f6df17f626b54a497d1a08bb2e638ca2b65b65d7522b61R231-R278) [[2]](diffhunk://#diff-a1b62aefe552e47a76b19624bdb4cca9a3e6d30385c28f8eb8c1a79915e0f769R18)

**Job Workflow and Permissions Enhancements**

* Added a new `NEEDS_REVISION` status to the `CompanyJob.Status` enum, supporting the revised job workflow.
* Updated the job patch logic to prevent editing of rejected jobs and to enforce that jobs in "Needs Revision" status must be resubmitted for approval, regardless of who is patching.

**API Behavior and Parameter Improvements**

* Changed the query parameter for CSV export in `CompanyTalentPoolInsightsAPIView` from `format` to `export`, and updated all related logic and documentation for clarity. [[1]](diffhunk://#diff-b085a94550b357c810ded26f85729b1892f4fcdbedfe25ac3203452d4610e271L391-R391) [[2]](diffhunk://#diff-b085a94550b357c810ded26f85729b1892f4fcdbedfe25ac3203452d4610e271L441-R441)
* Restricted the company profile update endpoint to only allow the company creator (not mentors) to update the profile, refining the permission logic and documentation.

These changes collectively improve the robustness, usability, and clarity of the company dashboard API.