### PR TITLE
Achievement admin-granted eligibility, task completion flag, and student serializer cleanup

### DIFF
--- a/api/dashboard/achievement/achievement_views.py
+++ b/api/dashboard/achievement/achievement_views.py
@@ -1108,40 +1108,64 @@ class AchievementIssueBulkAPIView(APIView):
             ach_idx = headers.index('achievement_id')
             
             success_count = 0
+            eligibility_granted_count = 0
             failed_rows = []
-            
-            from mu_celery.achievement_tasks import manual_issue_achievement
 
-            for i, row in enumerate(sheet.iter_rows(min_row=2, values_only=True), start=2):
+            from mu_celery.achievement_tasks import manual_issue_achievement, grant_achievement_eligibility
+
+            rows = list(sheet.iter_rows(min_row=2, values_only=True))
+            achievement_ids = {str(row[ach_idx]) for row in rows if row[ach_idx]}
+            achievements_by_id = {
+                achievement.id: achievement
+                for achievement in Achievement.objects.filter(id__in=achievement_ids)
+            }
+
+            for i, row in enumerate(rows, start=2):
                 muid = row[muid_idx]
                 achievement_id = row[ach_idx]
-                
+
                 if not muid or not achievement_id:
                     continue
-                     
+
                 try:
+                    achievement = achievements_by_id.get(str(achievement_id))
+                    if not achievement:
+                        failed_rows.append({"row": i, "muid": muid, "reason": "Achievement not found"})
+                        continue
+
                     user = User.objects.filter(muid=muid).first()
                     if not user:
                         failed_rows.append({"row": i, "muid": muid, "reason": "User not found"})
                         continue
 
-                    result = manual_issue_achievement(
-                        user_id=str(user.id),
-                        achievement_id=str(achievement_id),
-                        performed_by=user_id
-                    )
-                    
-                    if result['success']:
-                        success_count += 1
+                    if achievement.has_vc:
+                        result = grant_achievement_eligibility(
+                            user_id=str(user.id),
+                            achievement_id=str(achievement_id),
+                            granted_by=user_id,
+                        )
+                        if result['success']:
+                            eligibility_granted_count += 1
+                        else:
+                            failed_rows.append({"row": i, "muid": muid, "reason": result['message']})
                     else:
-                        failed_rows.append({"row": i, "muid": muid, "reason": result['message']})
-                        
+                        result = manual_issue_achievement(
+                            user_id=str(user.id),
+                            achievement_id=str(achievement_id),
+                            performed_by=user_id
+                        )
+                        if result['success']:
+                            success_count += 1
+                        else:
+                            failed_rows.append({"row": i, "muid": muid, "reason": result['message']})
+
                 except Exception as e:
                     failed_rows.append({"row": i, "muid": muid, "reason": str(e)})
 
             return CustomResponse(
                 response={
                     "success_count": success_count,
+                    "eligibility_granted_count": eligibility_granted_count,
                     "failed_count": len(failed_rows),
                     "failed_rows": failed_rows
                 },

--- a/api/dashboard/achievement/rule_engine.py
+++ b/api/dashboard/achievement/rule_engine.py
@@ -61,7 +61,10 @@ class RuleEvaluator:
             "achievement"
         )
 
+        rule_achievement_ids = set()
         for rule in active_rules:
+            rule_achievement_ids.add(str(rule.achievement_id))
+
             # Skip if already claimed
             if str(rule.achievement_id) in claimed_ids:
                 continue
@@ -69,6 +72,10 @@ class RuleEvaluator:
             result = self.evaluate_rule(rule)
             if result.eligible:
                 results.append(result)
+
+        results.extend(
+            self._get_manually_granted_results(claimed_ids, rule_achievement_ids)
+        )
 
         return results
 
@@ -93,13 +100,50 @@ class RuleEvaluator:
             "achievement"
         )
 
+        rule_achievement_ids = set()
         for rule in active_rules:
+            rule_achievement_ids.add(str(rule.achievement_id))
             result = self.evaluate_rule(rule)
             # Mark if already claimed without overriding the rule-based eligibility
             if str(rule.achievement_id) in claimed_ids:
                 result.claimed = True
                 result.reason = "Already claimed"
             results.append(result)
