### PR TITLE
feat: add status filter to learning circle list API

### DIFF
--- a/api/dashboard/learningcircle/learningcircle_serializer.py
+++ b/api/dashboard/learningcircle/learningcircle_serializer.py
@@ -265,11 +265,12 @@ class LearningCircleListMinSerializer(serializers.ModelSerializer):
     total_members = serializers.IntegerField(read_only=True)
     is_joined = serializers.SerializerMethodField()
     is_creator = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
     # attendees = serializers.SerializerMethodField()
     class Meta:
         model = LearningCircle
         # The 'attendees' field is removed as 'total_members' is used instead.
-        fields = ["id", "ig", "title", "org", "total_members", "is_joined", "is_creator"]
+        fields = ["id", "ig", "title", "org", "total_members", "is_joined", "is_creator", "status"]
 
     def get_is_joined(self, obj):
         user_id = self.context.get("user_id")
@@ -289,6 +290,18 @@ class LearningCircleListMinSerializer(serializers.ModelSerializer):
         if not user_id:
             return False
         return obj.created_by_id == user_id
+
+    def get_status(self, obj):
+        user_id = self.context.get("user_id")
+        if not user_id:
+            return "not_joined"
+        joined_ids = self.context.get("joined_circle_ids")
+        if joined_ids is not None and obj.id in joined_ids:
+            return "joined"
+        pending_ids = self.context.get("pending_circle_ids")
+        if pending_ids is not None and obj.id in pending_ids:
+            return "pending"
+        return "not_joined"
 
 
 class CircleMeetingLogCreateEditSerializer(serializers.ModelSerializer):

--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -77,6 +77,26 @@ class LearningCircleView(APIView):
         if ig_id:
             learning_circles = learning_circles.filter(ig_id=ig_id)
 
+        status = request.query_params.get("status")
+        if status:
+            if status == "joined":
+                joined_ids = UserCircleLink.objects.filter(
+                    user_id=user_id, accepted=True
+                ).values_list("circle_id", flat=True)
+                learning_circles = learning_circles.filter(id__in=joined_ids)
+            elif status == "pending":
+                pending_ids = UserCircleLink.objects.filter(
+                    user_id=user_id, accepted__isnull=True
+                ).values_list("circle_id", flat=True)
+                learning_circles = learning_circles.filter(id__in=pending_ids)
+            elif status == "not_joined":
+                member_ids = UserCircleLink.objects.filter(
+                    user_id=user_id,
+                ).filter(
+                    Q(accepted=True) | Q(accepted__isnull=True)
+                ).values_list("circle_id", flat=True)
+                learning_circles = learning_circles.exclude(id__in=member_ids)
+
         paginated_queryset = CommonUtils.get_paginated_queryset(
             learning_circles,
             request,
@@ -91,12 +111,20 @@ class LearningCircleView(APIView):
                 circle_id__in=page_circle_ids,
             ).values_list("circle_id", flat=True)
         )
+        pending_circle_ids = set(
+            UserCircleLink.objects.filter(
+                user_id=user_id,
+                accepted__isnull=True,
+                circle_id__in=page_circle_ids,
+            ).values_list("circle_id", flat=True)
+        )
         serializer = LearningCircleListMinSerializer(
             page,
             many=True,
             context={
                 "user_id": user_id,
                 "joined_circle_ids": joined_circle_ids,
+                "pending_circle_ids": pending_circle_ids,
             },
         )
         return CustomResponse().paginated_response(


### PR DESCRIPTION
## API Changes

### Query Parameter
`GET /api/v1/dashboard/learningcircle/list/?status=<value>`

| Value | Behavior |
|---|---|
| `joined` | Only circles the user has joined (`accepted=True`) |
| `pending` | Only circles with a pending invite/join request (`accepted=NULL`) |
| `not_joined` | Only circles the user hasn't joined |

### Response
Each circle now includes a `status` field:
```json
{
  "id": "...",
  "ig": "Product Management",
  "title": "...",
  "org": "...",
  "total_members": 3,
  "is_joined": false,
  "is_creator": false,
  "status": "not_joined"
}
