### PR TITLE
Bulk-issue VC achievements as admin-granted eligibility instead of direct issuance

### DIFF
--- a/api/dashboard/achievement/achievement_views.py
+++ b/api/dashboard/achievement/achievement_views.py
@@ -1108,40 +1108,64 @@ class AchievementIssueBulkAPIView(APIView):
             ach_idx = headers.index('achievement_id')
             
             success_count = 0
+            eligibility_granted_count = 0
             failed_rows = []
-            
-            from mu_celery.achievement_tasks import manual_issue_achievement
 
-            for i, row in enumerate(sheet.iter_rows(min_row=2, values_only=True), start=2):
+            from mu_celery.achievement_tasks import manual_issue_achievement, grant_achievement_eligibility
+
+            rows = list(sheet.iter_rows(min_row=2, values_only=True))
+            achievement_ids = {str(row[ach_idx]) for row in rows if row[ach_idx]}
+            achievements_by_id = {
+                achievement.id: achievement
+                for achievement in Achievement.objects.filter(id__in=achievement_ids)
+            }
+
+            for i, row in enumerate(rows, start=2):
                 muid = row[muid_idx]
                 achievement_id = row[ach_idx]
-                
+
                 if not muid or not achievement_id:
                     continue
-                     
+
                 try:
+                    achievement = achievements_by_id.get(str(achievement_id))
+                    if not achievement:
+                        failed_rows.append({"row": i, "muid": muid, "reason": "Achievement not found"})
+                        continue
+
                     user = User.objects.filter(muid=muid).first()
                     if not user:
                         failed_rows.append({"row": i, "muid": muid, "reason": "User not found"})
                         continue
 
-                    result = manual_issue_achievement(
-                        user_id=str(user.id),
-                        achievement_id=str(achievement_id),
-                        performed_by=user_id
-                    )
-                    
-                    if result['success']:
-                        success_count += 1
+                    if achievement.has_vc:
+                        result = grant_achievement_eligibility(
+                            user_id=str(user.id),
+                            achievement_id=str(achievement_id),
+                            granted_by=user_id,
+                        )
+                        if result['success']:
+                            eligibility_granted_count += 1
+                        else:
+                            failed_rows.append({"row": i, "muid": muid, "reason": result['message']})
                     else:
-                        failed_rows.append({"row": i, "muid": muid, "reason": result['message']})
-                        
+                        result = manual_issue_achievement(
+                            user_id=str(user.id),
+                            achievement_id=str(achievement_id),
+                            performed_by=user_id
+                        )
+                        if result['success']:
+                            success_count += 1
+                        else:
+                            failed_rows.append({"row": i, "muid": muid, "reason": result['message']})
+
                 except Exception as e:
                     failed_rows.append({"row": i, "muid": muid, "reason": str(e)})
 
             return CustomResponse(
                 response={
                     "success_count": success_count,
+                    "eligibility_granted_count": eligibility_granted_count,
                     "failed_count": len(failed_rows),
                     "failed_rows": failed_rows
                 },

--- a/api/dashboard/achievement/rule_engine.py
+++ b/api/dashboard/achievement/rule_engine.py
@@ -61,7 +61,10 @@ class RuleEvaluator:
             "achievement"
         )
 
+        rule_achievement_ids = set()
         for rule in active_rules:
+            rule_achievement_ids.add(str(rule.achievement_id))
+
             # Skip if already claimed
             if str(rule.achievement_id) in claimed_ids:
                 continue
@@ -69,6 +72,10 @@ class RuleEvaluator:
             result = self.evaluate_rule(rule)
             if result.eligible:
                 results.append(result)
+
+        results.extend(
+            self._get_manually_granted_results(claimed_ids, rule_achievement_ids)
+        )
 
         return results
 
@@ -93,13 +100,50 @@ class RuleEvaluator:
             "achievement"
         )
 
+        rule_achievement_ids = set()
         for rule in active_rules:
+            rule_achievement_ids.add(str(rule.achievement_id))
             result = self.evaluate_rule(rule)
             # Mark if already claimed without overriding the rule-based eligibility
             if str(rule.achievement_id) in claimed_ids:
                 result.claimed = True
                 result.reason = "Already claimed"
             results.append(result)
