### PR TITLE
feat: update hours field to use choice options for user mentors and adjust related serializers

### DIFF
--- a/alter-scripts/alter-1.64.py
+++ b/alter-scripts/alter-1.64.py
@@ -1,0 +1,74 @@
+import os
+import sys
+from pathlib import Path
+from decouple import config
+import django
+
+from connection import execute
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+os.chdir(BASE_DIR)
+sys.path.append(str(BASE_DIR))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mulearnbackend.settings')
+django.setup()
+
+DB_NAME = config('DATABASE_NAME')
+
+
+def get_column_type(table_name, column_name):
+    query = f"""
+        SELECT DATA_TYPE FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = '{DB_NAME}' AND TABLE_NAME = '{table_name}' AND COLUMN_NAME = '{column_name}';
+    """
+    result = execute(query)
+    return result[0][0] if result else None
+
+
+def migrate_user_mentor_hours():
+    """
+    `user_mentor.hours` was an `int NOT NULL` (0-based count of weekly
+    hours). It's now an optional free-choice bucket (e.g. "0-1 hours"),
+    stored as a short code ('0-1', '1-2', '2-5', '5-10', '10+') matching
+    db.user.UserMentor.HoursCommitment. Converts existing numeric values
+    into the closest bucket, then relaxes the column to a nullable varchar
+    so mentors can leave it unset.
+    """
+    current_type = get_column_type('user_mentor', 'hours')
+
+    if current_type is None:
+        print("[alter-1.64] Column 'user_mentor.hours' not found. Skipping.")
+        return
+
+    if current_type != 'int':
+        print(f"[alter-1.64] Column 'user_mentor.hours' is already '{current_type}'. Skipping.")
+        return
+
+    # 1. Add the new text column alongside the old numeric one.
+    execute("ALTER TABLE `user_mentor` ADD COLUMN `hours_bucket` VARCHAR(20) DEFAULT NULL;")
+    print("[alter-1.64] Added temporary column 'hours_bucket'.")
+
+    # 2. Bucket existing numeric values into the new ranges. A stored 0
+    # (the old field's default for "unset") becomes NULL rather than
+    # '0-1', since it never represented a deliberate choice.
+    execute("""
+        UPDATE `user_mentor` SET `hours_bucket` = CASE
+            WHEN `hours` IS NULL OR `hours` = 0 THEN NULL
+            WHEN `hours` <= 1 THEN '0-1'
+            WHEN `hours` <= 2 THEN '1-2'
+            WHEN `hours` <= 5 THEN '2-5'
+            WHEN `hours` <= 10 THEN '5-10'
+            ELSE '10+'
+        END;
+    """)
+    print("[alter-1.64] Backfilled 'hours_bucket' from existing numeric 'hours' values.")
+
+    # 3. Drop the old numeric column and put the new one in its place.
+    execute("ALTER TABLE `user_mentor` DROP COLUMN `hours`;")
+    execute("ALTER TABLE `user_mentor` CHANGE COLUMN `hours_bucket` `hours` VARCHAR(20) DEFAULT NULL;")
+    print("[alter-1.64] Replaced 'user_mentor.hours' with a nullable VARCHAR(20) bucket column.")
+
+
+if __name__ == '__main__':
+    migrate_user_mentor_hours()
+    execute("UPDATE system_setting SET value = '1.64', updated_at = now() WHERE `key` = 'db.version';")
+    print("[alter-1.64] Updated database version to 1.64.")

--- a/api/dashboard/company/serializers.py
+++ b/api/dashboard/company/serializers.py
@@ -677,7 +677,7 @@ class CompanyMentorApplySerializer(serializers.Serializer):
     about = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     expertise = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     reason = serializers.CharField(required=False, allow_blank=True)
-    hours = serializers.IntegerField(required=False, allow_null=True, min_value=0)
+    hours = serializers.ChoiceField(choices=UserMentor.HoursCommitment.choices, required=False, allow_null=True)
 
     def validate(self, data):
         user_id = self.context.get("user_id")
@@ -743,7 +743,7 @@ class CompanyMentorApplySerializer(serializers.Serializer):
                 defaults={
                     "about": about,
                     "expertise": expertise,
-                    "hours": hours or 0,
+                    "hours": hours,
                     "created_by_id": user_id,
                     "updated_by_id": user_id,
                 },

