### PR TITLE
fix: allow revoking sent invites via PATCH /join/<circle_id>/

### DIFF
--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -1267,11 +1267,11 @@ class CircleJoinAPI(APIView):
 
         try:
             link = UserCircleLink.objects.get(
-                id=link_id, circle=circle, is_invited=False, accepted__isnull=True
+                id=link_id, circle=circle, accepted__isnull=True
             )
         except UserCircleLink.DoesNotExist:
             return CustomResponse(
-                general_message="Pending join request not found"
+                general_message="Pending request not found"
             ).get_failure_response()
 
         action = request.data.get("action")


### PR DESCRIPTION
## Problem

The `PATCH /api/v1/dashboard/learningcircle/join/<circle_id>/` endpoint was only working 
for rejecting **join requests** (user → circle), but not for revoking **sent invitations** 
(circle lead → user).

This was because the `UserCircleLink` lookup in `CircleJoinAPI.patch()` filtered with 
`is_invited=False`, which excluded invitation records (`is_invited=True`).

## Fix

Removed the `is_invited=False` constraint from the lookup so the endpoint can find 
both join requests and sent invites by their `link_id`.
