### PR TITLE
fix(career_lab): ignore system-generated columns on Hiring CSV bulk import

### DIFF
--- a/api/dashboard/career_lab/career_lab_views.py
+++ b/api/dashboard/career_lab/career_lab_views.py
@@ -16,6 +16,10 @@ from . import career_lab_serializers
 
 CAREER_LAB_ADMIN_ROLES = [RoleType.ADMIN.value, RoleType.ASSOCIATE.value]
 
+# Columns present in the exported CSV that are system-managed and must be
+# ignored on re-import so an exported file can be re-imported unchanged.
+SYSTEM_GENERATED_FIELDS = {"id", "created_by", "created_at", "updated_by", "updated_at"}
+
 SEARCH_FIELDS = ["role", "organization", "title", "location"]
 SORT_FIELDS = {
     "lastdate": "lastdate",
@@ -226,6 +230,9 @@ class HiringCSVAPI(APIView):
             "Bulk import hiring postings from a CSV file. "
             "Expected columns: posted_date, role, organization, title, location, lastdate, "
             "applylink, jdlink, duration, remuneration, vacancies, extracontent. "
+            "System-generated columns from an exported CSV (id, created_by, created_at, "
+            "updated_by, updated_at) are ignored if present, so an exported file can be "
+            "re-imported unchanged. "
             "Import is create-only — existing rows are never updated."
         ),
     )
@@ -246,7 +253,11 @@ class HiringCSVAPI(APIView):
         created_count = 0
         row_errors = []
         for row_number, row in enumerate(reader, start=2):
-            cleaned_row = {key: (value if value not in ("", None) else None) for key, value in row.items()}
+            cleaned_row = {
+                key: (value if value not in ("", None) else None)
+                for key, value in row.items()
+                if key not in SYSTEM_GENERATED_FIELDS
+            }
             serializer = career_lab_serializers.HiringCSVRowSerializer(
                 data=cleaned_row, context={"user_id": user_id}
             )


### PR DESCRIPTION
## Description

### What
`HiringCSVAPI.post` now strips `id`, `created_by`, `created_at`, `updated_by`, and `updated_at` from each parsed row before handing it to `HiringCSVRowSerializer`, instead of passing every column straight through.

### Why
The CSV produced by **Export CSV** includes these system-managed columns. Re-uploading that same file via **Bulk Import** caused every row to fail. Since Bulk Import is create-only, these fields should never be user-supplied — they're now silently ignored if present, matching the behavior requested in the issue.

### Changes
- Added a `SYSTEM_GENERATED_FIELDS` constant (`id`, `created_by`, `created_at`, `updated_by`, `updated_at`) in `api/dashboard/career_lab/career_lab_views.py`.
- Filtered these keys out of each CSV row before building `cleaned_row` for validation.
- Updated the endpoint's `@extend_schema` description to document that these columns are ignored if present.

### Testing
- No existing test coverage for `HiringCSVAPI`; verified the change by inspection (row dict comprehension now excludes the listed keys before serializer validation).

Closes #446 