--- a/api/dashboard/mentor/analytics_views.py
+++ b/api/dashboard/mentor/analytics_views.py
@@ -79,7 +79,7 @@ class MentorPersonalAnalyticsAPI(APIView):
             "sessions": session_counts,
             "karma_earned": karma_earned,
             "hours_contributed": round(contributed_minutes / 60, 2),
-            "profile_hours": mentor_profile.hours if mentor_profile else 0,
+            "profile_hours": mentor_profile.hours if mentor_profile else None,
             "rating": {
                 "average": rating_aggregate["average"],
                 "count": rating_aggregate["count"] or 0,
@@ -109,7 +109,6 @@ class MentorProfileCompletionAPI(APIView):
         checklist = {
             "about": bool(mentor_profile and mentor_profile.about),
             "expertise": bool(mentor_profile and mentor_profile.expertise),
-            "hours": bool(mentor_profile and mentor_profile.hours),
             "linkedin": bool(socials and socials.linkedin),
         }
 

--- a/api/dashboard/mentor/serializers.py
+++ b/api/dashboard/mentor/serializers.py
@@ -68,7 +68,9 @@ class MentorRegisterSerializer(serializers.ModelSerializer):
     # fills the read side in manually from the UserMentor profile instead.
     about = serializers.CharField(required=False, allow_blank=True, allow_null=True, write_only=True, max_length=1000)
     expertise = serializers.CharField(required=False, allow_blank=True, allow_null=True, write_only=True, max_length=5000)
-    hours = serializers.IntegerField(required=False, allow_null=True, min_value=0, write_only=True)
+    hours = serializers.ChoiceField(
+        choices=UserMentor.HoursCommitment.choices, required=False, allow_null=True, write_only=True
+    )
 
     linkedin = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=255)
     mentor_tier = serializers.ChoiceField(choices=[
@@ -292,7 +294,9 @@ class MentorUpdateSerializer(serializers.ModelSerializer):
     # fills the read side in from the UserMentor profile instead.
     about = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=1000)
     expertise = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=5000)