+
+        results.extend(
+            self._get_manually_granted_results(claimed_ids, rule_achievement_ids)
+        )
+
+        return results
+
+    def _get_manually_granted_results(
+        self, claimed_ids: set, rule_achievement_ids: set
+    ) -> List[EligibilityResult]:
+        """
+        Achievements with a pending admin-granted eligibility (e.g. from
+        bulk-issue of VC achievements), not already covered by a rule.
+        """
+        from db.achievement import AchievementEligibilityGrant
+
+        grants = AchievementEligibilityGrant.objects.filter(
+            user_id=self.user_id, status="pending"
+        ).select_related("achievement")
+
+        results = []
+        for grant in grants:
+            achievement_id = str(grant.achievement_id)
+            if achievement_id in claimed_ids or achievement_id in rule_achievement_ids:
+                continue
+
+            results.append(
+                EligibilityResult(
+                    eligible=True,
+                    achievement_id=achievement_id,
+                    achievement_name=grant.achievement.name,
+                    rule_version=0,
+                    reason="Manually granted",
+                )
+            )
 
         return results
 

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -270,7 +270,6 @@ class CampusDetailsSerializer(serializers.ModelSerializer):
 
 
 class CampusStudentDetailsSerializer(serializers.Serializer):
-    user_id = serializers.CharField()
     full_name = serializers.SerializerMethodField()
     muid = serializers.CharField()
     karma = serializers.IntegerField()
@@ -279,8 +278,6 @@ class CampusStudentDetailsSerializer(serializers.Serializer):
     # is_active = serializers.CharField()
     join_date = serializers.CharField()
     last_karma_gained = serializers.CharField()
-    email = serializers.CharField()
-    mobile = serializers.CharField()
     graduation_year = serializers.CharField()
     department = serializers.CharField()
     is_alumni = serializers.BooleanField()
@@ -289,9 +286,6 @@ class CampusStudentDetailsSerializer(serializers.Serializer):
 
     class Meta:
         fields = (
-            "user_id",
-            "email",
-            "mobile",
             "full_name",
             "karma",
             "muid",

--- a/api/dashboard/district/dash_district_serializer.py
+++ b/api/dashboard/district/dash_district_serializer.py
@@ -128,7 +128,6 @@ class DistrictStudentLevelStatusSerializer(serializers.ModelSerializer):
 
 
 class DistrictStudentDetailsSerializer(serializers.Serializer):
-    user_id = serializers.CharField()
     full_name = serializers.SerializerMethodField()
     muid = serializers.CharField()
     karma = serializers.IntegerField()
@@ -137,7 +136,6 @@ class DistrictStudentDetailsSerializer(serializers.Serializer):
 
     class Meta:
         fields = (
-            "user_id",
             "full_name",
             "karma",
             "muid",
@@ -159,7 +157,6 @@ class DistrictCollegeDetailsSerializer(serializers.Serializer):
     code = serializers.CharField()
     level = serializers.CharField()
     lead = serializers.SerializerMethodField()
-    lead_number = serializers.SerializerMethodField()
 
     class Meta:
         fields = (
@@ -168,15 +165,9 @@ class DistrictCollegeDetailsSerializer(serializers.Serializer):
             'level',
             'code',
             'lead',
-            'lead_number',
         )
 
     def get_lead(self, obj):
         leads = self.context.get("leads")
         college_lead = [lead for lead in leads if lead.college == obj["id"]]
         return college_lead[0].full_name if college_lead else None
-
-    def get_lead_number(self, obj):
-        leads = self.context.get("leads")
-        college_lead = [lead for lead in leads if lead.college == obj["id"]]
-        return college_lead[0].mobile if college_lead else None

--- a/api/dashboard/profile/profile_serializer.py
+++ b/api/dashboard/profile/profile_serializer.py
@@ -277,14 +277,14 @@ class UserProfileSerializer(serializers.ModelSerializer):
 
     def get_interest_groups(self, obj):
         
-        # Get all IGs where user has a level entry (has interacted with this IG)
-        user_ig_levels = UserIgLvlLink.objects.filter(user=obj).select_related('ig', 'level')
-        
         # Get user's currently selected IGs
         selected_ig_ids = set(
             UserIgLink.objects.filter(user=obj, is_active=True, assignment_type=UserIgLink.AssignmentType.LEARNER).values_list('ig_id', flat=True)
         )
-        
+
+        # Get level entries only for IGs the user currently has selected
+        user_ig_levels = UserIgLvlLink.objects.filter(user=obj, ig_id__in=selected_ig_ids).select_related('ig', 'level')
+
         interest_groups = []
         for ig_level_link in user_ig_levels:
             # Calculate IG-specific karma

--- a/api/dashboard/task/dash_task_serializer.py
+++ b/api/dashboard/task/dash_task_serializer.py
@@ -2,7 +2,7 @@ import uuid
 
 from rest_framework import serializers
 
-from db.task import TaskList, TaskType
+from db.task import KarmaActivityLog, TaskList, TaskType
 from utils.permission import JWTUtils
 from utils.utils import DateTimeUtils
 
@@ -17,6 +17,7 @@ class TaskListPublicSerializer(serializers.ModelSerializer):
     company_name = serializers.CharField(
         source="requested_by.company_profile.name", required=False, default=None
     )
+    completed = serializers.SerializerMethodField()
 
     class Meta:
         model = TaskList
@@ -35,7 +36,14 @@ class TaskListPublicSerializer(serializers.ModelSerializer):
             "event",
             "event_id",
             "company_name",
+            "completed",
         ]
+
+    def get_completed(self, obj):
+        completed_task_ids = self.context.get("completed_task_ids")
+        if completed_task_ids is None:
+            return False
+        return obj.id in completed_task_ids
 
 
 class TaskListSerializer(serializers.ModelSerializer):

--- a/api/dashboard/task/dash_task_view.py
+++ b/api/dashboard/task/dash_task_view.py
@@ -69,6 +69,7 @@ class TaskPublicListAPI(APIView):
         from api.dashboard.events.serializers import get_live_events
         from db.events import Event
         from db.user import UserRoleLink
+        from db.task import KarmaActivityLog
 
         base_queryset = TaskList.objects.select_related(
             "channel", "type", "level", "ig", "org", "event_fk",
@@ -108,10 +109,18 @@ class TaskPublicListAPI(APIView):
                     is_active=True,
                 ).values_list("ig_id", flat=True)
             )
