### PR TITLE
feat: implement self-service endpoint for mentors to manage preferred Interest Groups

### DIFF
--- a/api/dashboard/mentor/dash_mentor_helper.py
+++ b/api/dashboard/mentor/dash_mentor_helper.py
@@ -12,6 +12,40 @@ from utils.utils import DateTimeUtils
 
 CACHE_TTL = 15 * 60  # 15 minutes
 
+# Maximum number of distinct Interest Groups a mentor may actively mentor at
+# once, counted across ALL of their approved applications combined (an
+# IG_MENTOR app and a COMPANY_MENTOR app can each carry their own
+# preferred_ig_ids — this caps the union, not any single application's list).
+MAX_PREFERRED_IGS = 5
+
+
+def get_effective_ig_ids(user, preferred_ig_ids, exclude_application_id=None):
+    """
+    The full set of IG ids `user` would actively mentor if `preferred_ig_ids`
+    were in effect for one application, unioned with every OTHER currently
+    APPROVED application this user holds. `exclude_application_id` excludes
+    that one application's own DB row from the "other approved" side of the
+    union — needed because callers pass its in-progress preferred_ig_ids
+    explicitly rather than relying on a DB read (the caller's own row may not
+    be saved/committed as APPROVED yet, or may still hold its old value).
+
+    This is the single source of truth for a mentor's active IG footprint:
+    reconcile_mentor_ig_links applies it, release_mentor_ig_links and the
+    max-IG-limit checks validate against it — so a mentor's IG access is
+    additive across tiers/applications and never depends on approval order.
+    """
+    desired = {str(i) for i in (preferred_ig_ids or []) if i}
+
+    other_approved = MentorApplication.objects.filter(
+        user=user, status=MentorApplication.Status.APPROVED,
+    )
+    if exclude_application_id:
+        other_approved = other_approved.exclude(id=exclude_application_id)
+    for app in other_approved:
+        desired.update(str(i) for i in (app.preferred_ig_ids or []) if i)
+
+    return desired
+
 
 def get_mentor_company(application):
     """
@@ -195,11 +229,19 @@ def reconcile_mentor_ig_grants(application, actor_user_id):
 
 
 @transaction.atomic
-def reconcile_mentor_ig_links(user, preferred_ig_ids, actor_user_id):
+def reconcile_mentor_ig_links(user, preferred_ig_ids, actor_user_id, exclude_application_id=None):
     """
     Make the user's ACTIVE MENTOR UserIgLink set exactly equal the (valid)
-    preferred_ig_ids: adds/reactivates links for newly chosen IGs and
-    deactivates links for removed IGs.
+    union of `preferred_ig_ids` (the application currently being reconciled)
+    and every OTHER APPROVED application's preferred_ig_ids — see
+    get_effective_ig_ids. Adds/reactivates links for newly chosen IGs and
+    deactivates links for IGs no APPROVED application wants anymore.
+
+    Using the union (rather than just this application's own list) is
+    what makes a mentor's active IGs additive across tiers: approving or
+    editing one application's IG list can no longer clobber the IGs another
+    still-APPROVED application legitimately grants, regardless of which was
+    approved first.
 
     Only ever touches assignment_type=MENTOR rows — LEARNER/LEAD/MODERATOR
     links for the same IG are never modified. Used both for first-time admin
@@ -207,7 +249,7 @@ def reconcile_mentor_ig_links(user, preferred_ig_ids, actor_user_id):
 
     Returns (added_ig_ids, removed_ig_ids) as sets of str.
     """
-    desired = {str(i) for i in (preferred_ig_ids or []) if i}
+    desired = get_effective_ig_ids(user, preferred_ig_ids, exclude_application_id)
     if desired:
         desired &= {
             str(x)
@@ -255,6 +297,33 @@ def reconcile_mentor_ig_links(user, preferred_ig_ids, actor_user_id):
         ).update(is_active=False, unassigned_at=now)
 
     return to_add, to_remove
+
+
+def release_mentor_ig_links(user, ig_ids, exclude_application_id, actor_user_id):
+    """
+    Deactivate MENTOR UserIgLink rows for `ig_ids`, but only the ones no
+    OTHER currently-APPROVED application (excluding `exclude_application_id`,
+    the one being rejected/revoked) still claims. Used wherever a single
+    application/grant is revoked directly (outside reconcile_mentor_ig_links'
+    approve-time reconciliation) so revoking one application never removes
+    IG access another still-APPROVED application legitimately grants.
+
+    Returns the set of ig_ids actually deactivated.
+    """
+    still_claimed = get_effective_ig_ids(user, [], exclude_application_id=exclude_application_id)
+    safe_to_release = {str(i) for i in ig_ids if i} - still_claimed
+
+    if safe_to_release:
+        now = DateTimeUtils.get_current_utc_time()
+        UserIgLink.objects.filter(
+            user=user,
+            assignment_type=UserIgLink.AssignmentType.MENTOR,
+            ig_id__in=safe_to_release,
+            is_active=True,
+        ).update(is_active=False, unassigned_at=now)
+
+    return safe_to_release
+
 
 def get_mentor_overview(user_id):
         """

--- a/api/dashboard/mentor/mentor_views.py
+++ b/api/dashboard/mentor/mentor_views.py
@@ -839,6 +839,173 @@ class MentorChangeCompanyAPI(APIView):
             response=serializer.data
         ).get_success_response()
 