-    hours = serializers.IntegerField(required=False, allow_null=True, min_value=0, write_only=True)
+    hours = serializers.ChoiceField(
+        choices=UserMentor.HoursCommitment.choices, required=False, allow_null=True, write_only=True
+    )
 
     linkedin = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=255)
     mentor_tier = serializers.ChoiceField(choices=[
@@ -1588,7 +1592,9 @@ class AdminAssignMentorSerializer(serializers.Serializer):
     )
     about        = serializers.CharField(required=False, allow_blank=True, default=None, max_length=1000)
     expertise    = serializers.CharField(required=False, allow_blank=True, default=None, max_length=5000)
-    hours        = serializers.IntegerField(required=False, min_value=0, default=0)
+    hours        = serializers.ChoiceField(
+        choices=UserMentor.HoursCommitment.choices, required=False, allow_null=True, default=None
+    )
 
     def validate_user_muids(self, value):
         for muid in value:
@@ -1705,7 +1711,7 @@ class AdminAssignMentorSerializer(serializers.Serializer):
                 profile_data = {
                     "about": validated_data.get("about"),
                     "expertise": validated_data.get("expertise"),
-                    "hours": validated_data.get("hours", 0),
+                    "hours": validated_data.get("hours"),
                 }
                 UserMentor.objects.get_or_create(
                     user=user,

--- a/api/register/serializers.py
+++ b/api/register/serializers.py
@@ -152,7 +152,7 @@ class MentorSerializer(serializers.ModelSerializer):
     user = serializers.CharField(required=False)
     about = serializers.CharField(required=False)
     reason = serializers.CharField(required=False)
-    hours = serializers.IntegerField(required=False)
+    hours = serializers.ChoiceField(choices=UserMentor.HoursCommitment.choices, required=False, allow_null=True)
 
     def create(self, validated_data):
         about = validated_data.get("about", None)
@@ -167,7 +167,7 @@ class MentorSerializer(serializers.ModelSerializer):
             defaults={
                 "about": about,
                 "reason": reason,
-                "hours": hours or 0,
+                "hours": hours,
                 "created_by": validated_data["user"],
                 "created_at": DateTimeUtils.get_current_utc_time(),
                 "updated_by": validated_data["user"],

--- a/db/user.py
+++ b/db/user.py
@@ -144,6 +144,13 @@ class UserEndgoals(models.Model):
         
 
 class UserMentor(models.Model):
+    class HoursCommitment(models.TextChoices):
+        RANGE_0_1 = '0-1', '0-1 hours'
+        RANGE_1_2 = '1-2', '1-2 hours'
+        RANGE_2_5 = '2-5', '2-5 hours'
+        RANGE_5_10 = '5-10', '5-10 hours'
+        RANGE_10_PLUS = '10+', '10+ hours'
+
     id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
     user = models.OneToOneField(
         User,
@@ -155,7 +162,10 @@ class UserMentor(models.Model):
 
     expertise = models.TextField(blank=True, null=True)
 
-    hours = models.PositiveIntegerField(default=0)
+    # Weekly time-commitment bucket the mentor self-selects (e.g. "0-1
+    # hours") rather than a raw number — optional, never required for
+    # registration or profile completion.
+    hours = models.CharField(max_length=20, choices=HoursCommitment.choices, blank=True, null=True)
 
     is_active = models.BooleanField(default=True)
 

--- a/schema.sql
+++ b/schema.sql
@@ -2044,7 +2044,7 @@ CREATE TABLE `user_mentor` (
   `user_id` varchar(36) NOT NULL,
   `about` varchar(1000) DEFAULT NULL,
   `reason` varchar(1000) DEFAULT NULL,
-  `hours` int NOT NULL,
+  `hours` varchar(20) DEFAULT NULL,
   `updated_by` varchar(36) NOT NULL,
   `updated_at` datetime DEFAULT NULL,
   `created_by` varchar(36) NOT NULL,


### PR DESCRIPTION
## Summary

Makes mentor `hours` (weekly time commitment) fully optional across the platform — previously a NOT NULL DB column with an unsound in-code default, and counted toward mentor profile-completion percentage.

- **`db/user.py`** — `UserMentor.hours` changed from `PositiveIntegerField(default=0)` to a nullable `CharField` with a new `HoursCommitment` choice set: `0-1`, `1-2`, `2-5`, `5-10`, `10+` (each with an "N-M hours" label). Previously a raw int; now a self-selected range, and optional.
- **`schema.sql`** — `user_mentor.hours` updated to `varchar(20) DEFAULT NULL`.
- **`alter-scripts/alter-1.64.py`** (new) — idempotent migration: buckets any existing numeric `hours` values into the new ranges (preserving data), then drops the old `int NOT NULL` column in favor of the nullable `varchar(20)`.
- **Serializers** (`api/dashboard/mentor/serializers.py`, `api/register/serializers.py`, `api/dashboard/company/serializers.py`) — `hours` switched from `IntegerField` to `ChoiceField` on every mentor registration/update/admin-assign path (`MentorRegisterSerializer`, `MentorUpdateSerializer`, `AdminAssignMentorSerializer`, `MentorSerializer`, `CompanyMentorApplySerializer`); dropped the `hours or 0` fallbacks since `None` is now a valid, correct value instead of a workaround for a NOT NULL column.
- **`api/dashboard/mentor/analytics_views.py`** — `hours` removed entirely from `MentorProfileCompletionAPI`'s checklist (no longer factors into the completion percentage); `profile_hours` fallback in `MentorPersonalAnalyticsAPI` changed from `0` to `None` to match the new type.

## Migration note
Run `alter-scripts/alter-1.64.py` (or the equivalent manual SQL) against the target DB before deploying — this is a schema change, not a Django migration (models are `managed = False`).

## Test plan
- [ ] Register a new mentor without `hours` — confirm success, no DB error, `hours: null` in response.
- [ ] Register/update with a valid `hours` choice (e.g. `"2-5"`) — confirm it's accepted and persisted.
- [ ] Submit an invalid `hours` value — confirm `ChoiceField` validation rejects it.
- [ ] `GET /mentor/profile/completion/` — confirm `hours` is absent from the checklist and percentage is unaffected by it.
- [ ] Run `alter-1.64.py` against a DB with pre-existing numeric `hours` values — confirm they land in the expected bucket and no data is lost.
