### PR TITLE
fix: cherry-pick career lab, community partner, IG/campus, and learning circle fixes from dev

### DIFF
--- a/api/common/urls.py
+++ b/api/common/urls.py
@@ -6,6 +6,7 @@ from . import common_views
 from .college_details_views import CollegeDetailsAPI
 from api.dashboard.company import job_views
 from api.dashboard.career_lab import career_lab_views
+from api.dashboard.events.public_views import PublicEventListAPI
 
 urlpatterns = [
     path('campus-details/<str:college_code>/', CollegeDetailsAPI.as_view()),
@@ -39,4 +40,5 @@ urlpatterns = [
     path('ig/<str:pk>/', common_views.IGDetailAPI.as_view()),
     path('career-lab/ongoing/', career_lab_views.PublicOngoingHiringAPI.as_view(), name='public-career-lab-ongoing'),
     path('career-lab/previous/', career_lab_views.PublicPreviousHiringAPI.as_view(), name='public-career-lab-previous'),
+    path('events/', PublicEventListAPI.as_view(), name='public-events-list'),
 ]

--- a/api/common/urls.py
+++ b/api/common/urls.py
@@ -5,6 +5,7 @@ from .external_api_views import ExternalUserDetailsAPI
 from . import common_views
 from .college_details_views import CollegeDetailsAPI
 from api.dashboard.company import job_views
+from api.dashboard.career_lab import career_lab_views
 
 urlpatterns = [
     path('campus-details/<str:college_code>/', CollegeDetailsAPI.as_view()),
@@ -36,4 +37,6 @@ urlpatterns = [
     path("external/user/", ExternalUserDetailsAPI.as_view()),
     path('jobs/', job_views.PublicJobAPI.as_view(), name='public-jobs-list'),
     path('ig/<str:pk>/', common_views.IGDetailAPI.as_view()),
+    path('career-lab/ongoing/', career_lab_views.PublicOngoingHiringAPI.as_view(), name='public-career-lab-ongoing'),
+    path('career-lab/previous/', career_lab_views.PublicPreviousHiringAPI.as_view(), name='public-career-lab-previous'),
 ]

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -21,14 +21,16 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
     college_name = serializers.ReadOnlyField(source="title")
     campus_code = serializers.ReadOnlyField(source="code")
     campus_zone = serializers.ReadOnlyField(source="district.zone.name")
-    campus_level = serializers.SerializerMethodField()
     total_karma = serializers.SerializerMethodField()
     total_members = serializers.SerializerMethodField()
     active_members = serializers.SerializerMethodField()
     rank = serializers.SerializerMethodField()
     social_links = serializers.SerializerMethodField()
-   
-    
+    campus_lead = serializers.SerializerMethodField()
+    execom = serializers.SerializerMethodField()
+    top_10_mulearn_leaderboard = serializers.SerializerMethodField()
+    active_ig_chapters = serializers.SerializerMethodField()
+    karma_by_cluster = serializers.SerializerMethodField()
 
     class Meta:
         model = Organization
@@ -37,29 +39,26 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
             "college_name",
             "campus_code",
             "campus_zone",
-            "campus_level",
             "total_karma",
             "total_members",
             "active_members",
             "rank",
             "social_links",
+            "campus_lead",
+            "execom",
+            "top_10_mulearn_leaderboard",
+            "active_ig_chapters",
+            "karma_by_cluster",
         ]
-
-    def get_campus_level(self, obj):
-        campus = obj.college_org
-        if campus:
-            return campus.level
-
-        return None
 
     def get_total_members(self, obj):
         return obj.user_organization_link_org.filter(verified=True).values('user').distinct().count()
 
     def get_active_members(self, obj):
+        since = DateTimeUtils.get_current_utc_time() - timedelta(days=30)
         return obj.user_organization_link_org.filter(
             verified=True,
-            user__discord_id__isnull=False,
-            user__exist_in_guild=True
+            user__wallet_user__karma_last_updated_at__gte=since
         ).values('user').distinct().count()
 
     def get_total_karma(self, obj):
@@ -103,6 +102,139 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
         links = CampusSocialLink.objects.filter(org=obj)
         return CampusSocialLinkSerializer(links, many=True).data
 
+    def get_campus_lead(self, obj):
+        lead_link = UserRoleLink.objects.filter(
+            user__user_organization_link_user__org=obj,
+            user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            user__user_organization_link_user__verified=True,
+            role__title=RoleType.CAMPUS_LEAD.value,
+        ).select_related("user", "role").first()
+
+        if not lead_link:
+            return None
+
+        user = lead_link.user
+        return {
+            "user_id": str(user.id),
+            "full_name": user.full_name,
+            "muid": user.muid,
+            "profile_pic": str(user.profile_pic) if user.profile_pic else None,
+            "role": lead_link.role.title,
+        }
+
+    def get_execom(self, obj):
+        campus_user_ids = obj.user_organization_link_org.filter(
+            verified=True
+        ).values_list("user_id", flat=True)
+
+        execom_links = UserRoleLink.objects.filter(
+            user_id__in=campus_user_ids,
+            role__is_execom_role=True,
+        ).select_related("user", "role")
+
+        return ExecomMemberSerializer(execom_links, many=True).data
+
+    def get_top_10_mulearn_leaderboard(self, obj):
+        from db.task import Wallet
+
+        top_wallets = Wallet.objects.select_related("user").order_by(
+            "-karma", "created_at"
+        )[:10]
+
+        return [
+            {
+                "rank": index + 1,
+                "user_id": str(wallet.user.id),
+                "full_name": wallet.user.full_name,
+                "muid": wallet.user.muid,
+                "profile_pic": str(wallet.user.profile_pic) if wallet.user.profile_pic else None,
+                "karma": wallet.karma,
+            }
+            for index, wallet in enumerate(top_wallets)
+        ]
+
+    def get_active_ig_chapters(self, obj):
+        chapters = CampusIGChapter.objects.filter(
+            org=obj, is_active=True
+        ).select_related("ig", "lead")
+
+        result = []
+        for chapter in chapters:
+            member_count = UserIgLink.objects.filter(
+                ig=chapter.ig,
+                is_active=True,
+                assignment_type=UserIgLink.AssignmentType.LEARNER,
+                user__user_organization_link_user__org=obj,
+                user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                user__user_organization_link_user__verified=True,
+            ).values("user").distinct().count()
+
+            result.append({
+                "ig_chapter_id": chapter.id,
+                "ig_name": chapter.ig.name,
+                "ig_code": chapter.ig.code,
+                "lead": {
+                    "user_id": str(chapter.lead.id),
+                    "full_name": chapter.lead.full_name,
+                    "muid": chapter.lead.muid,
+                } if chapter.lead else None,
+                "member_count": member_count,
+            })
+
+        return result
+
+    def get_karma_by_cluster(self, obj):
+        from django.db.models import OuterRef, Subquery
+        from collections import defaultdict
+        from db.task import Wallet
+
+        wallet_karma_sq = Wallet.objects.filter(
+            user=OuterRef("pk")
+        ).values("karma")[:1]
+
+        primary_category_sq = (
+            UserIgLink.objects.filter(
+                user_id=OuterRef("pk"),
+                is_active=True,
+                assignment_type=UserIgLink.AssignmentType.LEARNER,
+            )
+            .order_by("created_at")
+            .values("ig__category")[:1]
+        )
+
+        all_rows = (
+            User.objects.filter(
+                user_organization_link_user__org=obj,
+                user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+                user_organization_link_user__verified=True,
+            )
+            .annotate(
+                user_karma=Subquery(wallet_karma_sq),
+                primary_category=Subquery(primary_category_sq),
+            )
+            .values("id", "primary_category", "user_karma")
+            .distinct()
+        )
+
+        category_map = defaultdict(lambda: {"total_karma": 0, "member_count": 0, "seen_users": set()})
+
+        for row in all_rows:
+            category = row["primary_category"] or "unclustered"
+            user_id = row["id"]
+            karma = row["user_karma"] or 0
+
+            if user_id not in category_map[category]["seen_users"]:
+                category_map[category]["seen_users"].add(user_id)
+                category_map[category]["total_karma"] += karma
+                category_map[category]["member_count"] += 1
+
+        return {
+            category: {
+                "total_karma": data["total_karma"],
+                "member_count": data["member_count"],
+            }
+            for category, data in category_map.items()
+        }
 
 
 class CampusListSerializer(serializers.ModelSerializer):

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -28,7 +28,7 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
     social_links = serializers.SerializerMethodField()
     campus_lead = serializers.SerializerMethodField()
     execom = serializers.SerializerMethodField()
-    top_10_mulearn_leaderboard = serializers.SerializerMethodField()
+    top_10_campus_leaderboard = serializers.SerializerMethodField()
     active_ig_chapters = serializers.SerializerMethodField()
     karma_by_cluster = serializers.SerializerMethodField()
 
@@ -46,7 +46,7 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
             "social_links",
             "campus_lead",
             "execom",
-            "top_10_mulearn_leaderboard",
+            "top_10_campus_leaderboard",
             "active_ig_chapters",
             "karma_by_cluster",
         ]
@@ -134,12 +134,14 @@ class CampusDetailsPublicSerializer(serializers.ModelSerializer):
 
         return ExecomMemberSerializer(execom_links, many=True).data
 
-    def get_top_10_mulearn_leaderboard(self, obj):
+    def get_top_10_campus_leaderboard(self, obj):
         from db.task import Wallet
 
