### PR TITLE
feat: add ability to remove RSVP from scheduled meetings

### DIFF
--- a/api/dashboard/learningcircle/learningcircle_serializer.py
+++ b/api/dashboard/learningcircle/learningcircle_serializer.py
@@ -692,6 +692,7 @@ class CircleMeetupMinSerializer(serializers.ModelSerializer):
     is_ended = serializers.SerializerMethodField()
     is_joined = serializers.SerializerMethodField()
     is_rsvp = serializers.SerializerMethodField()
+    can_remove_rsvp = serializers.SerializerMethodField()
     attendees_count = serializers.SerializerMethodField()
     created_by = serializers.CharField(source="created_by.full_name", read_only=True)
     created_by_id = serializers.CharField(source="created_by.id", read_only=True)
@@ -720,6 +721,22 @@ class CircleMeetupMinSerializer(serializers.ModelSerializer):
             ).exists()
         return False
 
+    def get_can_remove_rsvp(self, obj):
+        user_id = self.context.get("user_id")
+        if not user_id:
+            return False
+        attendee = obj.circle_meeting_attendance_meet_id.filter(
+            user_id=user_id
+        ).first()
+        if not attendee or attendee.is_joined:
+            return False
+        aware_time = _aware_meet_time(obj.meet_time)
+        if aware_time is None:
+            return False
+        now = DateTimeUtils.get_current_utc_time()
+        cutoff_time = aware_time - timedelta(minutes=30)
+        return now < cutoff_time
+
     def get_attendees_count(self, obj):
         return obj.circle_meeting_attendance_meet_id.count()
 
@@ -738,6 +755,7 @@ class CircleMeetupMinSerializer(serializers.ModelSerializer):
             "recurrence",
             "meet_place",
             "is_rsvp",
+            "can_remove_rsvp",
             "circle_id",
             "coord_x",
             "coord_y",

--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -393,6 +393,42 @@ class LearningCircleRSVPAPI(APIView):
             general_message="You have successfully RSVP'd for the Circle Meeting"
         ).get_success_response()
 
+    @extend_schema(
+        tags=['Dashboard - Learningcircle'],
+        description="Remove Learning Circle RSVP. Allowed until 30 minutes before the meeting starts.",
+        responses={200: OpenApiResponse(description="RSVP removed successfully. No response body.")},
+    )
+    def delete(self, request, meet_id: str):
+        user_id = JWTUtils.fetch_user_id(request)
+        circle_meeting, error = _get_meeting_or_response(meet_id)
+        if error:
+            return error
+        if not _is_member_or_creator(circle_meeting.circle_id, user_id):
+            return CustomResponse(
+                general_message="Only circle members can modify RSVP for this meeting"
+            ).get_failure_response()
+        attendee = CircleMeetingAttendees.objects.filter(
+            meet_id=circle_meeting, user_id_id=user_id
+        ).first()
+        if not attendee:
+            return CustomResponse(
+                general_message="You have not RSVP'd for this meeting"
+            ).get_failure_response()
+        if attendee.is_joined:
+            return CustomResponse(
+                general_message="Cannot remove RSVP after joining the meeting"
+            ).get_failure_response()
+        now = DateTimeUtils.get_current_utc_time()
+        cutoff_time = circle_meeting.meet_time - timedelta(minutes=30)
+        if now >= cutoff_time:
+            return CustomResponse(
+                general_message="Cannot remove RSVP within 30 minutes of the meeting start time"
+            ).get_failure_response()
+        attendee.delete()
+        return CustomResponse(
+            general_message="Your RSVP has been successfully removed"
+        ).get_success_response()
+
 
 class LearningCircleJoinAPI(APIView):
     permission_classes = [CustomizePermission]


### PR DESCRIPTION
## Summary
Adds the ability for users to remove their RSVP from a scheduled Learning Circle meeting.

## Changes

### `learningcircle_views.py`
- Added `DELETE` method to `LearningCircleRSVPAPI`
- Endpoint: `DELETE /api/v1/dashboard/learningcircle/meeting/rsvp/<meet_id>/`
- Validates that:
  - User is a circle member
  - RSVP exists for the user
  - User has not already joined the meeting
  - Current time is more than 30 minutes before the meeting start time

### `learningcircle_serializer.py`
- Added `can_remove_rsvp` boolean field to `CircleMeetupMinSerializer`
- Returns `true` when the user has RSVP'd, has not joined, and the meeting is more than 30 minutes away
- Frontend can use this field to conditionally show/hide the "Remove RSVP" button

## Endpoint Details

| Method | URL | Description |
|--------|-----|-------------|
| `POST` | `meeting/rsvp/<meet_id>/` | RSVP to a meeting *(existing, unchanged)* |
| `DELETE` | `meeting/rsvp/<meet_id>/` | Remove RSVP *(new)* |

## Error Responses
| Scenario | Message |
|----------|---------|
| No RSVP exists | "You have not RSVP'd for this meeting" |
| Already joined | "Cannot remove RSVP after joining the meeting" |
| Within 30 min of start | "Cannot remove RSVP within 30 minutes of the meeting start time" |
| Not a member | "Only circle members can modify RSVP for this meeting" |

## Testing
- Tested via Postman (POST to RSVP, DELETE to remove)
- Verified 30-minute cutoff and joined-state validations