+class MentorPreferredIgAPI(APIView):
+    """
+    GET/PATCH /mentor/<mentor_id>/preferred-igs/ — self-service request to
+    add/remove the Interest Groups a mentor mentors under one of their own
+    APPROVED applications. Registration (MentorRegistrationAPI) only accepts
+    preferred_ig_ids while PENDING/REJECTED; MentorRegistrationAPI.patch
+    explicitly refuses to touch an APPROVED application at all. This is the
+    endpoint that fills that gap — but rather than mutating the approved
+    application's IGs in place, PATCH creates a new PENDING "change request"
+    application (mirroring MentorChangeCompanyAPI) so the change goes
+    through the same verifier who'd review it normally: an IG lead/admin for
+    IG_MENTOR, the company owner for COMPANY_MENTOR, admins for CAMPUS_MENTOR.
+    The mentor's current IG access is untouched until that's approved.
+    """
+    permission_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Mentor'],
+        description="Get the preferred Interest Groups for one of the caller's approved mentor applications.",
+        responses={200: serializers.MentorApplicationProfileSerializer},
+    )
+    @role_required([RoleType.MENTOR.value])
+    def get(self, request, mentor_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        application = MentorApplication.objects.filter(
+            id=mentor_id, user_id=user_id, status=MentorApplication.Status.APPROVED
+        ).first()
+
+        if not application:
+            return CustomResponse(
+                general_message="No approved mentor application found with this ID for your account."
+            ).get_failure_response(status_code=404)
+
+        serializer = serializers.MentorApplicationProfileSerializer(application)
+        return CustomResponse(response=serializer.data).get_success_response()
+
+    @extend_schema(
+        tags=['Dashboard - Mentor'],
+        description=(
+            "Request a change to the preferred Interest Groups for one of the caller's "
+            "approved mentor applications. Creates a new PENDING application (preserving "
+            "the tier and org) for review by the appropriate verifier — the mentor's "
+            "current IG access is unaffected until it's approved."
+        ),
+        request=serializers.MentorIgPreferenceSerializer,
+        responses={200: serializers.MentorRegisterSerializer},
+    )
+    @role_required([RoleType.MENTOR.value])
+    def patch(self, request, mentor_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        application = MentorApplication.objects.filter(
+            id=mentor_id, user_id=user_id, status=MentorApplication.Status.APPROVED
+        ).first()
+
+        if not application:
+            return CustomResponse(
+                general_message="No approved mentor application found with this ID for your account."
+            ).get_failure_response(status_code=404)
+
+        serializer = serializers.MentorIgPreferenceSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(message=serializer.errors).get_failure_response()
+
+        new_ig_ids = serializer.validated_data["preferred_ig_ids"]
+
+        if set(new_ig_ids) == set(application.preferred_ig_ids or []):
+            return CustomResponse(
+                general_message="No change — these are already the active Interest Groups for this application."
+            ).get_failure_response()
+
+        if MentorApplication.objects.filter(
+            user_id=user_id, mentor_tier=application.mentor_tier,
+            status=MentorApplication.Status.PENDING,
+        ).exists():
+            return CustomResponse(
+                general_message="You already have a pending change request for this mentor tier."
+            ).get_failure_response()
+
+        from .dash_mentor_helper import get_effective_ig_ids, MAX_PREFERRED_IGS
+        effective = get_effective_ig_ids(
+            application.user, new_ig_ids, exclude_application_id=application.id
+        )
+        if len(effective) > MAX_PREFERRED_IGS:
+            return CustomResponse(
+                general_message=(
+                    f"This change would give you {len(effective)} active Interest Groups, "
+                    f"exceeding the maximum of {MAX_PREFERRED_IGS}."
+                )
+            ).get_failure_response()
+
+        now = DateTimeUtils.get_current_utc_time()
+        new_application = MentorApplication.objects.create(
+            user_id=user_id,
+            org=application.org,
+            mentor_tier=application.mentor_tier,
+            status=MentorApplication.Status.PENDING,
+            preferred_ig_ids=new_ig_ids,
+            reason=f"Interest Group preference change requested (supersedes application {application.id}).",
+            nomination_expires_at=now + timedelta(days=NOMINATION_EXPIRY_DAYS),
+            created_by_id=user_id,
+            updated_by_id=user_id,
+            created_at=now,
+            updated_at=now,
+        )
+
+        # Notify whoever verifies this tier — same routing as initial registration.
+        try:
+            from api.notification.notifications_utils import NotificationUtils
+            from db.user import User, UserRoleLink
+            from django.conf import settings
+
+            requester = User.every.filter(id=user_id).first()
+
+            if application.mentor_tier == MentorApplication.MentorTier.COMPANY_MENTOR:
+                from db.company import Company
+                try:
+                    company = Company.objects.get(org=application.org, status="verified")
+                    NotificationUtils.insert_notification(
+                        user=company.company_user,
+                        title="Mentor Interest Group Change Request",
+                        description=f"{requester.full_name} has requested to change their Interest Groups as a mentor for your company.",
+                        button="View Application",
+                        url=f"{settings.FR_DOMAIN_NAME}/dashboard/company/mentor/list/",
+                        created_by=requester,
+                    )
+                except Company.DoesNotExist:
+                    pass
+            elif application.mentor_tier == MentorApplication.MentorTier.IG_MENTOR:
+                from db.task import InterestGroup
+                from .dash_mentor_helper import notify_ig_leads
+                for ig in InterestGroup.objects.filter(id__in=new_ig_ids):
+                    notify_ig_leads(ig, requester, new_application)
+
+                admin_roles = UserRoleLink.objects.filter(role__title=RoleType.ADMIN.value, is_active=True).select_related('user')
+                for admin_link in admin_roles:
+                    NotificationUtils.insert_notification(
+                        user=admin_link.user,
+                        title="IG Mentor Preference Change Request",
+                        description=f"{requester.full_name} has requested to change their Interest Groups.",
+                        button="View Application",
+                        url=f"{settings.FR_DOMAIN_NAME}/dashboard/mentor/list/",
+                        created_by=requester,
+                    )
+            else:  # CAMPUS_MENTOR — admin-reviewed, same as initial registration
+                admin_roles = UserRoleLink.objects.filter(role__title=RoleType.ADMIN.value, is_active=True).select_related('user')
+                for admin_link in admin_roles:
+                    NotificationUtils.insert_notification(
+                        user=admin_link.user,
+                        title="Mentor Interest Group Change Request",
+                        description=f"{requester.full_name} has requested to change their Interest Groups.",
+                        button="View Application",
+                        url=f"{settings.FR_DOMAIN_NAME}/dashboard/mentor/list/",
+                        created_by=requester,
+                    )
+        except Exception:
+            import logging
+            logging.getLogger(__name__).exception(
+                "Failed to notify verifier for IG preference change application %s", new_application.id
+            )
+
+        response_serializer = serializers.MentorRegisterSerializer(new_application)
+        return CustomResponse(
+            general_message="Interest Group change request submitted successfully. It is pending approval.",
+            response=response_serializer.data
+        ).get_success_response()
+
+
 class MentorOverviewAPI(APIView):
     permission_classes = [CustomizePermission]
 
@@ -974,7 +1141,6 @@ class AdminAssignMentorAPI(APIView):
     )
     def delete(self, request, user_muid):
         from db.user import User, UserRoleLink, Role
-        from db.task import UserIgLink
         from db.user import MentorScopeGrant
         from utils.types import RoleType as _RoleType
         from django.db import transaction
@@ -1019,14 +1185,15 @@ class AdminAssignMentorAPI(APIView):
                 app.updated_at = now
                 app.save(update_fields=["status", "updated_by_id", "updated_at"])
 
-                # Deactivate IG links for IG_MENTOR
-                if app.mentor_tier == MentorApplication.MentorTier.IG_MENTOR:
-                    if app.preferred_ig_ids:
-                        UserIgLink.objects.filter(
-                            user=user,
-                            ig_id__in=app.preferred_ig_ids,
-                            assignment_type=UserIgLink.AssignmentType.MENTOR,
-                        ).update(is_active=False)
+                # Release IG links this application held — but only the ones no
+                # OTHER still-APPROVED application (e.g. a COMPANY_MENTOR app
+                # that separately lists the same IG) is still relying on.
+                if app.mentor_tier == MentorApplication.MentorTier.IG_MENTOR and app.preferred_ig_ids:
+                    from .dash_mentor_helper import release_mentor_ig_links
+                    release_mentor_ig_links(
+                        user, app.preferred_ig_ids,
+                        exclude_application_id=app.id, actor_user_id=admin_id,
+                    )
 
                 # Deactivate matching scope grants. NOTE: revoking mentor
                 MentorScopeGrant.objects.filter(
@@ -1151,13 +1318,13 @@ class MentorScopeGrantRevokeAPI(APIView):
             ).values_list('scope_id', flat=True)
 
             if ig_scope_ids_to_deactivate:
-                from db.task import UserIgLink
-                UserIgLink.objects.filter(
-                    user=application.user, 
-                    ig_id__in=list(ig_scope_ids_to_deactivate), 
-                    assignment_type=UserIgLink.AssignmentType.MENTOR,
-                    is_active=True
-                ).update(is_active=False)
+                # Only release IGs no OTHER still-APPROVED application (e.g. a
+                # separate COMPANY_MENTOR app listing the same IG) still relies on.
+                from .dash_mentor_helper import release_mentor_ig_links
+                release_mentor_ig_links(
+                    application.user, list(ig_scope_ids_to_deactivate),
+                    exclude_application_id=application.id, actor_user_id=actor_id,
+                )
 
             # 4. Deactivate all grants for this application.
             all_active_grants.update(is_active=False, revoked_by_id=actor_id, revoked_at=now)

--- a/api/dashboard/mentor/serializers.py
+++ b/api/dashboard/mentor/serializers.py
@@ -126,8 +126,14 @@ class MentorRegisterSerializer(serializers.ModelSerializer):
         return value
 
     def validate_preferred_ig_ids(self, value):
+        from .dash_mentor_helper import MAX_PREFERRED_IGS
+
         if not value or not isinstance(value, list) or len(value) == 0:
             raise serializers.ValidationError("At least one preferred IG ID must be provided.")
+        if len(value) > MAX_PREFERRED_IGS:
+            raise serializers.ValidationError(
+                f"You can select at most {MAX_PREFERRED_IGS} Interest Groups."
+            )
         for ig_id in value:
             validate_safe_text(str(ig_id))
             if not InterestGroup.objects.filter(id=ig_id).exists():
@@ -350,9 +356,15 @@ class MentorUpdateSerializer(serializers.ModelSerializer):
         return value
 
     def validate_preferred_ig_ids(self, value):
+        from .dash_mentor_helper import MAX_PREFERRED_IGS
+
         if value:
             if not isinstance(value, list) or len(value) == 0:
                 raise serializers.ValidationError("At least one preferred IG ID must be provided.")
+            if len(value) > MAX_PREFERRED_IGS:
+                raise serializers.ValidationError(
+                    f"You can select at most {MAX_PREFERRED_IGS} Interest Groups."
+                )
             for ig_id in value:
                 validate_safe_text(str(ig_id))
                 if not InterestGroup.objects.filter(id=ig_id).exists():
@@ -451,6 +463,35 @@ class MentorUpdateSerializer(serializers.ModelSerializer):
         instance.save()
 
         return instance
+
+class MentorIgPreferenceSerializer(serializers.Serializer):
+    """
+    Validates a self-service request to change the preferred Interest Groups
+    on one of the caller's already-APPROVED applications. Validation-only —
+    it does NOT mutate the application or reconcile UserIgLink/MentorScopeGrant
+    directly. MentorPreferredIgAPI.patch instead creates a new PENDING
+    "change request" application (mirroring MentorChangeCompanyAPI) so the
+    IG change goes through the same verifier who'd review it normally (IG
+    lead/admin for IG_MENTOR, the company owner for COMPANY_MENTOR); nothing
+    about the mentor's active IG access changes until that's approved.
+    """
+    preferred_ig_ids = serializers.ListField(child=serializers.CharField())
+
+    def validate_preferred_ig_ids(self, value):
+        from .dash_mentor_helper import MAX_PREFERRED_IGS
+
+        if not value or not isinstance(value, list) or len(value) == 0:
+            raise serializers.ValidationError("At least one preferred IG ID must be provided.")
+        if len(value) > MAX_PREFERRED_IGS:
+            raise serializers.ValidationError(
+                f"You can select at most {MAX_PREFERRED_IGS} Interest Groups."
+            )
+        for ig_id in value:
+            validate_safe_text(str(ig_id))
+            if not InterestGroup.objects.filter(id=ig_id).exists():
+                raise serializers.ValidationError(f"Invalid IG ID: {ig_id}")
+        return value
+
 
 class MentorApplicationListSerializer(serializers.ModelSerializer):
     user_full_name = serializers.CharField(source='user.full_name', read_only=True)
@@ -622,6 +663,20 @@ class MentorVerifySerializer(serializers.Serializer):
     def validate(self, attrs):
         if attrs.get("status") == MentorApplication.Status.REJECTED and not attrs.get("verification_note"):
             raise serializers.ValidationError("Verification note is required when rejecting.")
+
+        if attrs.get("status") == MentorApplication.Status.APPROVED and self.instance.preferred_ig_ids:
+            from .dash_mentor_helper import get_effective_ig_ids, MAX_PREFERRED_IGS
+
+            effective = get_effective_ig_ids(
+                self.instance.user, self.instance.preferred_ig_ids,
+                exclude_application_id=self.instance.id,
+            )
+            if len(effective) > MAX_PREFERRED_IGS:
+                raise serializers.ValidationError(
+                    f"Approving this application would give the mentor {len(effective)} active "
+                    f"Interest Groups, exceeding the maximum of {MAX_PREFERRED_IGS}."
+                )
+
         return attrs
 
     def update(self, instance, validated_data):
@@ -726,7 +781,8 @@ class MentorVerifySerializer(serializers.Serializer):
                     from .dash_mentor_helper import reconcile_mentor_ig_links, reconcile_mentor_ig_grants
 
                     reconcile_mentor_ig_links(
-                        instance.user, instance.preferred_ig_ids, user_id
+                        instance.user, instance.preferred_ig_ids, user_id,
+                        exclude_application_id=instance.id,
                     )
                     reconcile_mentor_ig_grants(
                         instance, user_id
@@ -1680,6 +1736,32 @@ class AdminAssignMentorSerializer(serializers.Serializer):
                         f"The following IG IDs are invalid: {', '.join(invalid_igs)}"
                     )
 
+        # Assigning ig_ids must not push any resolved user past the global
+        # active-IG cap once unioned with whatever they already hold via
+        # other APPROVED applications (see get_effective_ig_ids).
+        ig_ids = attrs.get("ig_ids") or []
+        if ig_ids and not errors.get("ig_ids"):
+            from .dash_mentor_helper import get_effective_ig_ids, MAX_PREFERRED_IGS
+
+            over_limit_muids = []
+            for muid, user in resolved_users.items():
+                existing_app = MentorApplication.objects.filter(
+                    user=user, mentor_tier=tier, org=attrs.get("_org"),
+                    status=MentorApplication.Status.APPROVED,
+                ).first()
+                effective = get_effective_ig_ids(
+                    user, ig_ids,
+                    exclude_application_id=existing_app.id if existing_app else None,
+                )
+                if len(effective) > MAX_PREFERRED_IGS:
+                    over_limit_muids.append(muid)
+
+            if over_limit_muids:
+                errors["ig_ids"] = (
+                    f"Assigning these Interest Groups would exceed the maximum of "
+                    f"{MAX_PREFERRED_IGS} active Interest Groups for: {', '.join(over_limit_muids)}"
+                )
+
         if errors:
             raise serializers.ValidationError(errors)
 
@@ -1795,7 +1877,9 @@ class AdminAssignMentorSerializer(serializers.Serializer):
                 # 5. Side-effects (IG links + org link)
                 if ig_ids:
                     from .dash_mentor_helper import reconcile_mentor_ig_links, reconcile_mentor_ig_grants
-                    reconcile_mentor_ig_links(user, ig_ids, admin_id)
+                    reconcile_mentor_ig_links(
+                        user, ig_ids, admin_id, exclude_application_id=application.id
+                    )
                     reconcile_mentor_ig_grants(application, admin_id)
 
                 if tier in (MentorApplication.MentorTier.CAMPUS_MENTOR, MentorApplication.MentorTier.COMPANY_MENTOR) and org:

--- a/api/dashboard/mentor/task_serializers.py
+++ b/api/dashboard/mentor/task_serializers.py
@@ -33,8 +33,14 @@ class MentorTaskCreateSerializer(serializers.ModelSerializer):
         }
 
     def validate_hashtag(self, value):