-        top_wallets = Wallet.objects.select_related("user").order_by(
-            "-karma", "created_at"
-        )[:10]
+        top_wallets = Wallet.objects.filter(
+            user__user_organization_link_user__org=obj,
+            user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            user__user_organization_link_user__verified=True,
+        ).select_related("user").distinct().order_by("-karma", "created_at")[:10]
 
         return [
             {

--- a/api/dashboard/career_lab/career_lab_serializers.py
+++ b/api/dashboard/career_lab/career_lab_serializers.py
@@ -1,0 +1,62 @@
+from rest_framework import serializers
+
+from db.career_lab import Hiring
+
+
+class HiringSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Hiring
+        fields = [
+            'id', 'posted_date', 'role', 'organization', 'title', 'location',
+            'lastdate', 'applylink', 'jdlink', 'duration', 'remuneration',
+            'vacancies', 'extracontent', 'created_at', 'updated_at',
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+    def create(self, validated_data):
+        user_id = self.context.get('user_id')
+        validated_data['created_by_id'] = user_id
+        validated_data['updated_by_id'] = user_id
+        return Hiring.objects.create(**validated_data)
+
+    def update(self, instance, validated_data):
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.updated_by_id = self.context.get('user_id')
+        instance.save()
+        return instance
+
+
+class HiringCSVRowSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Hiring
+        fields = [
+            'posted_date', 'role', 'organization', 'title', 'location',
+            'lastdate', 'applylink', 'jdlink', 'duration', 'remuneration',
+            'vacancies', 'extracontent',
+        ]
+
+    def create(self, validated_data):
+        user_id = self.context.get('user_id')
+        validated_data['created_by_id'] = user_id
+        validated_data['updated_by_id'] = user_id
+        return Hiring.objects.create(**validated_data)
+
+
+class PublicOngoingHiringSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Hiring
+        fields = [
+            'id', 'posted_date', 'role', 'organization', 'title', 'location',
+            'lastdate', 'applylink', 'jdlink', 'duration', 'remuneration',
+            'vacancies',
+        ]
+
+
+class PublicPreviousHiringSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Hiring
+        fields = [
+            'id', 'role', 'organization', 'title', 'location', 'lastdate',
+            'remuneration', 'vacancies', 'duration', 'extracontent',
+        ]

--- a/api/dashboard/career_lab/career_lab_serializers.py
+++ b/api/dashboard/career_lab/career_lab_serializers.py
@@ -4,12 +4,16 @@ from db.career_lab import Hiring
 
 
 class HiringSerializer(serializers.ModelSerializer):
+    created_by = serializers.ReadOnlyField(source='created_by.full_name')
+    updated_by = serializers.ReadOnlyField(source='updated_by.full_name')
+
     class Meta:
         model = Hiring
         fields = [
             'id', 'posted_date', 'role', 'organization', 'title', 'location',
             'lastdate', 'applylink', 'jdlink', 'duration', 'remuneration',
-            'vacancies', 'extracontent', 'created_at', 'updated_at',
+            'vacancies', 'extracontent', 'created_by', 'created_at',
+            'updated_by', 'updated_at',
         ]
         read_only_fields = ['id', 'created_at', 'updated_at']
 
@@ -44,19 +48,26 @@ class HiringCSVRowSerializer(serializers.ModelSerializer):
 
 
 class PublicOngoingHiringSerializer(serializers.ModelSerializer):
+    created_by = serializers.ReadOnlyField(source='created_by.full_name')
+    updated_by = serializers.ReadOnlyField(source='updated_by.full_name')
+
     class Meta:
         model = Hiring
         fields = [
             'id', 'posted_date', 'role', 'organization', 'title', 'location',
             'lastdate', 'applylink', 'jdlink', 'duration', 'remuneration',
-            'vacancies',
+            'vacancies', 'created_by', 'created_at', 'updated_by', 'updated_at',
         ]
 
 
 class PublicPreviousHiringSerializer(serializers.ModelSerializer):
+    created_by = serializers.ReadOnlyField(source='created_by.full_name')
+    updated_by = serializers.ReadOnlyField(source='updated_by.full_name')
+
     class Meta:
         model = Hiring
         fields = [
             'id', 'role', 'organization', 'title', 'location', 'lastdate',
             'remuneration', 'vacancies', 'duration', 'extracontent',
+            'created_by', 'created_at', 'updated_by', 'updated_at',
         ]

--- a/api/dashboard/career_lab/career_lab_views.py
+++ b/api/dashboard/career_lab/career_lab_views.py
@@ -121,7 +121,7 @@ class HiringAPI(APIView):
     )
     @role_required(CAREER_LAB_ADMIN_ROLES)
     def get(self, request):
-        queryset = _apply_filters(Hiring.objects.all().order_by("-created_at"), request)
+        queryset = _apply_filters(Hiring.objects.all().order_by("-posted_date"), request)
         paginated_queryset = CommonUtils.get_paginated_queryset(
             queryset, request,
             search_fields=SEARCH_FIELDS,

--- a/api/dashboard/career_lab/career_lab_views.py
+++ b/api/dashboard/career_lab/career_lab_views.py
@@ -16,6 +16,10 @@ from . import career_lab_serializers
 
 CAREER_LAB_ADMIN_ROLES = [RoleType.ADMIN.value, RoleType.ASSOCIATE.value]
 
+# Columns present in the exported CSV that are system-managed and must be
+# ignored on re-import so an exported file can be re-imported unchanged.
+SYSTEM_GENERATED_FIELDS = {"id", "created_by", "created_at", "updated_by", "updated_at"}
+
 SEARCH_FIELDS = ["role", "organization", "title", "location"]
 SORT_FIELDS = {
     "lastdate": "lastdate",
@@ -226,6 +230,9 @@ class HiringCSVAPI(APIView):
             "Bulk import hiring postings from a CSV file. "
             "Expected columns: posted_date, role, organization, title, location, lastdate, "
             "applylink, jdlink, duration, remuneration, vacancies, extracontent. "
+            "System-generated columns from an exported CSV (id, created_by, created_at, "
+            "updated_by, updated_at) are ignored if present, so an exported file can be "
+            "re-imported unchanged. "
             "Import is create-only — existing rows are never updated."
         ),
     )
@@ -246,7 +253,11 @@ class HiringCSVAPI(APIView):
         created_count = 0
         row_errors = []
         for row_number, row in enumerate(reader, start=2):
-            cleaned_row = {key: (value if value not in ("", None) else None) for key, value in row.items()}
+            cleaned_row = {
+                key: (value if value not in ("", None) else None)
+                for key, value in row.items()
+                if key not in SYSTEM_GENERATED_FIELDS
+            }
             serializer = career_lab_serializers.HiringCSVRowSerializer(
                 data=cleaned_row, context={"user_id": user_id}
             )

--- a/api/dashboard/career_lab/career_lab_views.py
+++ b/api/dashboard/career_lab/career_lab_views.py
@@ -272,7 +272,7 @@ class PublicOngoingHiringAPI(APIView):
         responses={200: career_lab_serializers.PublicOngoingHiringSerializer(many=True)},
     )
     def get(self, request):
-        queryset = Hiring.objects.filter(lastdate__gte=timezone.now().date())
+        queryset = Hiring.objects.filter(lastdate__gte=timezone.now().date()).order_by("-posted_date")
         queryset = _apply_filters(queryset, request)
         paginated_queryset = CommonUtils.get_paginated_queryset(
             queryset, request,
@@ -298,7 +298,7 @@ class PublicPreviousHiringAPI(APIView):
         responses={200: career_lab_serializers.PublicPreviousHiringSerializer(many=True)},
     )
     def get(self, request):
-        queryset = Hiring.objects.filter(lastdate__lt=timezone.now().date())
+        queryset = Hiring.objects.filter(lastdate__lt=timezone.now().date()).order_by("-posted_date")
         queryset = _apply_filters(queryset, request)
         paginated_queryset = CommonUtils.get_paginated_queryset(
             queryset, request,

--- a/api/dashboard/career_lab/career_lab_views.py
+++ b/api/dashboard/career_lab/career_lab_views.py
@@ -121,7 +121,7 @@ class HiringAPI(APIView):
     )
     @role_required(CAREER_LAB_ADMIN_ROLES)
     def get(self, request):
-        queryset = _apply_filters(Hiring.objects.all(), request)
+        queryset = _apply_filters(Hiring.objects.all().order_by("-created_at"), request)
         paginated_queryset = CommonUtils.get_paginated_queryset(
             queryset, request,
             search_fields=SEARCH_FIELDS,

--- a/api/dashboard/career_lab/career_lab_views.py
+++ b/api/dashboard/career_lab/career_lab_views.py
@@ -14,7 +14,7 @@ from utils.utils import CommonUtils
 
 from . import career_lab_serializers
 
-CAREER_LAB_ADMIN_ROLES = [RoleType.ADMIN.value]
+CAREER_LAB_ADMIN_ROLES = [RoleType.ADMIN.value, RoleType.ASSOCIATE.value]
 
 SEARCH_FIELDS = ["role", "organization", "title", "location"]
 SORT_FIELDS = {

--- a/api/dashboard/career_lab/career_lab_views.py
+++ b/api/dashboard/career_lab/career_lab_views.py
@@ -1,0 +1,314 @@
+import csv
+import io
+from datetime import datetime
+
+from django.utils import timezone
+from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
+
+from db.career_lab import Hiring
+from utils.permission import CustomizePermission, JWTUtils, role_required
+from utils.response import CustomResponse
+from utils.types import RoleType
+from utils.utils import CommonUtils
+
+from . import career_lab_serializers
+
+CAREER_LAB_ADMIN_ROLES = [RoleType.ADMIN.value]
+
+SEARCH_FIELDS = ["role", "organization", "title", "location"]
+SORT_FIELDS = {
+    "lastdate": "lastdate",
+    "posted_date": "posted_date",
+    "organization": "organization",
+    "role": "role",
+    "created_at": "created_at",
+}
+
+
+def _parse_date(value):
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def _apply_filters(queryset, request):
+    """Shared filter set for admin and public hiring list endpoints."""
+    params = request.query_params
+
+    status = params.get("status")
+    today = timezone.now().date()
+    if status == "ongoing":
+        queryset = queryset.filter(lastdate__gte=today)
+    elif status == "previous":
+        queryset = queryset.filter(lastdate__lt=today)
+
+    if organization := params.get("organization"):
+        queryset = queryset.filter(organization__icontains=organization)
+
+    if role := params.get("role"):
+        queryset = queryset.filter(role__icontains=role)
+
+    if location := params.get("location"):
+        queryset = queryset.filter(location__icontains=location)
+
+    if duration := params.get("duration"):
+        queryset = queryset.filter(duration__icontains=duration)
+
+    if title := params.get("title"):
+        queryset = queryset.filter(title__icontains=title)
+
+    if min_vacancies := params.get("min_vacancies"):
+        try:
+            queryset = queryset.filter(vacancies__gte=int(min_vacancies))
+        except ValueError:
+            pass
+
+    if max_vacancies := params.get("max_vacancies"):
+        try:
+            queryset = queryset.filter(vacancies__lte=int(max_vacancies))
+        except ValueError:
+            pass
+
+    if lastdate_from := params.get("lastdate_from"):
+        if parsed := _parse_date(lastdate_from):
+            queryset = queryset.filter(lastdate__gte=parsed)
+
+    if lastdate_to := params.get("lastdate_to"):
+        if parsed := _parse_date(lastdate_to):
+            queryset = queryset.filter(lastdate__lte=parsed)
+
+    if posted_from := params.get("posted_date_from"):
+        if parsed := _parse_date(posted_from):
+            queryset = queryset.filter(posted_date__gte=parsed)
+
+    if posted_to := params.get("posted_date_to"):
+        if parsed := _parse_date(posted_to):
+            queryset = queryset.filter(posted_date__lte=parsed)
+
+    return queryset
+
+
+FILTER_PARAMETERS = [
+    OpenApiParameter("status", OpenApiTypes.STR, description="ongoing | previous | all"),
+    OpenApiParameter("organization", OpenApiTypes.STR),
+    OpenApiParameter("role", OpenApiTypes.STR),
+    OpenApiParameter("location", OpenApiTypes.STR),
+    OpenApiParameter("title", OpenApiTypes.STR),
+    OpenApiParameter("duration", OpenApiTypes.STR),
+    OpenApiParameter("min_vacancies", OpenApiTypes.INT),
+    OpenApiParameter("max_vacancies", OpenApiTypes.INT),
+    OpenApiParameter("lastdate_from", OpenApiTypes.DATE),
+    OpenApiParameter("lastdate_to", OpenApiTypes.DATE),
+    OpenApiParameter("posted_date_from", OpenApiTypes.DATE),
+    OpenApiParameter("posted_date_to", OpenApiTypes.DATE),
+    OpenApiParameter("search", OpenApiTypes.STR, description="Search role/organization/title/location"),
+    OpenApiParameter("sortBy", OpenApiTypes.STR),
+    OpenApiParameter("pageIndex", OpenApiTypes.INT),
+    OpenApiParameter("perPage", OpenApiTypes.INT),
+]
+
+
+class HiringAPI(APIView):
+    permission_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Career Lab'],
+        description="List hiring postings with filters.",
+        parameters=FILTER_PARAMETERS,
+        responses={200: career_lab_serializers.HiringSerializer(many=True)},
+    )
+    @role_required(CAREER_LAB_ADMIN_ROLES)
+    def get(self, request):
+        queryset = _apply_filters(Hiring.objects.all(), request)
+        paginated_queryset = CommonUtils.get_paginated_queryset(
+            queryset, request,
+            search_fields=SEARCH_FIELDS,
+            sort_fields=SORT_FIELDS,
+        )
+        serializer = career_lab_serializers.HiringSerializer(paginated_queryset.get("queryset"), many=True)
+        return CustomResponse(
+            response={
+                "data": serializer.data,
+                "pagination": paginated_queryset.get("pagination"),
+            }
+        ).get_success_response()
+
+    @extend_schema(
+        tags=['Dashboard - Career Lab'],
+        description="Create a new hiring posting.",
+        request=career_lab_serializers.HiringSerializer,
+        responses={200: career_lab_serializers.HiringSerializer},
+    )
+    @role_required(CAREER_LAB_ADMIN_ROLES)
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        serializer = career_lab_serializers.HiringSerializer(data=request.data, context={"user_id": user_id})
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message="Hiring posting created successfully.",
+                response=serializer.data,
+            ).get_success_response()
+        return CustomResponse(message=serializer.errors).get_failure_response()
+
+
+class HiringDetailAPI(APIView):
+    permission_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Career Lab'],
+        description="Retrieve a specific hiring posting.",
+        responses={200: career_lab_serializers.HiringSerializer},
+    )
+    @role_required(CAREER_LAB_ADMIN_ROLES)
+    def get(self, request, hiring_id):
+        hiring = Hiring.objects.filter(id=hiring_id).first()
+        if not hiring:
+            return CustomResponse(general_message="Hiring posting not found.").get_failure_response(status_code=404)
+        serializer = career_lab_serializers.HiringSerializer(hiring)
+        return CustomResponse(response=serializer.data).get_success_response()
+
+    @extend_schema(
+        tags=['Dashboard - Career Lab'],
+        description="Update a specific hiring posting.",
+        request=career_lab_serializers.HiringSerializer,
+        responses={200: career_lab_serializers.HiringSerializer},
+    )
+    @role_required(CAREER_LAB_ADMIN_ROLES)
+    def put(self, request, hiring_id):
+        user_id = JWTUtils.fetch_user_id(request)
+        hiring = Hiring.objects.filter(id=hiring_id).first()
+        if not hiring:
+            return CustomResponse(general_message="Hiring posting not found.").get_failure_response(status_code=404)
+        serializer = career_lab_serializers.HiringSerializer(
+            hiring, data=request.data, partial=True, context={"user_id": user_id}
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return CustomResponse(
+                general_message="Hiring posting updated successfully.",
+                response=serializer.data,
+            ).get_success_response()
+        return CustomResponse(message=serializer.errors).get_failure_response()
+
+    @extend_schema(
+        tags=['Dashboard - Career Lab'],
+        description="Delete a specific hiring posting.",
+    )
+    @role_required(CAREER_LAB_ADMIN_ROLES)
+    def delete(self, request, hiring_id):
+        hiring = Hiring.objects.filter(id=hiring_id).first()
+        if not hiring:
+            return CustomResponse(general_message="Hiring posting not found.").get_failure_response(status_code=404)
+        hiring.delete()
+        return CustomResponse(general_message="Hiring posting deleted successfully.").get_success_response()
+
+
+class HiringCSVAPI(APIView):
+    permission_classes = [CustomizePermission]
+
+    @extend_schema(
+        tags=['Dashboard - Career Lab'],
+        description="Export hiring postings as CSV.",
+        parameters=FILTER_PARAMETERS,
+    )
+    @role_required(CAREER_LAB_ADMIN_ROLES)
+    def get(self, request):
+        queryset = _apply_filters(Hiring.objects.all(), request)
+        serializer = career_lab_serializers.HiringSerializer(queryset, many=True)
+        return CommonUtils.generate_csv(serializer.data, "Hiring")
+
+    @extend_schema(
+        tags=['Dashboard - Career Lab'],
+        description=(
+            "Bulk import hiring postings from a CSV file. "
+            "Expected columns: posted_date, role, organization, title, location, lastdate, "
+            "applylink, jdlink, duration, remuneration, vacancies, extracontent. "
+            "Import is create-only — existing rows are never updated."
+        ),
+    )
+    @role_required(CAREER_LAB_ADMIN_ROLES)
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        csv_file = request.FILES.get('file')
+        if not csv_file:
+            return CustomResponse(general_message="No CSV file provided.").get_failure_response()
+
+        try:
+            decoded_file = csv_file.read().decode('utf-8-sig')
+        except UnicodeDecodeError:
+            return CustomResponse(general_message="Unable to decode CSV file. Please upload a UTF-8 encoded CSV.").get_failure_response()
+
+        reader = csv.DictReader(io.StringIO(decoded_file))
+
+        created_count = 0
+        row_errors = []
+        for row_number, row in enumerate(reader, start=2):
+            cleaned_row = {key: (value if value not in ("", None) else None) for key, value in row.items()}
+            serializer = career_lab_serializers.HiringCSVRowSerializer(
+                data=cleaned_row, context={"user_id": user_id}
+            )
+            if serializer.is_valid():
+                serializer.save()
+                created_count += 1
+            else:
+                row_errors.append({"row": row_number, "errors": serializer.errors})
+
+        return CustomResponse(
+            general_message=f"Imported {created_count} hiring posting(s).",
+            response={"created": created_count, "errors": row_errors},
+        ).get_success_response()
+
+
+class PublicOngoingHiringAPI(APIView):
+    permission_classes = []
+
+    @extend_schema(
+        tags=['Public - Career Lab'],
+        description="Public endpoint to list ongoing hiring postings.",
+        parameters=FILTER_PARAMETERS,
+        responses={200: career_lab_serializers.PublicOngoingHiringSerializer(many=True)},
+    )
+    def get(self, request):
+        queryset = Hiring.objects.filter(lastdate__gte=timezone.now().date())
+        queryset = _apply_filters(queryset, request)
+        paginated_queryset = CommonUtils.get_paginated_queryset(
+            queryset, request,
+            search_fields=SEARCH_FIELDS,
+            sort_fields=SORT_FIELDS,
+        )
+        serializer = career_lab_serializers.PublicOngoingHiringSerializer(paginated_queryset.get("queryset"), many=True)
+        return CustomResponse(
+            response={
+                "data": serializer.data,
+                "pagination": paginated_queryset.get("pagination"),
+            }
+        ).get_success_response()
+
+
+class PublicPreviousHiringAPI(APIView):
+    permission_classes = []
+
+    @extend_schema(
+        tags=['Public - Career Lab'],
+        description="Public endpoint to list previous/archived hiring postings.",
+        parameters=FILTER_PARAMETERS,
+        responses={200: career_lab_serializers.PublicPreviousHiringSerializer(many=True)},
+    )
+    def get(self, request):
+        queryset = Hiring.objects.filter(lastdate__lt=timezone.now().date())
+        queryset = _apply_filters(queryset, request)
+        paginated_queryset = CommonUtils.get_paginated_queryset(
+            queryset, request,
+            search_fields=SEARCH_FIELDS,
+            sort_fields=SORT_FIELDS,
+        )
+        serializer = career_lab_serializers.PublicPreviousHiringSerializer(paginated_queryset.get("queryset"), many=True)
+        return CustomResponse(
+            response={
+                "data": serializer.data,
+                "pagination": paginated_queryset.get("pagination"),
+            }
+        ).get_success_response()

--- a/api/dashboard/career_lab/urls.py
+++ b/api/dashboard/career_lab/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import career_lab_views
+
+urlpatterns = [
+    path("hiring/", career_lab_views.HiringAPI.as_view()),
+    path("hiring/csv/", career_lab_views.HiringCSVAPI.as_view()),
+    path("hiring/<str:hiring_id>/", career_lab_views.HiringDetailAPI.as_view()),
+]

--- a/api/dashboard/community_partner/serializers.py
+++ b/api/dashboard/community_partner/serializers.py
@@ -1,0 +1,81 @@
+"""
+Serializers for the Community Partner module.
+
+Read serializer  — returned in GET responses; embeds linked IGs.
+Write serializer — used for POST (create) and PATCH (partial update); validates
+                    the `interest_groups` id list against real InterestGroup rows.
+"""
+from rest_framework import serializers
+
+from db.community_partner import CommunityPartner, IgCommunityPartnerLink
+from db.task import InterestGroup
+
+
+class CommunityPartnerReadSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for Community Partners.
+
+    `logo_key` is returned as-is (a plain string) rather than resolved to a
+    URL — there is no upload/storage backing it yet (S3 is not functional).
+    """
+    interest_groups = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CommunityPartner
+        fields = [
+            'id',
+            'name',
+            'logo_key',
+            'description',
+            'linkedin',
+            'github',
+            'website',
+            'instagram',
+            'interest_groups',
+            'created_at',
+            'updated_at',
+        ]
+
+    def get_interest_groups(self, obj):
+        links = IgCommunityPartnerLink.objects.filter(
+            community_partner=obj
+        ).select_related('interest_group')
+        return [
+            {
+                'id': link.interest_group.id,
+                'name': link.interest_group.name,
+                'code': link.interest_group.code,
+            }
+            for link in links
+        ]
+
+
+class CommunityPartnerWriteSerializer(serializers.Serializer):
+    """
+    Write serializer for Community Partners (POST / PATCH).
+    """
+    name            = serializers.CharField(max_length=150)
+    logo_key        = serializers.CharField(max_length=255, required=False, allow_blank=True, allow_null=True)
+    description     = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    linkedin        = serializers.CharField(max_length=255, required=False, allow_blank=True, allow_null=True)
+    github          = serializers.CharField(max_length=255, required=False, allow_blank=True, allow_null=True)
+    website         = serializers.CharField(max_length=255, required=False, allow_blank=True, allow_null=True)
+    instagram       = serializers.CharField(max_length=255, required=False, allow_blank=True, allow_null=True)
+    interest_groups = serializers.ListField(
+        child=serializers.CharField(), required=False, allow_null=True
+    )
+
+    def validate_interest_groups(self, value):
+        """`value` is a list of interest_group ids. Every id must resolve to
+        an existing InterestGroup."""
+        if not value:
+            return value
+        found_ids = set(
+            InterestGroup.objects.filter(id__in=value).values_list('id', flat=True)
+        )
+        unknown_ids = [ig_id for ig_id in value if ig_id not in found_ids]
+        if unknown_ids:
+            raise serializers.ValidationError(
+                f"Unknown interest group id(s): {', '.join(unknown_ids)}."
+            )
+        return value

--- a/api/dashboard/community_partner/urls.py
+++ b/api/dashboard/community_partner/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('', views.CommunityPartnerListCreateAPI.as_view()),
+    path('<str:partner_id>/', views.CommunityPartnerDetailAPI.as_view()),
+]

--- a/api/dashboard/community_partner/views.py
+++ b/api/dashboard/community_partner/views.py
@@ -1,0 +1,185 @@
+"""
+Community Partner API views.
+
+Exposes CRUD endpoints for CommunityPartner, with IG links managed via a
+plain `interest_groups` id list embedded in the create/update payload
+(mirroring api/dashboard/media_content's `_sync_ig_links` approach) rather
+than a separate link/unlink endpoint.
+
+Read (GET) endpoints are publicly accessible.
+Write (POST / PATCH / DELETE) endpoints require ADMIN / ASSOCIATE / IG_LEAD.
+"""
+import uuid
+
+from rest_framework.views import APIView
+
+from db.community_partner import CommunityPartner, IgCommunityPartnerLink
+from utils.permission import CustomizePermission, JWTUtils, RoleRequired
+from utils.response import CustomResponse
+from utils.types import RoleType
+from utils.utils import CommonUtils
+
+from .serializers import CommunityPartnerReadSerializer, CommunityPartnerWriteSerializer
+
+from drf_spectacular.utils import extend_schema
+
+
+class PublicGetMixin:
+    """Mixin to bypass JWT authentication for GET requests."""
+    def get_authenticators(self):
+        if getattr(self, 'request', None) and self.request.method == 'GET':
+            return []
+        return super().get_authenticators()
+
+
+def _sync_ig_links(record, ig_ids, user_id):
+    """Replace all IgCommunityPartnerLink rows for `record` with one per id
+    in `ig_ids`."""
+    record.ig_links.all().delete()
+    ig_ids = ig_ids or []
+    IgCommunityPartnerLink.objects.bulk_create([
+        IgCommunityPartnerLink(
+            id=str(uuid.uuid4()),
+            community_partner=record,
+            interest_group_id=ig_id,
+            created_by_id=user_id,
+        )
+        for ig_id in ig_ids
+    ])
+
+
+class CommunityPartnerListCreateAPI(PublicGetMixin, APIView):
+    """
+    GET  /community-partner/  — Public paginated list of community partners.
+                                 Optional `?ig_id=<id>` filters to partners
+                                 linked to that Interest Group.
+    POST /community-partner/  — Create a community partner (Admin/Associate/IG Lead).
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Community Partner'])
+    def get(self, request):
+        qs = CommunityPartner.objects.all().order_by('name')
+
+        ig_id = request.query_params.get('ig_id')
+        if ig_id:
+            partner_ids = IgCommunityPartnerLink.objects.filter(
+                interest_group_id=ig_id
+            ).values_list('community_partner_id', flat=True)
+            qs = qs.filter(id__in=partner_ids)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            qs, request,
+            search_fields=['name'],
+            sort_fields={
+                'name': 'name',
+                'created_at': 'created_at',
+            },
+        )
+
+        serializer = CommunityPartnerReadSerializer(paginated['queryset'], many=True)
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+    @extend_schema(tags=['Community Partner'])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
+    def post(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        serializer = CommunityPartnerWriteSerializer(data=request.data)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message='Invalid data.',
+                message=serializer.errors,
+            ).get_failure_response()
+
+        data = serializer.validated_data
+        ig_ids = data.pop('interest_groups', None)
+        record = CommunityPartner.objects.create(
+            id=str(uuid.uuid4()),
+            created_by_id=user_id,
+            updated_by_id=user_id,
+            **data,
+        )
+
+        _sync_ig_links(record, ig_ids, user_id)
+
+        return CustomResponse(
+            general_message='Community partner created successfully.',
+            response=CommunityPartnerReadSerializer(record).data,
+        ).get_success_response()
+
+
+class CommunityPartnerDetailAPI(PublicGetMixin, APIView):
+    """
+    GET    /community-partner/<partner_id>/  — Public partner detail.
+    PATCH  /community-partner/<partner_id>/  — Partial update (Admin/Associate/IG Lead).
+    DELETE /community-partner/<partner_id>/  — Delete (Admin/Associate/IG Lead).
+    """
+    authentication_classes = [CustomizePermission]
+
+    def _get_record(self, partner_id):
+        return CommunityPartner.objects.filter(id=partner_id).first()
+
+    @extend_schema(tags=['Community Partner'])
+    def get(self, request, partner_id):
+        record = self._get_record(partner_id)
+        if not record:
+            return CustomResponse(
+                general_message='Community partner not found.'
+            ).get_failure_response()
+
+        return CustomResponse(
+            general_message='Community partner retrieved.',
+            response=CommunityPartnerReadSerializer(record).data,
+        ).get_success_response()
+
+    @extend_schema(tags=['Community Partner'])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
+    def patch(self, request, partner_id):
+        record = self._get_record(partner_id)
+        if not record:
+            return CustomResponse(
+                general_message='Community partner not found.'
+            ).get_failure_response()
+
+        serializer = CommunityPartnerWriteSerializer(data=request.data, partial=True)
+        if not serializer.is_valid():
+            return CustomResponse(
+                general_message='Invalid data.',
+                message=serializer.errors,
+            ).get_failure_response()
+
+        user_id = JWTUtils.fetch_user_id(request)
+        data = serializer.validated_data
+
+        if 'interest_groups' in data:
+            ig_ids = data.pop('interest_groups')
+            _sync_ig_links(record, ig_ids, user_id)
+
+        for attr, value in data.items():
+            setattr(record, attr, value)
+        record.updated_by_id = user_id
+        record.save()
+
+        return CustomResponse(
+            general_message='Community partner updated.',
+            response=CommunityPartnerReadSerializer(record).data,
+        ).get_success_response()
+
+    @extend_schema(tags=['Community Partner'])
+    @RoleRequired([RoleType.ADMIN.value, RoleType.ASSOCIATE.value, RoleType.IG_LEAD.value])
+    def delete(self, request, partner_id):
+        record = self._get_record(partner_id)
+        if not record:
+            return CustomResponse(
+                general_message='Community partner not found.'
+            ).get_failure_response()
+
+        record.delete()
+
+        return CustomResponse(
+            general_message='Community partner deleted.'
+        ).get_success_response()

--- a/api/dashboard/events/public_views.py
+++ b/api/dashboard/events/public_views.py
@@ -182,6 +182,92 @@ class EventListAPI(APIView):
         )
 
 