+
+            # Tasks the caller has already been awarded karma for.
+            completed_task_ids = set(
+                KarmaActivityLog.objects.filter(
+                    user_id=user_id, appraiser_approved=True
+                ).values_list("task_id", flat=True)
+            )
         else:
             # Unauthenticated: global + company tasks only
             org_filter = Q(org__isnull=True) | Q(org__org_type=OrganizationType.COMPANY.value)
             member_ig_ids = []
+            completed_task_ids = set()
 
         # ---------- start_journey: generic, level-ordered tasks ----------
         # No IG, no event, and not an "intern" task (same convention used by
@@ -151,7 +160,10 @@ class TaskPublicListAPI(APIView):
             .order_by("level__level_order", "title")
             .distinct()
         )
-        become_expert_data = TaskListPublicSerializer(become_expert_qs, many=True).data
+        serializer_context = {"completed_task_ids": completed_task_ids}
+        become_expert_data = TaskListPublicSerializer(
+            become_expert_qs, many=True, context=serializer_context
+        ).data
 
         # ---------- events: event-linked tasks visible to the caller ----------
         # _get_viewer_id/_build_scope_filter already degrade gracefully to
@@ -170,11 +182,15 @@ class TaskPublicListAPI(APIView):
             event_fk__isnull=False,
             event_fk_id__in=accessible_event_ids,
         ).order_by("event_fk__title", "title")
