### PR TITLE
fix:removed redundant created_by_id inside the object creation

### DIFF
--- a/api/dashboard/company/job_serializers.py
+++ b/api/dashboard/company/job_serializers.py
@@ -70,7 +70,7 @@ class JobCreateSerializer(serializers.ModelSerializer):
         validated_data['created_by_id'] = user_id
         validated_data['updated_by_id'] = user_id
 
-        job = CompanyJob.objects.create(company=company, created_by_id=user_id, **validated_data)
+        job = CompanyJob.objects.create(company=company, **validated_data)
 
         for rule_data in rules_data:
             CompanyJobRule.objects.create(job=job, **rule_data)


### PR DESCRIPTION
This pull request makes a minor change to the job creation logic in `job_serializers.py`. The `created_by_id` is no longer passed explicitly to the `CompanyJob.objects.create()` call, as it is already included in `validated_data`. This helps prevent redundancy and potential conflicts during object creation.