+class PublicEventListAPI(APIView):
+    """
+    GET /api/v1/public/events/
+
+    Fully public event listing: no authentication and no campus/IG scope
+    gating (every viewer sees the same set). Only lifecycle-public events
+    (published, ongoing, completed) are returned; draft/pending/cancelled/
+    rejected events are never exposed here.
+    """
+    permission_classes = []
+
+    @extend_schema(
+        tags=['Public - Events'],
+        description="Fully public, unauthenticated list of events with status and date filters.",
+        responses={200: EventListItemSerializer},
+    )
+    def get(self, request):
+        params = request.query_params
+        now = timezone.now()
+
+        events = get_live_events().select_related(
+            'category', 'organiser_ig', 'organiser_org'
+        ).filter(
+            status__in=[Event.Status.PUBLISHED, Event.Status.ONGOING, Event.Status.COMPLETED]
+        )
+
+        # ── status filter — repeated params (?status=a&status=b) and/or
+        # comma-separated (?status=a,b) are both accepted and OR'd together.
+        # Computed from start/end datetime rather than the lifecycle `status`
+        # field, since a published event may not have started yet.
+        raw_statuses = params.getlist('status')
+        statuses = {
+            s.strip().lower()
+            for raw in raw_statuses
+            for s in raw.split(',')
+            if s.strip()
+        }
+        if statuses:
+            status_q = Q()
+            if 'upcoming' in statuses:
+                status_q |= Q(start_datetime__gt=now)
+            if 'ongoing' in statuses:
+                status_q |= Q(start_datetime__lte=now, end_datetime__gte=now)
+            if 'completed' in statuses:
+                status_q |= Q(end_datetime__lt=now)
+            if status_q:
+                events = events.filter(status_q)
+
+        # ── date range filter ────────────────────────────────────────────
+        if start_date := params.get('start_date'):
+            events = events.filter(start_datetime__date__gte=start_date)
+        if end_date := params.get('end_date'):
+            events = events.filter(end_datetime__date__lte=end_date)
+
+        # ── other filters ────────────────────────────────────────────────
+        if event_type := params.get('event_type'):
+            events = events.filter(event_type=event_type)
+        if scope := params.get('scope'):
+            events = events.filter(scope=scope)
+        if ig_id := params.get('ig_id'):
+            events = events.filter(scope_ig_id=ig_id)
+        if campus_id := params.get('campus_id'):
+            events = events.filter(scope_org_id=campus_id)
+        if cluster := params.get('cluster'):
+            events = events.filter(organiser_ig__category=cluster)
+        if is_featured := params.get('is_featured'):
+            events = events.filter(is_featured=is_featured.lower() == 'true')
+        if tags := params.get('tags'):
+            events = events.filter(tags__icontains=tags)
+
+        paginated = CommonUtils.get_paginated_queryset(
+            events, request,
+            search_fields=['title', 'description', 'venue_city'],
+            sort_fields=_PUBLIC_EVENT_SORT_FIELDS,
+        )
+
+        serializer = EventListItemSerializer(
+            paginated['queryset'], many=True,
+            context={'user_id': None, 'request': request},
+        )
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
+
+
 class EventFeaturedAPI(APIView):
     """
     GET /events/featured/  and  GET /events/is-featured/

--- a/api/dashboard/events/public_views.py
+++ b/api/dashboard/events/public_views.py
@@ -190,6 +190,8 @@ class PublicEventListAPI(APIView):
     gating (every viewer sees the same set). Only lifecycle-public events
     (published, ongoing, completed) are returned; draft/pending/cancelled/
     rejected events are never exposed here.
+
+    Unpaginated — returns the full matching set in one response.
     """
     permission_classes = []
 