+
+        results.extend(
+            self._get_manually_granted_results(claimed_ids, rule_achievement_ids)
+        )
+
+        return results
+
+    def _get_manually_granted_results(
+        self, claimed_ids: set, rule_achievement_ids: set
+    ) -> List[EligibilityResult]:
+        """
+        Achievements with a pending admin-granted eligibility (e.g. from
+        bulk-issue of VC achievements), not already covered by a rule.
+        """
+        from db.achievement import AchievementEligibilityGrant
+
+        grants = AchievementEligibilityGrant.objects.filter(
+            user_id=self.user_id, status="pending"
+        ).select_related("achievement")
+
+        results = []
+        for grant in grants:
+            achievement_id = str(grant.achievement_id)
+            if achievement_id in claimed_ids or achievement_id in rule_achievement_ids:
+                continue
+
+            results.append(
+                EligibilityResult(
+                    eligible=True,
+                    achievement_id=achievement_id,
+                    achievement_name=grant.achievement.name,
+                    rule_version=0,
+                    reason="Manually granted",
+                )
+            )
 
         return results
 

--- a/db/achievement.py
+++ b/db/achievement.py
@@ -74,6 +74,48 @@ class UserAchievementsLog(models.Model):
         unique_together = [["user_id", "achievement_id"]]
 
 
+class AchievementEligibilityGrant(models.Model):
+    """
+    Admin-granted eligibility for an achievement (e.g. from bulk-issue of
+    VC achievements). Lets a user claim the achievement themselves - picking
+    their DID and issuing the VC - instead of it being force-issued.
+    """
+    STATUS_CHOICES = [
+        ("pending", "Pending"),
+        ("claimed", "Claimed"),
+        ("revoked", "Revoked"),
+    ]
+
+    id = models.CharField(primary_key=True, default=uuid.uuid4, max_length=36)
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="achievement_eligibility_grants",
+        db_column="user_id",
+    )
+    achievement = models.ForeignKey(
+        Achievement,
+        on_delete=models.CASCADE,
+        related_name="eligibility_grants",
+        db_column="achievement_id",
+    )
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="pending")
+    granted_by = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="achievement_eligibility_grants_given",
+        db_column="granted_by",
+    )
+    source = models.CharField(max_length=30, default="bulk_issue")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "achievement_eligibility_grant"
+        managed = False
+        unique_together = [["user", "achievement"]]
+
+
 # ============================================================================
 # NEW MODELS FOR ACHIEVEMENT SYSTEM
 # ============================================================================

--- a/mu_celery/achievement_tasks.py
+++ b/mu_celery/achievement_tasks.py
@@ -178,7 +178,8 @@ def claim_achievement(user_id: str, achievement_id: str) -> dict:
     )
 
     if not rule:
-        return {"success": False, "message": "No active rule for this achievement"}
+        # No rule - fall back to an admin-granted eligibility (e.g. from bulk-issue)
+        return _claim_via_eligibility_grant(user_id, achievement_id)
 
     # Evaluate eligibility
     evaluator = RuleEvaluator(user_id)
@@ -209,6 +210,102 @@ def claim_achievement(user_id: str, achievement_id: str) -> dict:
         }
     else:
         return {"success": False, "message": "Failed to claim achievement"}