-        """Global hashtag uniqueness — same rule as admin."""
-        validate_safe_text(value)
+        """Must start with '#' (same convention as admin/company task creation);
+        global hashtag uniqueness — same rule as admin. Not run through
+        validate_safe_text: its SQL-injection heuristic bans a bare '#',
+        which every valid hashtag necessarily starts with.
+        """
+        value = value.strip()
+        if not value.startswith('#'):
+            raise serializers.ValidationError("hashtag must start with '#'")
         qs = TaskList.objects.filter(hashtag=value)
         if self.instance:
             qs = qs.exclude(pk=self.instance.pk)
@@ -90,8 +96,10 @@ class MentorTaskUpdateSerializer(serializers.ModelSerializer):
         )
 
     def validate_hashtag(self, value):
-        """Exclude current instance from uniqueness check on edit."""
-        validate_safe_text(value)
+        """Must start with '#'; exclude current instance from uniqueness check on edit."""
+        value = value.strip()
+        if not value.startswith('#'):
+            raise serializers.ValidationError("hashtag must start with '#'")
         qs = TaskList.objects.filter(hashtag=value)
         if self.instance:
             qs = qs.exclude(pk=self.instance.pk)

--- a/api/dashboard/mentor/urls.py
+++ b/api/dashboard/mentor/urls.py
@@ -46,6 +46,7 @@ urlpatterns = [
     path('admin/assign/<str:user_muid>/',       mentor_views.AdminAssignMentorAPI.as_view(), name='admin-revoke-mentor'),
     path('admin/deactivate/<str:user_mentor_id>/', admin_views.MentorDeactivationAPI.as_view(), name='mentor-deactivate'),
     path('admin/reactivate/<str:user_mentor_id>/', admin_views.MentorReactivationAPI.as_view(), name='mentor-reactivate'),
+    path('<str:mentor_id>/preferred-igs/',        mentor_views.MentorPreferredIgAPI.as_view(), name='mentor-preferred-igs'),
     path('<str:mentor_id>/grants/',              mentor_views.MentorScopeGrantListAPI.as_view(), name='mentor-grant-list'),
     path('<str:mentor_id>/grants/<str:grant_id>/', mentor_views.MentorScopeGrantRevokeAPI.as_view(), name='mentor-grant-revoke'),
     path('change-company/', mentor_views.MentorChangeCompanyAPI.as_view(), name='mentor-change-company'),

--- a/api/dashboard/roles/dash_roles_serializer.py
+++ b/api/dashboard/roles/dash_roles_serializer.py
@@ -324,7 +324,10 @@ class UserRoleCreateSerializer(serializers.ModelSerializer):
 
                 # 4. Side-effects (IG links + org link)
                 if ig_ids:
-                    reconcile_mentor_ig_links(application.user, ig_ids, admin_user_id)
+                    reconcile_mentor_ig_links(
+                        application.user, ig_ids, admin_user_id,
+                        exclude_application_id=application.id,
+                    )
                     reconcile_mentor_ig_grants(application, admin_user_id)
 
                 if mentor_tier in (

--- a/api/dashboard/roles/dash_roles_views.py
+++ b/api/dashboard/roles/dash_roles_views.py
@@ -402,7 +402,6 @@ class UserRole(APIView):
             # ── Mentor cleanup ──────────────────────────────────────────────
             if role_title == RoleType.MENTOR.value:
                 from db.user import MentorApplication, MentorScopeGrant
-                from db.task import UserIgLink
 
                 applications = MentorApplication.objects.filter(
                     user=user, status=MentorApplication.Status.APPROVED
@@ -413,11 +412,15 @@ class UserRole(APIView):
                     app.updated_at = now
                     app.save(update_fields=["status", "updated_by_id", "updated_at"])
 
-                    if app.mentor_tier == MentorApplication.MentorTier.IG_MENTOR:
-                        UserIgLink.objects.filter(
-                            user=user, ig_id__in=ig_scope_ids,
-                            assignment_type=UserIgLink.AssignmentType.MENTOR,
-                        ).update(is_active=False)
+                    if app.mentor_tier == MentorApplication.MentorTier.IG_MENTOR and app.preferred_ig_ids:
+                        # Only release IGs no OTHER still-APPROVED application
+                        # (e.g. a separate COMPANY_MENTOR app listing the same
+                        # IG) still relies on.
+                        from api.dashboard.mentor.dash_mentor_helper import release_mentor_ig_links
+                        release_mentor_ig_links(
+                            user, app.preferred_ig_ids,
+                            exclude_application_id=app.id, actor_user_id=admin_id,
+                        )
 
                     MentorScopeGrant.objects.filter(
                         application=app, is_active=True


### PR DESCRIPTION
## Summary

Fixes a class of bugs where a mentor's Interest Group access was being silently overwritten/lost depending on which of their applications was touched last, and closes a validation false-positive on task hashtags. Also adds a review step and a hard cap to IG assignment.

- **`api/dashboard/mentor/task_serializers.py`** — `hashtag` validation on mentor task create/update no longer runs through the generic SQL-injection filter (which flagged any bare `#`, and every valid hashtag starts with one). Now matches the company flow: strip → must start with `#` → uniqueness check.

- **`api/dashboard/mentor/dash_mentor_helper.py`** — core fix. Added `get_effective_ig_ids()`, the single source of truth for a mentor's active IG footprint: the union of one application's IGs with every *other* currently-APPROVED application's IGs. `reconcile_mentor_ig_links()` now uses this instead of just the one application being touched, so approving or editing one tier's IGs (e.g. COMPANY_MENTOR) can no longer deactivate IGs another still-approved tier (e.g. IG_MENTOR) legitimately holds — previously this depended on approval order. Added `release_mentor_ig_links()`, the mirror-image fix for revocation: releasing one application's IGs now skips any IG still claimed by another approved application. Added `MAX_PREFERRED_IGS = 5`, capping a mentor's *combined* active IG count across all applications.

- **`api/dashboard/mentor/serializers.py`** — `MentorVerifySerializer`, `AdminAssignMentorSerializer` updated to pass application-scoped exclusions into the reconciliation helpers and enforce the new max-IG limit before approval. `MentorIgPreferenceSerializer` changed from a `ModelSerializer` that mutated the approved application in place to a validation-only serializer.

- **`api/dashboard/mentor/mentor_views.py`** — `MentorPreferredIgAPI.patch` (self-service IG change) no longer edits the approved application directly. It now creates a new PENDING "change request" application (mirroring `MentorChangeCompanyAPI`) and notifies the correct verifier per tier (IG lead + admin for IG_MENTOR, company owner for COMPANY_MENTOR, admin for CAMPUS_MENTOR) — the mentor's live IG access is unaffected until that request is approved. `AdminAssignMentorAPI.delete` updated to use the new safe-release helper instead of unconditionally deactivating IGs.

- **`api/dashboard/roles/dash_roles_serializer.py`, `dash_roles_views.py`** — same reconciliation/release fixes applied to the role-assignment and role-strip admin paths for consistency. Also fixes an unrelated pre-existing crash: `dash_roles_views.py`'s role-strip cleanup referenced an undefined `ig_scope_ids` variable (`NameError`) whenever stripping the MENTOR role from a user holding an approved IG_MENTOR application.

## Test plan
- [ ] Approve two different mentor tiers (e.g. IG_MENTOR then COMPANY_MENTOR) with different IGs for the same user — confirm both tiers' IGs end up active regardless of order.
- [ ] Revoke one tier's application where an IG overlaps with another still-approved tier — confirm the shared IG stays active.
- [ ] Attempt to exceed the 5-IG cap via approval, admin bulk-assign, and self-service change request — confirm each is rejected cleanly.
- [ ] Submit a self-service IG change request — confirm it creates a PENDING application, live access is unaffected until approved, and the right verifier is notified.
- [ ] Create a valid task hashtag (`#...`) via `/mentor/tasks/` — confirm it's no longer rejected.
- [ ] Strip the MENTOR role from a user holding an approved IG_MENTOR application — confirm no crash.