@@ -252,20 +254,20 @@ class PublicEventListAPI(APIView):
         if tags := params.get('tags'):
             events = events.filter(tags__icontains=tags)
 
-        paginated = CommonUtils.get_paginated_queryset(
+        events = CommonUtils.get_paginated_queryset(
             events, request,
             search_fields=['title', 'description', 'venue_city'],
             sort_fields=_PUBLIC_EVENT_SORT_FIELDS,
+            is_pagination=False,
         )
 
         serializer = EventListItemSerializer(
-            paginated['queryset'], many=True,
+            events, many=True,
             context={'user_id': None, 'request': request},
         )
-        return CustomResponse().paginated_response(
-            data=serializer.data,
-            pagination=paginated['pagination'],
-        )
+        return CustomResponse(
+            response=serializer.data,
+        ).get_success_response()
 
 
 class EventFeaturedAPI(APIView):

--- a/api/dashboard/ig/dash_ig_serializer.py
+++ b/api/dashboard/ig/dash_ig_serializer.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 import json
+from datetime import date
 
 from db.task import InterestGroup
 from db.user import User, Socials
@@ -186,10 +187,13 @@ class InterestGroupSerializer(serializers.ModelSerializer):
         """
         Media content (e.g. Office Hours sessions) linked to this IG via
         ig_media_content_link, excluding soft-deleted media content.
+        Only upcoming and ongoing (today) content is included.
         """
+        today = date.today()
         links = obj.media_content_links.filter(
-            media_content__deleted_at__isnull=True
-        ).select_related("media_content").order_by("-media_content__date")
+            media_content__deleted_at__isnull=True,
+            media_content__date__gte=today,
+        ).select_related("media_content").order_by("media_content__date")
 
         return [
             {
@@ -198,6 +202,8 @@ class InterestGroupSerializer(serializers.ModelSerializer):
                 "content_type": link.media_content.content_type,
                 "title": link.media_content.title,
                 "date": link.media_content.date,
+                "link": link.media_content.link,
+                "status": "ongoing" if link.media_content.date == today else "upcoming",
             }
             for link in links
         ]