+
+
+def _claim_via_eligibility_grant(user_id: str, achievement_id: str) -> dict:
+    """
+    Claim an achievement that has no active rule, using a pending
+    admin-granted eligibility (created by bulk-issue for VC achievements).
+    """
+    from db.achievement import Achievement, AchievementEligibilityGrant
+
+    grant = AchievementEligibilityGrant.objects.filter(
+        user_id=user_id, achievement_id=achievement_id, status="pending"
+    ).first()
+
+    if not grant:
+        return {"success": False, "message": "No active rule for this achievement"}
+
+    success = _issue_achievement(
+        user_id=user_id,
+        achievement_id=achievement_id,
+        rule_version=0,
+        source="manual_grant_claim",
+    )
+
+    if not success:
+        return {"success": False, "message": "Failed to claim achievement"}
+
+    grant.status = "claimed"
+    grant.save(update_fields=["status", "updated_at"])
+
+    achievement = Achievement.objects.get(id=achievement_id)
+    return {
+        "success": True,
+        "message": "Achievement claimed successfully!",
+        "vc_pending": achievement.has_vc,
+        "achievement_name": achievement.name,
+    }
+
+
+def grant_achievement_eligibility(
+    user_id: str,
+    achievement_id: str,
+    granted_by: str,
+) -> dict:
+    """
+    Grant a user eligibility to claim an achievement (admin operation, e.g.
+    bulk-issue of VC achievements) without issuing it directly. The user
+    claims it themselves later - picking their DID and issuing the VC.
+    """
+    from db.achievement import Achievement, AchievementEligibilityGrant, UserAchievementsLog
+
+    if UserAchievementsLog.objects.filter(
+        user_id=user_id, achievement_id=achievement_id
+    ).exists():
+        return {"success": False, "message": "Achievement already issued"}
+
+    try:
+        with transaction.atomic():
+            existing = (
+                AchievementEligibilityGrant.objects.select_for_update()
+                .filter(user_id=user_id, achievement_id=achievement_id)
+                .first()
+            )
+
+            if existing:
+                if existing.status == "pending":
+                    return {"success": False, "message": "Already eligible"}
+
+                # revoked (or claimed but the issued log was separately
+                # deleted) - re-grant by resetting the existing row instead
+                # of inserting a new one (unique_together blocks that).
+                existing.status = "pending"
+                existing.granted_by_id = granted_by
+                existing.source = "bulk_issue"
+                existing.updated_at = datetime.now()
+                existing.save(
+                    update_fields=["status", "granted_by", "source", "updated_at"]
+                )
+            else:
+                AchievementEligibilityGrant.objects.create(
+                    id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    achievement_id=achievement_id,
+                    status="pending",
+                    granted_by_id=granted_by,
+                    source="bulk_issue",
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                )
+    except IntegrityError:
+        return {"success": False, "message": "Already eligible"}
+
+    achievement = Achievement.objects.get(id=achievement_id)
+    return {
+        "success": True,
+        "message": f"Eligibility granted for '{achievement.name}'",
+    }
 
 
 def _issue_achievement(
@@ -391,14 +488,23 @@ def revoke_achievement(
     """
     Revoke an achievement (admin operation).
     """
-    from db.achievement import UserAchievementsLog, AchievementAuditLog
+    from db.achievement import UserAchievementsLog, AchievementAuditLog, AchievementEligibilityGrant
 
     achievement_log = UserAchievementsLog.objects.filter(
         user_id=user_id, achievement_id=achievement_id
     ).first()
 
     if not achievement_log:
-        return {"success": False, "message": "Achievement not found for user"}
+        grant = AchievementEligibilityGrant.objects.filter(
+            user_id=user_id, achievement_id=achievement_id, status="pending"
+        ).first()
+
+        if not grant:
+            return {"success": False, "message": "Achievement not found for user"}
+
+        grant.status = "revoked"
+        grant.save(update_fields=["status", "updated_at"])
+        return {"success": True, "message": "Eligibility grant revoked successfully"}
 
     # Delete the achievement log
     achievement_log.delete()


### PR DESCRIPTION
## Summary
- `bulk-issue/` previously force-issued every achievement in the uploaded sheet immediately, even ones requiring a Verifiable Credential (`has_vc=True`) — skipping the step where the user picks their DID and issues the VC themselves.
- Bulk-issue now branches on `Achievement.has_vc`: non-VC achievements are still issued directly (unchanged); VC achievements only grant the user *eligibility* via a new `AchievementEligibilityGrant` record.
- The user then sees it in `GET /eligible/`, claims it via `POST /claim/<id>/` (which now falls back to a pending grant when there's no rule engine entry), and only then does it appear in their profile achievements list and become ready for VC issuance via `issue-vc/`.
- `revoke/` can now also revoke a still-pending grant (not just an already-issued achievement), and re-bulk-issuing after a revoke correctly resets the grant back to `pending` instead of failing on the unique constraint.

## Changes
- **New table** `achievement_eligibility_grant` (`alter-scripts/alter-1.69.sql` / `.py`, db version bump to `1.69`) + matching `AchievementEligibilityGrant` model in `db/achievement.py`.
- `mu_celery/achievement_tasks.py`: new `grant_achievement_eligibility()`; `claim_achievement()` falls back to a pending grant when no active rule exists; `revoke_achievement()` handles pending grants; grant re-creation after revoke reuses/resets the existing row instead of inserting a duplicate.
- `api/dashboard/achievement/rule_engine.py`: `get_eligible_achievements()` / `get_all_progress()` now also surface pending grants (`reason: "Manually granted"`).
- `api/dashboard/achievement/achievement_views.py`: `AchievementIssueBulkAPIView` batches achievement lookups and branches per row on `has_vc`; response now includes `eligibility_granted_count` alongside `success_count`.
- Docs: `api_docs/Achievement_Bulk_Issue_Eligibility_API.md` — full endpoint reference, flow diagram, and worked example.

## Test plan
- [x] Bulk-issue a mix of VC/non-VC rows — verified `success_count`/`eligibility_granted_count` split correctly against the dev DB.
- [x] VC achievement does *not* appear in the profile list until claimed; appears in `eligible/` with `reason: "Manually granted"` in the meantime.
- [x] Claim consumes the grant, issues the achievement, `vc_pending: true` returned.
- [x] Re-running bulk-issue on already-issued/already-eligible rows is idempotent (no duplicates/errors).
- [x] Revoke a pending grant → disappears from eligible list, claim fails afterward.
- [x] Re-bulk-issue after a revoke correctly re-grants (resets the row to `pending`) instead of erroring on the unique constraint.
