### PR TITLE
fix: Circle Lead not updating after leadership transfer

### DIFF
--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -1022,8 +1022,12 @@ class LearningCircleMemberDetailsView(APIView):
             # Sort by karma (highest first)
             member_details = sorted(member_details, key=lambda x: x['ig_karma'], reverse=True)
 
-            # Build owner details from the circle's created_by FK
-            owner = circle.created_by
+            # Build owner details from the current leader, falling back to circle creator
+            leader_id = next(iter(leaders), None)
+            if leader_id and leader_id in users:
+                owner = users[leader_id]
+            else:
+                owner = circle.created_by
             owner_details = {
                 'id': owner.id,
                 'full_name': owner.full_name,


### PR DESCRIPTION
## Summary

Fixes a bug where the "Circle Lead" (owner) displayed on the Learning Circle 
detail page always showed the **original creator** of the circle, even after 
leadership was transferred to another member.