--- a/api/dashboard/ig/dash_ig_serializer.py
+++ b/api/dashboard/ig/dash_ig_serializer.py
@@ -150,6 +150,7 @@ class InterestGroupSerializer(serializers.ModelSerializer):
         choices=["active", "inactive", "requested", "cancelled", "rejected"]
     )
     media_content_links = serializers.SerializerMethodField()
+    community_partners = serializers.SerializerMethodField()
 
     class Meta:
         model = InterestGroup
@@ -174,6 +175,7 @@ class InterestGroupSerializer(serializers.ModelSerializer):
             "status",
             "members",
             "media_content_links",
+            "community_partners",
             "updated_by",
             "updated_at",
             "created_by",
@@ -204,6 +206,25 @@ class InterestGroupSerializer(serializers.ModelSerializer):
                 "date": link.media_content.date,
                 "link": link.media_content.link,
                 "status": "ongoing" if link.media_content.date == today else "upcoming",
+            }
+            for link in links
+        ]
+
+    def get_community_partners(self, obj):
+        """
+        Community partners linked to this IG via ig_community_partner_link.
+        """
+        links = obj.community_partner_links.select_related("community_partner")
+        return [
+            {
+                "id": link.community_partner.id,
+                "name": link.community_partner.name,
+                "logo_key": link.community_partner.logo_key,
+                "description": link.community_partner.description,
+                "linkedin": link.community_partner.linkedin,
+                "github": link.community_partner.github,
+                "website": link.community_partner.website,
+                "instagram": link.community_partner.instagram,
             }
             for link in links
         ]

--- a/api/dashboard/ig/dash_ig_serializer.py
+++ b/api/dashboard/ig/dash_ig_serializer.py
@@ -148,6 +148,7 @@ class InterestGroupSerializer(serializers.ModelSerializer):
     status = serializers.ChoiceField(
         choices=["active", "inactive", "requested", "cancelled", "rejected"]
     )
+    media_content_links = serializers.SerializerMethodField()
 
     class Meta:
         model = InterestGroup
@@ -171,6 +172,7 @@ class InterestGroupSerializer(serializers.ModelSerializer):
             "category",
             "status",
             "members",
+            "media_content_links",
             "updated_by",
             "updated_at",
             "created_by",
@@ -179,6 +181,26 @@ class InterestGroupSerializer(serializers.ModelSerializer):
 
     def get_members(self, obj):
         return obj.user_ig_link_ig.all().count()
