### PR TITLE
feat(muComics): Comics API updates - admin create, contributors in list, unarchive

### DIFF
--- a/api/muComics/comic/comic_views.py
+++ b/api/muComics/comic/comic_views.py
@@ -3,12 +3,13 @@ Comic CRUD views.
 
 Endpoints:
   GET    /muComics/comics/                      → list (paginated, search, filter, sort)
-  POST   /muComics/comics/                      → create
+  POST   /muComics/comics/                      → create (admin only)
   GET    /muComics/comics/<comic_id>/            → detail
   PATCH  /muComics/comics/<comic_id>/            → partial update (creator or editor)
   DELETE /muComics/comics/<comic_id>/            → soft delete (creator only)
   POST   /muComics/comics/<comic_id>/publish/    → draft → published (creator only)
   POST   /muComics/comics/<comic_id>/archive/    → published/draft → archived (creator only)
+  POST   /muComics/comics/<comic_id>/unarchive/  → archived → draft (creator only)
 """
 
 from django.utils import timezone
@@ -76,7 +77,7 @@ def can_edit_comic(user_id, comic):
 class ComicListCreateView(APIView):
     """
     GET  /muComics/comics/  → paginated list with search, status filter, sort
-    POST /muComics/comics/  → create a new comic (any authenticated user)
+    POST /muComics/comics/  → create a new comic (admin only)
     """
     authentication_classes = [CustomizePermission]
 
@@ -110,7 +111,7 @@ class ComicListCreateView(APIView):
                 ).distinct()
 
         paginated = CommonUtils.get_paginated_queryset(
-            queryset.select_related('created_by').prefetch_related('genre_links__genre'),
+            queryset.select_related('created_by').prefetch_related('genre_links__genre', 'contributor_links__user'),
             request,
             search_fields=['title'],
             sort_fields={
@@ -130,12 +131,18 @@ class ComicListCreateView(APIView):
 
     @extend_schema(
         tags=['muComics'],
-        description="Create a new comic. Any authenticated user may create a comic. Returns the full comic detail on success.",
+        description="Create a new comic. Only admins may create. The creator is specified via creator_muid. Returns the full comic detail on success.",
         request=ComicWriteSerializer,
         responses={200: ComicDetailSerializer},
     )
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
+
+        # Only admins can create comics
+        if RoleType.ADMIN.value not in JWTUtils.fetch_role(request):
+            return CustomResponse(
+                general_message='Only admins can create comics.'
+            ).get_unauthorized_response()
 
         serializer = ComicWriteSerializer(
             data=request.data,
@@ -395,6 +402,63 @@ class ComicArchiveView(APIView):
         return CustomResponse(
             general_message=f'Comic "{comic.title}" archived successfully.',
             response={'id': comic.id, 'status': Comic.Status.ARCHIVED},
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# UNARCHIVE
+# ─────────────────────────────────────────────────────────────────────────────
+
+class ComicUnarchiveView(APIView):
+    """
+    POST /muComics/comics/<comic_id>/unarchive/
+    Transitions an archived comic back to draft (creator only).
+
+    Workflow:
+        archived  → draft  ✅
+        draft     → ❌  (not archived)
+        published → ❌  (not archived)
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['muComics'],
+        description="Unarchive an archived comic (archived → draft). Only the creator may unarchive. Non-archived comics are rejected.",
+        responses={200: inline_serializer(
+            name='ComicUnarchiveResponse',
+            fields={
+                'id':     s.CharField(),
+                'status': s.CharField(),
+            },
+        )},
+    )
+    def post(self, request, comic_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        comic   = _get_active_comics().filter(id=comic_id).first()
+
+        if not comic:
+            return CustomResponse(general_message='Comic not found.').get_failure_response()
+
+        # Only creator can unarchive
+        if comic.created_by_id != user_id:
+            return CustomResponse(
+                general_message='Only the comic creator can unarchive this comic.'
+            ).get_unauthorized_response()
+
+        if comic.status != Comic.Status.ARCHIVED:
+            return CustomResponse(
+                general_message='Only archived comics can be unarchived.'
+            ).get_failure_response()
+
+        now = timezone.now()
+        comic.status        = Comic.Status.DRAFT
+        comic.updated_by_id = user_id
+        comic.updated_at    = now
+        comic.save(update_fields=['status', 'updated_by', 'updated_at'])
+
+        return CustomResponse(
+            general_message=f'Comic "{comic.title}" unarchived successfully.',
+            response={'id': comic.id, 'status': Comic.Status.DRAFT},
         ).get_success_response()
 
 

--- a/api/muComics/comic/serializers.py
+++ b/api/muComics/comic/serializers.py
@@ -46,22 +46,27 @@ class ContributorSerializer(serializers.ModelSerializer):
 # ─────────────────────────────────────────────────────────────────────────────
 
 class ComicListItemSerializer(serializers.ModelSerializer):
-    created_by = MinimalUserSerializer(read_only=True)
-    genres     = serializers.SerializerMethodField()
- 
+    created_by   = MinimalUserSerializer(read_only=True)
+    genres       = serializers.SerializerMethodField()
+    contributors = serializers.SerializerMethodField()
+
     class Meta:
         model = Comic
         fields = [
             'id', 'title', 'slug', 'cover_image_key',
             'status', 'like_count', 'comment_count', 'bookmark_count',
             'published_at', 'created_by', 'created_at',
-            'genres',
+            'genres', 'contributors',
         ]
 
     def get_genres(self, obj):
         links = obj.genre_links.all()
         active_genres = [link.genre for link in links if link.genre.is_active]
         return MinimalGenreSerializer(active_genres, many=True).data
+
+    def get_contributors(self, obj):
+        links = obj.contributor_links.select_related('user').all()
+        return ContributorSerializer(links, many=True).data
 
 
 
@@ -106,11 +111,13 @@ class ComicWriteSerializer(serializers.ModelSerializer):
     """
     Input serializer for POST /comics/ and PATCH /comics/<id>/.
     The caller never sends: slug, status, *_count, published_at, or audit fields.
+    On create, `creator_muid` specifies the comic owner (resolved to a User).
     """
+    creator_muid = serializers.CharField(required=False, write_only=True)
 
     class Meta:
         model = Comic
-        fields = ['title', 'description', 'cover_image_key']
+        fields = ['title', 'description', 'cover_image_key', 'creator_muid']
         extra_kwargs = {
             'title': {
                 'required': True,
@@ -133,6 +140,18 @@ class ComicWriteSerializer(serializers.ModelSerializer):
         if not value or not value.strip():
             raise serializers.ValidationError('Title must not be blank.')
         return value.strip()
+
+    def validate_creator_muid(self, value):
+        try:
+            return User.objects.get(muid=value, is_active=True)
+        except User.DoesNotExist:
+            raise serializers.ValidationError(f'No active user with muid "{value}" found.')
+
+    def validate(self, attrs):
+        # creator_muid is required on create only
+        if not self.instance and 'creator_muid' not in attrs:
+            raise serializers.ValidationError({'creator_muid': 'This field is required when creating a comic.'})
+        return attrs
 
     def _generate_unique_slug(self, title):
         """
@@ -159,18 +178,20 @@ class ComicWriteSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         user_id = self.context['user_id']
+        creator = validated_data.pop('creator_muid')  # User object from validate_creator_muid
         now     = timezone.now()
 
         validated_data['id']           = str(uuid.uuid4())
         validated_data['slug']         = self._generate_unique_slug(validated_data['title'])
-        validated_data['created_by_id'] = user_id
-        validated_data['updated_by_id'] = user_id
+        validated_data['created_by_id'] = creator.id   # specified creator, not the admin
+        validated_data['updated_by_id'] = user_id      # admin who performed the action
         validated_data['created_at']   = now
         validated_data['updated_at']   = now
         return Comic.objects.create(**validated_data)
 
     def update(self, instance, validated_data):
         user_id = self.context['user_id']
+        validated_data.pop('creator_muid', None)  # creator is not changeable after creation
         now     = timezone.now()
 
         # Re-generate slug only when title changes

--- a/api/muComics/comic/urls.py
+++ b/api/muComics/comic/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     # Status workflow
     path('<str:comic_id>/publish/', comic_views.ComicPublishView.as_view(),  name='comic-publish'),
     path('<str:comic_id>/archive/', comic_views.ComicArchiveView.as_view(),  name='comic-archive'),
+    path('<str:comic_id>/unarchive/', comic_views.ComicUnarchiveView.as_view(), name='comic-unarchive'),
 
     # Contributors
     path('<str:comic_id>/contributors/',


### PR DESCRIPTION
Changes

List Comics — Response now includes contributors field (populated from the contributors endpoint)

Create Comic — Restricted to admin role only. The comic creator/owner is specified via creator_muid in the request body instead of being auto-set from the authenticated user's JWT

Unarchive Comic — New POST /api/v1/muComics/comics/<comic_id>/unarchive/ endpoint that transitions archived → draft (creator only). Non-archived comics are rejected

Files modified

api/muComics/comic/serializers.py
api/muComics/comic/comic_views.py
api/muComics/comic/urls.py