-        events_data = TaskListPublicSerializer(events_qs, many=True).data
+        events_data = TaskListPublicSerializer(
+            events_qs, many=True, context=serializer_context
+        ).data
 
         return CustomResponse(
             response={
-                "start_journey": TaskListPublicSerializer(start_journey_qs, many=True).data,
+                "start_journey": TaskListPublicSerializer(
+                    start_journey_qs, many=True, context=serializer_context
+                ).data,
                 "become_expert": become_expert_data,
                 "events": events_data,
             }

--- a/api/dashboard/zonal/dash_zonal_serializer.py
+++ b/api/dashboard/zonal/dash_zonal_serializer.py
@@ -118,7 +118,6 @@ class ZonalStudentLevelStatusSerializer(serializers.ModelSerializer):
 
 
 class ZonalStudentDetailsSerializer(serializers.Serializer):
-    user_id = serializers.CharField()
     full_name = serializers.SerializerMethodField()
     muid = serializers.CharField()
     karma = serializers.IntegerField()
@@ -126,7 +125,7 @@ class ZonalStudentDetailsSerializer(serializers.Serializer):
     level = serializers.CharField()
 
     class Meta:
-        fields = ["user_id", "full_name", "karma", "muid", "level", "rank"]
+        fields = ["full_name", "karma", "muid", "level", "rank"]
 
     def get_rank(self, obj):
         ranks = self.context.get("ranks")
@@ -142,17 +141,11 @@ class ZonalCollegeDetailsSerializer(serializers.Serializer):
     code = serializers.CharField()
     level = serializers.CharField()
     lead = serializers.SerializerMethodField()
-    lead_number = serializers.SerializerMethodField()
 
     def get_lead(self, obj):
         leads = self.context.get("leads")
         college_lead = [lead for lead in leads if lead.college == obj["id"]]
         return college_lead[0].full_name if college_lead else None
 
-    def get_lead_number(self, obj):
-        leads = self.context.get("leads")
-        college_lead = [lead for lead in leads if lead.college == obj["id"]]
-        return college_lead[0].mobile if college_lead else None
-
     class Meta:
-        fields = ["id", "title", "code", "level", "lead", "lead_number"]
+        fields = ["id", "title", "code", "level", "lead"]

--- a/db/achievement.py
+++ b/db/achievement.py
@@ -74,6 +74,48 @@ class UserAchievementsLog(models.Model):
         unique_together = [["user_id", "achievement_id"]]
 
 
+class AchievementEligibilityGrant(models.Model):
+    """
+    Admin-granted eligibility for an achievement (e.g. from bulk-issue of
+    VC achievements). Lets a user claim the achievement themselves - picking
+    their DID and issuing the VC - instead of it being force-issued.
+    """
+    STATUS_CHOICES = [
+        ("pending", "Pending"),
+        ("claimed", "Claimed"),
+        ("revoked", "Revoked"),
+    ]
+
+    id = models.CharField(primary_key=True, default=uuid.uuid4, max_length=36)
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="achievement_eligibility_grants",
+        db_column="user_id",
+    )
+    achievement = models.ForeignKey(
+        Achievement,
+        on_delete=models.CASCADE,
+        related_name="eligibility_grants",
+        db_column="achievement_id",
+    )
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="pending")
+    granted_by = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="achievement_eligibility_grants_given",
+        db_column="granted_by",
+    )
+    source = models.CharField(max_length=30, default="bulk_issue")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "achievement_eligibility_grant"
+        managed = False
+        unique_together = [["user", "achievement"]]
+
+
 # ============================================================================
 # NEW MODELS FOR ACHIEVEMENT SYSTEM
 # ============================================================================

--- a/mu_celery/achievement_tasks.py
+++ b/mu_celery/achievement_tasks.py
@@ -178,7 +178,8 @@ def claim_achievement(user_id: str, achievement_id: str) -> dict:
     )
 
     if not rule:
-        return {"success": False, "message": "No active rule for this achievement"}
+        # No rule - fall back to an admin-granted eligibility (e.g. from bulk-issue)
+        return _claim_via_eligibility_grant(user_id, achievement_id)
 
     # Evaluate eligibility
     evaluator = RuleEvaluator(user_id)
@@ -209,6 +210,102 @@ def claim_achievement(user_id: str, achievement_id: str) -> dict:
         }
     else:
         return {"success": False, "message": "Failed to claim achievement"}