+
+    def get_media_content_links(self, obj):
+        """
+        Media content (e.g. Office Hours sessions) linked to this IG via
+        ig_media_content_link, excluding soft-deleted media content.
+        """
+        links = obj.media_content_links.filter(
+            media_content__deleted_at__isnull=True
+        ).select_related("media_content").order_by("-media_content__date")
+
+        return [
+            {
+                "id": link.id,
+                "media_content_id": link.media_content_id,
+                "content_type": link.media_content.content_type,
+                "title": link.media_content.title,
+                "date": link.media_content.date,
+            }
+            for link in links
+        ]
 
     def to_representation(self, instance):
         """Convert JSON-serialized text fields back to Python objects for API output.

--- a/api/dashboard/ig/dash_ig_serializer.py
+++ b/api/dashboard/ig/dash_ig_serializer.py
@@ -146,7 +146,7 @@ class InterestGroupSerializer(serializers.ModelSerializer):
         choices=["maker", "coder", "creative", "manager", "others"]
     )
     status = serializers.ChoiceField(
-        choices=["active", "requested", "cancelled", "rejected"]
+        choices=["active", "inactive", "requested", "cancelled", "rejected"]
     )
 
     class Meta:

--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -8,7 +8,7 @@ from db.user import User, Role
 from utils.permission import CustomizePermission
 from utils.permission import JWTUtils, role_required
 from utils.response import CustomResponse
-from utils.types import RoleType, WebHookActions, WebHookCategory
+from utils.types import RoleType, WebHookActions, WebHookCategory, InterestGroupStatus
 from utils.utils import CommonUtils, DiscordWebhooks
 from .dash_ig_serializer import (
     InterestGroupSerializer,
@@ -486,6 +486,54 @@ class InterestGroupAPI(APIView):
         return CustomResponse(
             general_message="ig deleted successfully"
         ).get_success_response()
+
+
+class InterestGroupActivateAPIView(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value, RoleType.IG_LEAD.value])
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="Activate an Interest Group.",
+        responses={200: InterestGroupSerializer},
+    )
+    def post(self, request, pk):
+        ig = InterestGroup.objects.filter(id=pk).first()
+        if not ig:
+            return CustomResponse(general_message="Interest Group not found").get_failure_response()
+
+        if ig.status == InterestGroupStatus.ACTIVE.value:
+            return CustomResponse(general_message="Interest Group is already active").get_failure_response()
+
+        ig.status = InterestGroupStatus.ACTIVE.value
+        ig.updated_by_id = JWTUtils.fetch_user_id(request)
+        ig.save()
+
+        return CustomResponse(general_message=f"{ig.name} activated").get_success_response()
+
+
+class InterestGroupDeactivateAPIView(APIView):
+    authentication_classes = [CustomizePermission]
+
+    @role_required([RoleType.ADMIN.value, RoleType.IG_LEAD.value])
+    @extend_schema(
+        tags=['Dashboard - Ig'],
+        description="Deactivate an Interest Group.",
+        responses={200: InterestGroupSerializer},
+    )
+    def post(self, request, pk):
+        ig = InterestGroup.objects.filter(id=pk).first()
+        if not ig:
+            return CustomResponse(general_message="Interest Group not found").get_failure_response()
+
+        if ig.status == InterestGroupStatus.INACTIVE.value:
+            return CustomResponse(general_message="Interest Group is already inactive").get_failure_response()
+
+        ig.status = InterestGroupStatus.INACTIVE.value
+        ig.updated_by_id = JWTUtils.fetch_user_id(request)
+        ig.save()
+
+        return CustomResponse(general_message=f"{ig.name} deactivated").get_success_response()
 
 
 class InterestGroupCSV(APIView):

--- a/api/dashboard/ig/urls.py
+++ b/api/dashboard/ig/urls.py
@@ -14,6 +14,8 @@ urlpatterns = [
     path('<str:pk>/cover-image/', dash_ig_view.InterestGroupImageAPI.as_view(), {'image_type': 'cover'}),
     path('<str:pk>/icon-image/', dash_ig_view.InterestGroupImageAPI.as_view(), {'image_type': 'icon'}),
     path('<str:pk>/', dash_ig_view.InterestGroupAPI.as_view()),  # for edit and delete
+    path('<str:pk>/activate/', dash_ig_view.InterestGroupActivateAPIView.as_view()),
+    path('<str:pk>/deactivate/', dash_ig_view.InterestGroupDeactivateAPIView.as_view()),
     path('get/<str:pk>/', dash_ig_view.InterestGroupGetAPI.as_view()),  # for edit and delete
     path('<str:pk>/join/', dash_ig_view.InterestGroupMembershipAPI.as_view()),
     path('<str:pk>/leave/', dash_ig_view.InterestGroupMembershipAPI.as_view()),

--- a/api/dashboard/learningcircle/learningcircle_serializer.py
+++ b/api/dashboard/learningcircle/learningcircle_serializer.py
@@ -265,11 +265,12 @@ class LearningCircleListMinSerializer(serializers.ModelSerializer):
     total_members = serializers.IntegerField(read_only=True)
     is_joined = serializers.SerializerMethodField()
     is_creator = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
     # attendees = serializers.SerializerMethodField()
     class Meta:
         model = LearningCircle
         # The 'attendees' field is removed as 'total_members' is used instead.
-        fields = ["id", "ig", "title", "org", "total_members", "is_joined", "is_creator"]
+        fields = ["id", "ig", "title", "org", "total_members", "is_joined", "is_creator", "status"]
 
     def get_is_joined(self, obj):
         user_id = self.context.get("user_id")
@@ -289,6 +290,18 @@ class LearningCircleListMinSerializer(serializers.ModelSerializer):
         if not user_id:
             return False
         return obj.created_by_id == user_id
+
+    def get_status(self, obj):
+        user_id = self.context.get("user_id")
+        if not user_id:
+            return "not_joined"
+        joined_ids = self.context.get("joined_circle_ids")
+        if joined_ids is not None and obj.id in joined_ids:
+            return "joined"
+        pending_ids = self.context.get("pending_circle_ids")
+        if pending_ids is not None and obj.id in pending_ids:
+            return "pending"
+        return "not_joined"
 
 
 class CircleMeetingLogCreateEditSerializer(serializers.ModelSerializer):

--- a/api/dashboard/learningcircle/learningcircle_serializer.py
+++ b/api/dashboard/learningcircle/learningcircle_serializer.py
@@ -692,6 +692,7 @@ class CircleMeetupMinSerializer(serializers.ModelSerializer):
     is_ended = serializers.SerializerMethodField()
     is_joined = serializers.SerializerMethodField()
     is_rsvp = serializers.SerializerMethodField()
+    can_remove_rsvp = serializers.SerializerMethodField()
     attendees_count = serializers.SerializerMethodField()
     created_by = serializers.CharField(source="created_by.full_name", read_only=True)
     created_by_id = serializers.CharField(source="created_by.id", read_only=True)
@@ -720,6 +721,22 @@ class CircleMeetupMinSerializer(serializers.ModelSerializer):
             ).exists()
         return False
 
+    def get_can_remove_rsvp(self, obj):
+        user_id = self.context.get("user_id")
+        if not user_id:
+            return False
+        attendee = obj.circle_meeting_attendance_meet_id.filter(
+            user_id=user_id
+        ).first()
+        if not attendee or attendee.is_joined:
+            return False
+        aware_time = _aware_meet_time(obj.meet_time)
+        if aware_time is None:
+            return False
+        now = DateTimeUtils.get_current_utc_time()
+        cutoff_time = aware_time - timedelta(minutes=30)
+        return now < cutoff_time
+
     def get_attendees_count(self, obj):
         return obj.circle_meeting_attendance_meet_id.count()
 
@@ -738,6 +755,7 @@ class CircleMeetupMinSerializer(serializers.ModelSerializer):
             "recurrence",
             "meet_place",
             "is_rsvp",
+            "can_remove_rsvp",
             "circle_id",
             "coord_x",
             "coord_y",

--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -77,6 +77,26 @@ class LearningCircleView(APIView):
         if ig_id:
             learning_circles = learning_circles.filter(ig_id=ig_id)
 
+        status = request.query_params.get("status")
+        if status:
+            if status == "joined":
+                joined_ids = UserCircleLink.objects.filter(
+                    user_id=user_id, accepted=True
+                ).values_list("circle_id", flat=True)
+                learning_circles = learning_circles.filter(id__in=joined_ids)
+            elif status == "pending":
+                pending_ids = UserCircleLink.objects.filter(
+                    user_id=user_id, accepted__isnull=True
+                ).values_list("circle_id", flat=True)
+                learning_circles = learning_circles.filter(id__in=pending_ids)
+            elif status == "not_joined":
+                member_ids = UserCircleLink.objects.filter(
+                    user_id=user_id,
+                ).filter(
+                    Q(accepted=True) | Q(accepted__isnull=True)
+                ).values_list("circle_id", flat=True)
+                learning_circles = learning_circles.exclude(id__in=member_ids)
+
         paginated_queryset = CommonUtils.get_paginated_queryset(
             learning_circles,
             request,
@@ -91,12 +111,20 @@ class LearningCircleView(APIView):
                 circle_id__in=page_circle_ids,
             ).values_list("circle_id", flat=True)
         )
+        pending_circle_ids = set(
+            UserCircleLink.objects.filter(
+                user_id=user_id,
+                accepted__isnull=True,
+                circle_id__in=page_circle_ids,
+            ).values_list("circle_id", flat=True)
+        )
         serializer = LearningCircleListMinSerializer(
             page,
             many=True,
             context={
                 "user_id": user_id,
                 "joined_circle_ids": joined_circle_ids,
+                "pending_circle_ids": pending_circle_ids,
             },
         )
         return CustomResponse().paginated_response(

--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -393,6 +393,42 @@ class LearningCircleRSVPAPI(APIView):
             general_message="You have successfully RSVP'd for the Circle Meeting"
         ).get_success_response()
 
+    @extend_schema(
+        tags=['Dashboard - Learningcircle'],
+        description="Remove Learning Circle RSVP. Allowed until 30 minutes before the meeting starts.",
+        responses={200: OpenApiResponse(description="RSVP removed successfully. No response body.")},
+    )
+    def delete(self, request, meet_id: str):
+        user_id = JWTUtils.fetch_user_id(request)
+        circle_meeting, error = _get_meeting_or_response(meet_id)
+        if error:
+            return error
+        if not _is_member_or_creator(circle_meeting.circle_id, user_id):
+            return CustomResponse(
+                general_message="Only circle members can modify RSVP for this meeting"
+            ).get_failure_response()
+        attendee = CircleMeetingAttendees.objects.filter(
+            meet_id=circle_meeting, user_id_id=user_id
+        ).first()
+        if not attendee:
+            return CustomResponse(
+                general_message="You have not RSVP'd for this meeting"
+            ).get_failure_response()
+        if attendee.is_joined:
+            return CustomResponse(
+                general_message="Cannot remove RSVP after joining the meeting"
+            ).get_failure_response()
+        now = DateTimeUtils.get_current_utc_time()
+        cutoff_time = circle_meeting.meet_time - timedelta(minutes=30)
+        if now >= cutoff_time:
+            return CustomResponse(
+                general_message="Cannot remove RSVP within 30 minutes of the meeting start time"
+            ).get_failure_response()
+        attendee.delete()
+        return CustomResponse(
+            general_message="Your RSVP has been successfully removed"
+        ).get_success_response()
+
 
 class LearningCircleJoinAPI(APIView):
     permission_classes = [CustomizePermission]

--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -1267,11 +1267,11 @@ class CircleJoinAPI(APIView):
 
         try:
             link = UserCircleLink.objects.get(
-                id=link_id, circle=circle, is_invited=False, accepted__isnull=True
+                id=link_id, circle=circle, accepted__isnull=True
             )
         except UserCircleLink.DoesNotExist:
             return CustomResponse(
-                general_message="Pending join request not found"
+                general_message="Pending request not found"
             ).get_failure_response()
 
         action = request.data.get("action")

--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -843,7 +843,6 @@ class LearningCircleReportExportAPI(APIView):
             [
                 "MuID",
                 "Full Name",
-                "Email",
                 "Report Submitted",
                 "LC Approved",
                 "Report",
@@ -856,7 +855,6 @@ class LearningCircleReportExportAPI(APIView):
                 [
                     clean(user.muid),
                     clean(user.full_name),
-                    clean(user.email),
                     "Yes" if attendee.is_report_submitted else "No",
                     "Yes" if attendee.is_lc_approved else "No",
                     clean(attendee.report_text),

--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -1022,8 +1022,12 @@ class LearningCircleMemberDetailsView(APIView):
             # Sort by karma (highest first)
             member_details = sorted(member_details, key=lambda x: x['ig_karma'], reverse=True)
 
-            # Build owner details from the circle's created_by FK
-            owner = circle.created_by
+            # Build owner details from the current leader, falling back to circle creator
+            leader_id = next(iter(leaders), None)
+            if leader_id and leader_id in users:
+                owner = users[leader_id]
+            else:
+                owner = circle.created_by
             owner_details = {
                 'id': owner.id,
                 'full_name': owner.full_name,

--- a/api/dashboard/media_content/serializers.py
+++ b/api/dashboard/media_content/serializers.py
@@ -11,7 +11,8 @@ from datetime import date
 from rest_framework import serializers
 
 from api.dashboard.media_content.image_utils import resolve_image_url
-from db.events import MediaContent
+from db.events import MediaContent, IgMediaContentLink
+from db.task import InterestGroup
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -40,6 +41,7 @@ class OfficeHoursReadSerializer(serializers.ModelSerializer):
     """
     status = serializers.SerializerMethodField()
     poster_thumbnail = serializers.SerializerMethodField()
+    interest_groups = serializers.SerializerMethodField()
 
     class Meta:
         model = MediaContent
@@ -64,6 +66,16 @@ class OfficeHoursReadSerializer(serializers.ModelSerializer):
 
     def get_poster_thumbnail(self, obj):
         return resolve_image_url(obj.poster_thumbnail, self.context.get('request'))
+
+    def get_interest_groups(self, obj):
+        link_ids = obj.interest_groups or []
+        if not link_ids:
+            return []
+        links = IgMediaContentLink.objects.filter(
+            id__in=link_ids
+        ).select_related('interest_group')
+        names_by_id = {link.id: link.interest_group.name for link in links}
+        return [names_by_id[link_id] for link_id in link_ids if link_id in names_by_id]
 
 
 class GrabYourSuperpowersReadSerializer(serializers.ModelSerializer):
@@ -188,6 +200,21 @@ class OfficeHoursWriteSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "Invalid date format. Expected DD/MM/YYYY (e.g. 27/06/2025)."
             )
+
+    def validate_interest_groups(self, value):
+        """`value` is a list of interest_group ids. Every id must resolve to
+        an existing InterestGroup."""
+        if not value:
+            return value
+        found_ids = set(
+            InterestGroup.objects.filter(id__in=value).values_list('id', flat=True)
+        )
+        unknown_ids = [ig_id for ig_id in value if ig_id not in found_ids]
+        if unknown_ids:
+            raise serializers.ValidationError(
+                f"Unknown interest group id(s): {', '.join(unknown_ids)}."
+            )
+        return value
 
     def to_internal_value(self, data):
         value = super().to_internal_value(data)

--- a/api/dashboard/media_content/views.py
+++ b/api/dashboard/media_content/views.py
@@ -70,15 +70,28 @@ def _apply_common_filters(qs, request, *, has_zone: bool = False):
     """Apply shared query-param filters to a MediaContent queryset."""
     params = request.query_params
     from datetime import date
+    from django.db.models import Q
 
-    if status := params.get('status'):
-        status = status.lower()
-        if status == 'upcoming':
-            qs = qs.filter(date__gt=date.today())
-        elif status == 'ongoing':
-            qs = qs.filter(date=date.today())
-        elif status == 'completed':
-            qs = qs.filter(date__lt=date.today())
+    # Accepts repeated params (?status=a&status=b) and/or comma-separated
+    # values (?status=a,b) — both are normalized into one status list.
+    raw_statuses = params.getlist('status')
+    statuses = {
+        s.strip().lower()
+        for raw in raw_statuses
+        for s in raw.split(',')
+        if s.strip()
+    }
+
+    if statuses:
+        status_q = Q()
+        if 'upcoming' in statuses:
+            status_q |= Q(date__gt=date.today())
+        if 'ongoing' in statuses:
+            status_q |= Q(date=date.today())
+        if 'completed' in statuses:
+            status_q |= Q(date__lt=date.today())
+        if status_q:
+            qs = qs.filter(status_q)
 
     if has_zone:
         if zone := params.get('zone'):

--- a/api/dashboard/media_content/views.py
+++ b/api/dashboard/media_content/views.py
@@ -17,7 +17,8 @@ import uuid
 from django.utils import timezone
 from rest_framework.views import APIView
 
-from db.events import MediaContent
+from db.events import MediaContent, IgMediaContentLink
+from db.task import InterestGroup
 from utils.permission import CustomizePermission, JWTUtils, RoleRequired
 from utils.response import CustomResponse
 from utils.types import RoleType
@@ -86,6 +87,23 @@ def _apply_common_filters(qs, request, *, has_zone: bool = False):
     return qs
 
 
+def _sync_ig_links(record, ig_ids):
+    """Replace all IgMediaContentLink rows for `record` with one per id in
+    `ig_ids`, and return the new link ids (to store on record.interest_groups).
+    """
+    record.ig_links.all().delete()
+    ig_ids = ig_ids or []
+    links = IgMediaContentLink.objects.bulk_create([
+        IgMediaContentLink(
+            id=str(uuid.uuid4()),
+            media_content=record,
+            interest_group_id=ig_id,
+        )
+        for ig_id in ig_ids
+    ])
+    return [link.id for link in links]
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Office Hours
 # ─────────────────────────────────────────────────────────────────────────────
@@ -143,12 +161,17 @@ class OfficeHoursListCreateAPI(PublicGetMixin, APIView):
             ).get_failure_response()
 
         data = serializer.validated_data
+        ig_ids = data.pop('interest_groups', None)
         record = MediaContent.objects.create(
             id=str(uuid.uuid4()),
             created_by_id=user_id,
             updated_by_id=user_id,
             **data,
         )
+
+        link_ids = _sync_ig_links(record, ig_ids)
+        record.interest_groups = link_ids
+        record.save(update_fields=['interest_groups'])
 
         for field, (raw_url, subdir) in pending_urls.items():
             fetch_and_attach_poster.delay(record.id, raw_url, subdir, field)
@@ -216,6 +239,10 @@ class OfficeHoursDetailAPI(PublicGetMixin, APIView):
         user_id = JWTUtils.fetch_user_id(request)
         data = serializer.validated_data
         data.pop('content_type', None)  # never allow overriding the discriminator
+
+        if 'interest_groups' in data:
+            ig_ids = data.pop('interest_groups')
+            data['interest_groups'] = _sync_ig_links(record, ig_ids)
 
         old_poster = record.poster_thumbnail
         for attr, value in data.items():
@@ -709,11 +736,25 @@ class MediaContentBulkImportAPI(APIView):
                 if 'topic' in row_data and not row_data.get('title'):
                     row_data['title'] = row_data.pop('topic')
                 if 'interest_groups' in row_data:
-                    row_data['interest_groups'] = [
+                    # CSV supplies human-readable IG names; resolve to ids
+                    # (the write serializer expects interest_group ids).
+                    names = [
                         ig.strip()
                         for ig in str(row_data['interest_groups']).split(',')
                         if ig.strip()
                     ]
+                    ig_by_name = dict(
+                        InterestGroup.objects.filter(name__in=names).values_list('name', 'id')
+                    )
+                    unknown_names = [n for n in names if n not in ig_by_name]
+                    if unknown_names:
+                        failed_rows.append({
+                            "row": row_num,
+                            "title": row.get('title') or row.get('topic', ''),
+                            "reason": f"Unknown interest group name(s): {', '.join(unknown_names)}.",
+                        })
+                        continue
+                    row_data['interest_groups'] = [ig_by_name[n] for n in names]
                 serializer = OfficeHoursWriteSerializer(data=row_data)
 
             elif content_type == MediaContent.ContentType.SALT_MANGO_TREE:
@@ -745,12 +786,16 @@ class MediaContentBulkImportAPI(APIView):
 
             if serializer.is_valid():
                 data = serializer.validated_data
-                MediaContent.objects.create(
+                ig_ids = data.pop('interest_groups', None)
+                record = MediaContent.objects.create(
                     id=str(uuid.uuid4()),
                     created_by_id=user_id,
                     updated_by_id=user_id,
                     **data,
                 )
+                if content_type == MediaContent.ContentType.OFFICE_HOURS:
+                    record.interest_groups = _sync_ig_links(record, ig_ids)
+                    record.save(update_fields=['interest_groups'])
                 success_count += 1
             else:
                 failed_rows.append({

--- a/api/dashboard/organisation/organisation_views.py
+++ b/api/dashboard/organisation/organisation_views.py
@@ -2,7 +2,8 @@ import uuid
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 
-from django.db.models import F, Prefetch, Sum, Q
+from django.db.models import F, Prefetch, Sum, Q, OuterRef, Subquery, IntegerField
+from django.db.models.functions import Coalesce
 from django.http import FileResponse
 from openpyxl import load_workbook
 from rest_framework.views import APIView
@@ -174,6 +175,32 @@ class InstitutionAPI(APIView):
         else:
             organisations = Organization.objects.filter(org_type=org_type)
 
+        params = request.query_params
+        zone_id = params.get("zone_id")
+        state_id = params.get("state_id")
+        country_id = params.get("country_id")
+        affiliation_id = params.get("affiliation_id")
+
+        if zone_id:
+            organisations = organisations.filter(district__zone_id=zone_id)
+        if state_id:
+            organisations = organisations.filter(district__zone__state_id=state_id)
+        if country_id:
+            organisations = organisations.filter(
+                district__zone__state__country_id=country_id
+            )
+        if affiliation_id:
+            organisations = organisations.filter(affiliation_id=affiliation_id)
+
+        karma_subquery = (
+            UserOrganizationLink.objects.filter(
+                org_id=OuterRef("id"), verified=True
+            )
+            .values("org_id")
+            .annotate(total_karma=Sum("user__wallet_user__karma"))
+            .values("total_karma")
+        )
+
         org_queryset = (
             organisations
             .select_related("affiliation")
@@ -186,7 +213,12 @@ class InstitutionAPI(APIView):
                 )
             )
             .annotate(user_count=Count("user_organization_link_org", filter=Q(user_organization_link_org__verified=True)))
-            .order_by("-user_count")  # Sort by highest user_count
+            .annotate(
+                total_karma=Coalesce(
+                    Subquery(karma_subquery, output_field=IntegerField()), 0
+                )
+            )
+            .order_by("-total_karma")  # Sort by highest karma
         )
 
         paginated_queryset = CommonUtils.get_paginated_queryset(
@@ -209,6 +241,8 @@ class InstitutionAPI(APIView):
                 "zone": "district__zone__name",
                 "state": "district__zone__state__name",
                 "country": "district__zone__state__country__name",
+                "karma": "total_karma",
+                "user_count": "user_count",
             },
         )
 

--- a/api/dashboard/organisation/serializers.py
+++ b/api/dashboard/organisation/serializers.py
@@ -31,6 +31,7 @@ class InstitutionSerializer(serializers.ModelSerializer):
     state = serializers.ReadOnlyField(source="district.zone.state.name")
     country = serializers.ReadOnlyField(source="district.zone.state.country.name")
     user_count = serializers.SerializerMethodField()
+    total_karma = serializers.SerializerMethodField()
 
     class Meta:
         model = Organization
@@ -44,10 +45,14 @@ class InstitutionSerializer(serializers.ModelSerializer):
             "state",
             "country",
             "user_count",
+            "total_karma",
         ]
 
     def get_user_count(self, obj):
         return obj.user_organization_link_org.filter(verified=True).count()
+
+    def get_total_karma(self, obj):
+        return getattr(obj, "total_karma", 0) or 0
 
 
 # class InstitutionSerializer(serializers.ModelSerializer):

--- a/api/dashboard/urls.py
+++ b/api/dashboard/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path("skill/", include("api.dashboard.skill.urls")),
     path("task-report/", include("api.dashboard.task_report.urls")),
     path("media-content/", include("api.dashboard.media_content.urls")),
+    path("community-partner/", include("api.dashboard.community_partner.urls")),
 
     path("category/", include("api.dashboard.category.urls")),
     path("mentor/", include("api.dashboard.mentor.urls")),

--- a/api/dashboard/urls.py
+++ b/api/dashboard/urls.py
@@ -40,6 +40,6 @@ urlpatterns = [
     path("manage-interns/", include("api.dashboard.manage_interns.urls")),
     path("company/", include("api.dashboard.company.urls")),
     path("feature/", include("api.dashboard.feature.urls")),
-    # path("career-lab/", include("api.dashboard.career_lab.urls")),
+    path("career-lab/", include("api.dashboard.career_lab.urls")),
     # mentorship/ has been consolidated into mentor/ — do not re-add
 ]