+
+
+def _claim_via_eligibility_grant(user_id: str, achievement_id: str) -> dict:
+    """
+    Claim an achievement that has no active rule, using a pending
+    admin-granted eligibility (created by bulk-issue for VC achievements).
+    """
+    from db.achievement import Achievement, AchievementEligibilityGrant
+
+    grant = AchievementEligibilityGrant.objects.filter(
+        user_id=user_id, achievement_id=achievement_id, status="pending"
+    ).first()
+
+    if not grant:
+        return {"success": False, "message": "No active rule for this achievement"}
+
+    success = _issue_achievement(
+        user_id=user_id,
+        achievement_id=achievement_id,
+        rule_version=0,
+        source="manual_grant_claim",
+    )
+
+    if not success:
+        return {"success": False, "message": "Failed to claim achievement"}
+
+    grant.status = "claimed"
+    grant.save(update_fields=["status", "updated_at"])
+
+    achievement = Achievement.objects.get(id=achievement_id)
+    return {
+        "success": True,
+        "message": "Achievement claimed successfully!",
+        "vc_pending": achievement.has_vc,
+        "achievement_name": achievement.name,
+    }
+
+
+def grant_achievement_eligibility(
+    user_id: str,
+    achievement_id: str,
+    granted_by: str,
+) -> dict:
+    """
+    Grant a user eligibility to claim an achievement (admin operation, e.g.
+    bulk-issue of VC achievements) without issuing it directly. The user
+    claims it themselves later - picking their DID and issuing the VC.
+    """
+    from db.achievement import Achievement, AchievementEligibilityGrant, UserAchievementsLog
+
+    if UserAchievementsLog.objects.filter(
+        user_id=user_id, achievement_id=achievement_id
+    ).exists():
+        return {"success": False, "message": "Achievement already issued"}
+
+    try:
+        with transaction.atomic():
+            existing = (
+                AchievementEligibilityGrant.objects.select_for_update()
+                .filter(user_id=user_id, achievement_id=achievement_id)
+                .first()
+            )
+
+            if existing:
+                if existing.status == "pending":
+                    return {"success": False, "message": "Already eligible"}
+
+                # revoked (or claimed but the issued log was separately
+                # deleted) - re-grant by resetting the existing row instead
+                # of inserting a new one (unique_together blocks that).
+                existing.status = "pending"
+                existing.granted_by_id = granted_by
+                existing.source = "bulk_issue"
+                existing.updated_at = datetime.now()
+                existing.save(
+                    update_fields=["status", "granted_by", "source", "updated_at"]
+                )
+            else:
+                AchievementEligibilityGrant.objects.create(
+                    id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    achievement_id=achievement_id,
+                    status="pending",
+                    granted_by_id=granted_by,
+                    source="bulk_issue",
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                )
+    except IntegrityError:
+        return {"success": False, "message": "Already eligible"}
+
+    achievement = Achievement.objects.get(id=achievement_id)
+    return {
+        "success": True,
+        "message": f"Eligibility granted for '{achievement.name}'",
+    }
 
 
 def _issue_achievement(
@@ -391,14 +488,23 @@ def revoke_achievement(
     """
     Revoke an achievement (admin operation).
     """
-    from db.achievement import UserAchievementsLog, AchievementAuditLog
+    from db.achievement import UserAchievementsLog, AchievementAuditLog, AchievementEligibilityGrant
 
     achievement_log = UserAchievementsLog.objects.filter(
         user_id=user_id, achievement_id=achievement_id
     ).first()
 
     if not achievement_log:
-        return {"success": False, "message": "Achievement not found for user"}
+        grant = AchievementEligibilityGrant.objects.filter(
+            user_id=user_id, achievement_id=achievement_id, status="pending"
+        ).first()
+
+        if not grant:
+            return {"success": False, "message": "Achievement not found for user"}
+
+        grant.status = "revoked"
+        grant.save(update_fields=["status", "updated_at"])
+        return {"success": True, "message": "Eligibility grant revoked successfully"}
 
     # Delete the achievement log
     achievement_log.delete()


### PR DESCRIPTION
## Summary
- Add admin-granted eligibility flow for VC-gated achievements: bulk issue now grants eligibility (via `grant_achievement_eligibility`) instead of directly issuing when `achievement.has_vc` is true, and reports `eligibility_granted_count` separately from `success_count`.
- Add a `completed` field to `TaskListPublicSerializer` / `TaskPublicListAPI`, computed from `KarmaActivityLog` (appraiser-approved entries) so the public task list reflects which tasks the authenticated caller has already completed.
- Remove unused `user_id` and `lead_number` fields from the Campus, District, and Zonal student detail serializers.

## Commits
- `38e48956` Implement admin-granted eligibility for achievements and enhance claiming logic
- `b327e397` fix(task): add completed field to TaskListPublicSerializer and update context handling in TaskPublicListAPI
- `5cbc6aac` Remove user_id and lead_number fields from Campus, District, and Zonal student detail serializers

## Test plan
- [ ] Bulk-issue an achievement with `has_vc=True` and confirm eligibility is granted rather than direct issuance, and `eligibility_granted_count` is returned correctly.
- [ ] Bulk-issue an achievement with `has_vc=False` and confirm direct issuance still works as before.
- [ ] Hit `TaskPublicListAPI` (`/api/v1/task/list/`) as an authenticated user with completed tasks and confirm `completed: true` appears for tasks with an approved `KarmaActivityLog` entry.
- [ ] Hit the same endpoint unauthenticated and confirm it still returns global/company tasks without error.
- [ ] Confirm Campus/District/Zonal student detail endpoints no longer return `user_id`/`lead_number` and nothing downstream depended on them.