--- a/api/url_shortener/serializers.py
+++ b/api/url_shortener/serializers.py
@@ -10,10 +10,22 @@ from utils.utils import DateTimeUtils
 
 
 class ShowShortenUrlsSerializer(ModelSerializer):
+    created_by = serializers.ReadOnlyField(source="created_by.full_name")
+    updated_by = serializers.ReadOnlyField(source="updated_by.full_name")
+
     class Meta:
         model = UrlShortener
 
-        fields = ["id", "title", "long_url", "short_url", "created_at"]
+        fields = [
+            "id",
+            "title",
+            "long_url",
+            "short_url",
+            "created_by",
+            "updated_by",
+            "created_at",
+            "updated_at",
+        ]
 
 
 class ShortenUrlsCreateUpdateSerializer(ModelSerializer):

--- a/api/url_shortener/url_shortener_view.py
+++ b/api/url_shortener/url_shortener_view.py
@@ -55,7 +55,9 @@ class UrlShortenerAPI(APIView):
         responses={200: ShowShortenUrlsSerializer},
     )
     def get(self, request):
-        url_shortener_objects = UrlShortener.objects.all().order_by('-created_at')
+        url_shortener_objects = UrlShortener.objects.select_related(
+            "created_by", "updated_by"
+        ).order_by('-created_at')
 
         paginated_queryset = CommonUtils.get_paginated_queryset(
             url_shortener_objects,
@@ -170,6 +172,9 @@ class UrlAnalyticsAPI(APIView):
                 'long_url': s.CharField(),
                 'short_url': s.CharField(),
                 'title': s.CharField(),
+                'created_by': s.CharField(),
+                'updated_by': s.CharField(),
+                'updated_at': s.CharField(),
             },
         )},
     )
@@ -204,6 +209,10 @@ class UrlAnalyticsAPI(APIView):
                 'long_url': url_shortener.long_url,
                 'short_url': url_shortener.short_url,
                 'title': url_shortener.title,
+                'created_by': getattr(url_shortener.created_by, 'full_name', None),
+                'updated_by': getattr(url_shortener.updated_by, 'full_name', None),
+                'updated_at': url_shortener.updated_at.strftime('%Y-%m-%d')
+                if getattr(url_shortener, 'updated_at', None) else None,
             }
             return CustomResponse(response=empty_result).get_success_response()
 
@@ -252,7 +261,11 @@ class UrlAnalyticsAPI(APIView):
             'time_based_data': time_based_data,
             'long_url': url_shortener.long_url,
             'short_url': url_shortener.short_url,
-            'title': url_shortener.title
+            'title': url_shortener.title,
+            'created_by': getattr(url_shortener.created_by, 'full_name', None),
+            'updated_by': getattr(url_shortener.updated_by, 'full_name', None),
+            'updated_at': url_shortener.updated_at.strftime('%Y-%m-%d')
+            if getattr(url_shortener, 'updated_at', None) else None,
         }
 
         return CustomResponse(response=result).get_success_response()

--- a/db/career_lab.py
+++ b/db/career_lab.py
@@ -1,0 +1,30 @@
+import uuid
+from django.db import models
+
+
+class Hiring(models.Model):
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    posted_date = models.DateField(null=True, blank=True)
+    role = models.CharField(max_length=255)
+    organization = models.CharField(max_length=255)
+    title = models.CharField(max_length=255, null=True, blank=True)
+    location = models.CharField(max_length=255, null=True, blank=True)
+    lastdate = models.DateField(db_index=True)
+    applylink = models.URLField(null=True, blank=True)
+    jdlink = models.URLField(null=True, blank=True)
+    duration = models.CharField(max_length=100, null=True, blank=True)
+    remuneration = models.CharField(max_length=255, null=True, blank=True)
+    vacancies = models.PositiveIntegerField(null=True, blank=True)
+    extracontent = models.TextField(null=True, blank=True)
+    created_by = models.ForeignKey(
+        'db.User', on_delete=models.SET_NULL, null=True, blank=True, related_name='hiring_created_by'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_by = models.ForeignKey(
+        'db.User', on_delete=models.SET_NULL, null=True, blank=True, related_name='hiring_updated_by'
+    )
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        managed = False
+        db_table = 'hiring'

--- a/db/community_partner.py
+++ b/db/community_partner.py
@@ -1,0 +1,58 @@
+import uuid
+
+from django.conf import settings
+from django.db import models
+
+from .task import InterestGroup
+from .user import User
+
+
+class CommunityPartner(models.Model):
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    name = models.CharField(max_length=150)
+    logo_key = models.CharField(max_length=255, blank=True, null=True)
+    description = models.TextField(blank=True, null=True)
+    linkedin = models.CharField(max_length=255, blank=True, null=True)
+    github = models.CharField(max_length=255, blank=True, null=True)
+    website = models.CharField(max_length=255, blank=True, null=True)
+    instagram = models.CharField(max_length=255, blank=True, null=True)
+    created_by = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column='created_by',
+        related_name='community_partner_created_by',
+    )
+    updated_by = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column='updated_by',
+        related_name='community_partner_updated_by',
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        managed = False
+        db_table = 'community_partner'
+
+
+class IgCommunityPartnerLink(models.Model):
+    """
+    Links a CommunityPartner to an InterestGroup. A partner can be linked
+    to multiple IGs; an IG can have multiple partners.
+    """
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    community_partner = models.ForeignKey(
+        CommunityPartner, on_delete=models.CASCADE,
+        db_column='community_partner_id', related_name='ig_links',
+    )
+    interest_group = models.ForeignKey(
+        InterestGroup, on_delete=models.CASCADE,
+        db_column='ig_id', related_name='community_partner_links',
+    )
+    created_by = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column='created_by',
+        related_name='ig_community_partner_link_created_by',
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        managed = False
+        db_table = 'ig_community_partner_link'
+        unique_together = [('community_partner', 'interest_group')]

--- a/db/events.py
+++ b/db/events.py
@@ -361,7 +361,7 @@ class MediaContent(models.Model):
     # ── Office Hours specific ─────────────────────────────────────────────────
     performer        = models.CharField(max_length=200, blank=True, null=True)
     designation      = models.CharField(max_length=200, blank=True, null=True)
-    interest_groups  = models.JSONField(blank=True, null=True)   # list of IG slugs
+    interest_groups  = models.JSONField(blank=True, null=True)   # list of ig_media_content_link ids for this record
     poster_thumbnail = models.CharField(max_length=512, blank=True, null=True)
 
     # ── SMT & Inspiration Station specific ────────────────────────────────────
@@ -391,3 +391,26 @@ class MediaContent(models.Model):
         indexes = [
             models.Index(fields=['content_type', 'date']),
         ]
+
+
+class IgMediaContentLink(models.Model):
+    """
+    Links a MediaContent record (e.g. an Office Hours session) to an
+    InterestGroup. MediaContent.interest_groups stores the ids of these
+    link rows rather than IG ids/codes directly.
+    """
+    id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    media_content = models.ForeignKey(
+        MediaContent, on_delete=models.CASCADE,
+        db_column='media_content_id', related_name='ig_links'
+    )
+    interest_group = models.ForeignKey(
+        InterestGroup, on_delete=models.CASCADE,
+        db_column='ig_id', related_name='media_content_links'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        managed = False
+        db_table = 'ig_media_content_link'
+        unique_together = [('media_content', 'interest_group')]

--- a/db/models.py
+++ b/db/models.py
@@ -14,6 +14,7 @@ When you add a new model module under ``db/``, add it to the import list below.
 from db import (  # noqa: F401
     achievement,
     campus,
+    career_lab,
     comic,
     comic_comment,
     company,

--- a/db/task.py
+++ b/db/task.py
@@ -49,6 +49,7 @@ class InterestGroup(models.Model):
         max_length=20,
         choices=[
             ('active', 'Active'),
+            ('inactive', 'Inactive'),
             ('requested', 'Requested'),
             ('cancelled', 'Cancelled'),
             ('rejected', 'Rejected'),

--- a/utils/types.py
+++ b/utils/types.py
@@ -106,6 +106,7 @@ class IntegrationType(Enum):
 
 class InterestGroupStatus(Enum):
     ACTIVE = "active"
+    INACTIVE = "inactive"
     REQUESTED = "requested"
     CANCELLED = "cancelled"
     REJECTED = "rejected"


### PR DESCRIPTION
## Summary

Cherry-picked fixes and features from `dev` across several modules:

### Career Lab (new)
- New `Hiring` model + CRUD API for job/internship postings, with CSV bulk import/export and public `ongoing`/`previous` listing endpoints.

### Community Partner (new)
- New `CommunityPartner` model + CRUD API, with public read access and IG linking.

### Public Events (new)
- New unauthenticated event listing endpoint with status and date-range filters.

### Interest Group
- New activate/deactivate endpoints and an `inactive` status.
- IG serializer now returns linked media content and linked community partners.

### Media Content
- Status filtering now accepts multiple comma-separated values.
- `interest_groups` field now resolves via link-table IDs instead of stored slugs.

### Campus
- Public campus details response gains `campus_lead`, `execom`, `top_10_campus_leaderboard` (renamed from `top_10_mulearn_leaderboard`), `active_ig_chapters`, `karma_by_cluster`.
- `active_members` redefinition (Discord presence → karma recency in last 30 days).

### Organisation
- Institution API supports location/affiliation filters and a `total_karma` annotation; default sort changed to karma.

### URL Shortener
- Adds `created_by`, `updated_by`, `updated_at` tracking to responses.

### Learning Circle
- Member-details "owner" now reflects the current lead, not just the original creator.
- New `?status=joined|pending|not_joined` filter and `status` field on the circle list API.
- Leads can revoke/reject invites they've sent via `PATCH /join/<circle_id>/`.
- Meeting report CSV export no longer includes the "Email" column.
- Users can remove their RSVP up to 30 minutes before a scheduled meeting.

## Test plan
- [ ] Career Lab: create/list/CSV-import hiring postings, verify public ongoing/previous endpoints
- [ ] Community Partner: create/list/update with and without linked IGs
- [ ] Public events listing with status/date filters
- [ ] IG activate/deactivate as Admin and as a per-IG lead
- [ ] Media content status filter with multiple values; verify IG links resolve correctly on new records
- [ ] Campus public details response includes new fields
- [ ] Institution API filters and sort order
- [ ] Learning circle status filter, invite revoke, RSVP removal, CSV export
