### PR TITLE
feat: add notification for learning circle.

### DIFF
--- a/api/dashboard/learningcircle/learningcircle_views.py
+++ b/api/dashboard/learningcircle/learningcircle_views.py
@@ -20,6 +20,9 @@ from db.user import UserDomains, User
 from django.conf import settings
 from api.notification.broadcast_utils import BroadcastUtils
 from api.notification.notifications_utils import NotificationUtils
+from api.notification.service import NotificationService
+from api.notification.types import NotificationType
+from api.notification.audience import Audience
 from utils.karma import add_karma, remove_karma
 from utils.utils import CommonUtils
 from utils.permission import CustomizePermission, JWTUtils
@@ -308,7 +311,19 @@ class LearningCircleMeetingView(APIView):
                 general_message="Circle Meeting creation failed",
                 response=serializer.errors,
             ).get_failure_response()
-        serializer.save()
+        with transaction.atomic():
+            serializer.save()
+            NotificationService.dispatch(
+                notif_type = NotificationType.LC_MEETING_SCHEDULED,
+                audience   = Audience.lc_members(circle_id),
+                context    = {
+                    "lc_name":   circle.title,
+                    "meet_time": serializer.instance.meet_time.strftime("%d %b %Y, %I:%M %p"),
+                },
+                entity_id  = str(circle_id),
+                occurrence = str(serializer.instance.id),
+                actor_id   = user_id,
+            )
         return CustomResponse(
             general_message="Circle Meeting created successfully"
         ).get_success_response()
@@ -1260,27 +1275,30 @@ class CircleJoinAPI(APIView):
                 general_message="You have a previous link to this circle that prevents joining. Contact the circle lead."
             ).get_failure_response()
 
-        UserCircleLink.objects.create(
-            id=str(uuid.uuid4()),
-            user_id=user_id,
-            circle=circle,
-            lead=False,
-            is_invited=False,
-            accepted=None,
-            accepted_at=None,
-        )
+        requester_name = User.objects.filter(id=user_id).values_list("full_name", flat=True).first() or ""
 
-        # Notify the circle lead about the new join request
-        lead_link = UserCircleLink.objects.filter(circle=circle, lead=True).select_related('user').first()
-        requester = User.objects.filter(id=user_id).first()
-        if lead_link and requester:
-            NotificationUtils.insert_notification(
-                user=lead_link.user,
-                title="Member Request",
-                description=f"{requester.full_name} has requested to join your learning circle '{circle.title}'",
-                button="View",
-                url=f"{settings.FR_DOMAIN_NAME}/dashboard/learningcircle/{circle_id}/",
-                created_by=requester,
+        # Pre-generate the link ID so we can use it as the occurrence discriminator
+        # in the dedupe_key. This ensures that if two different users each request to
+        # join the same LC, the lead gets a separate notification for each one.
+        link_id = str(uuid.uuid4())
+
+        with transaction.atomic():
+            UserCircleLink.objects.create(
+                id=link_id,
+                user_id=user_id,
+                circle=circle,
+                lead=False,
+                is_invited=False,
+                accepted=None,
+                accepted_at=None,
+            )
+            NotificationService.dispatch(
+                notif_type = NotificationType.LC_JOIN_REQUEST,
+                audience   = Audience.lc_lead(circle_id),
+                context    = {"lc_name": circle.title, "requester_name": requester_name},
+                entity_id  = str(circle_id),
+                occurrence = link_id,   # unique per request — prevents cross-user deduplication
+                actor_id   = user_id,
             )
 
         return CustomResponse(
@@ -1353,37 +1371,34 @@ class CircleJoinAPI(APIView):
                 general_message="Invalid action. Must be 'accept' or 'reject'"
             ).get_failure_response()
 
-        lead_user = User.objects.filter(id=user_id).first()
-        requester_user = link.user
-
         if action == "accept":
-            link.accepted = True
-            link.accepted_at = DateTimeUtils.get_current_utc_time()
-            link.save()
-            # Notify the requester that they have been accepted
-            NotificationUtils.insert_notification(
-                user=requester_user,
-                title="Request Approved",
-                description=f"Your request to join the learning circle '{circle.title}' has been approved.",
-                button="View",
-                url=f"{settings.FR_DOMAIN_NAME}/dashboard/learningcircle/{circle_id}/",
-                created_by=lead_user,
-            )
+            with transaction.atomic():
+                link.accepted = True
+                link.accepted_at = DateTimeUtils.get_current_utc_time()
+                link.save()
+                NotificationService.dispatch(
+                    notif_type = NotificationType.LC_JOIN_APPROVED,
+                    audience   = Audience.user(str(link.user_id)),
+                    context    = {"lc_name": circle.title},
+                    entity_id  = str(circle_id),
+                    occurrence = str(link.id),   # unique per join request instance
+                    actor_id   = user_id,
+                )
             return CustomResponse(
                 general_message="Join request accepted. User is now a member."
             ).get_success_response()
 
-        link.accepted = False
-        link.save()
-        # Notify the requester that they have been rejected
-        NotificationUtils.insert_notification(
-            user=requester_user,
-            title="Request Rejected",
-            description=f"Your request to join the learning circle '{circle.title}' has been rejected.",
-            button=None,
-            url=None,
-            created_by=lead_user,
-        )
+        with transaction.atomic():
+            link.accepted = False
+            link.save()
+            NotificationService.dispatch(
+                notif_type = NotificationType.LC_JOIN_REJECTED,
+                audience   = Audience.user(str(link.user_id)),
+                context    = {"lc_name": circle.title},
+                entity_id  = str(circle_id),
+                occurrence = str(link.id),   # unique per join request instance
+                actor_id   = user_id,
+            )
         return CustomResponse(
             general_message="Join request rejected."
         ).get_success_response()
@@ -1497,15 +1512,25 @@ class CircleInviteAPI(APIView):
                 general_message="An invitation is already pending for this user"
             ).get_failure_response()
 
-        UserCircleLink.objects.create(
-            id=str(uuid.uuid4()),
-            user_id=target_user_id,
-            circle=circle,
-            lead=invite_as_lead,
-            is_invited=True,
-            invited_by_id=user_id,
-            accepted=None,
-        )
+        link_id = str(uuid.uuid4())
+        with transaction.atomic():
+            UserCircleLink.objects.create(
+                id=link_id,
+                user_id=target_user_id,
+                circle=circle,
+                lead=invite_as_lead,
+                is_invited=True,
+                invited_by_id=user_id,
+                accepted=None,
+            )
+            NotificationService.dispatch(
+                notif_type = NotificationType.LC_INVITE,
+                audience   = Audience.user(str(target_user_id)),
+                context    = {"lc_name": circle.title},
+                entity_id  = str(circle_id),
+                occurrence = link_id,   # unique per invite — allows re-invite after decline
+                actor_id   = user_id,
+            )
         return CustomResponse(general_message="Invitation sent successfully").get_success_response()
 
 

--- a/api/notification/audience.py
+++ b/api/notification/audience.py
@@ -1,0 +1,136 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AudienceSpec — describes WHO should receive a notification
+#
+# Producers never pass raw user ID lists to dispatch().
+# They declare the audience semantically using the Audience factory:
+#
+#   Audience.user("some-user-uuid")          → one specific user
+#   Audience.users(["uuid1", "uuid2"])       → explicit list of users
+#   Audience.lc_members("lc-uuid")          → all accepted members of an LC
+#   Audience.lc_lead("lc-uuid")             → only the lead(s) of an LC
+#
+# AudienceResolver then resolves this into a concrete set of user_id strings.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class AudienceSpec:
+    type:    str                           # "USER", "USERS", "LC_MEMBERS", "LC_LEAD"
+    ids:     List[str] = field(default_factory=list)   # pre-resolved IDs (USER / USERS)
+    lc_id:  Optional[str] = None          # for LC_MEMBERS and LC_LEAD
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Audience — factory that creates AudienceSpec objects
+#
+# Producers call these static methods to declare their audience.
+# No DB queries happen here — resolution is deferred to AudienceResolver.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class Audience:
+
+    @staticmethod
+    def user(user_id: str) -> AudienceSpec:
+        """Single user. Most common — approvals, rejections, personal alerts."""
+        return AudienceSpec(type="USER", ids=[str(user_id)])
+
+    @staticmethod
+    def users(user_ids: List[str]) -> AudienceSpec:
+        """Explicit list of users. Used when the producer already has the IDs."""
+        return AudienceSpec(type="USERS", ids=[str(uid) for uid in user_ids])
+
+    @staticmethod
+    def lc_members(lc_id: str) -> AudienceSpec:
+        """
+        All accepted (approved) members of a Learning Circle.
+        Used for: LC_MEETING_SCHEDULED (all members except creator).
+        The actor_id passed to dispatch() removes the creator automatically.
+        """
+        return AudienceSpec(type="LC_MEMBERS", lc_id=str(lc_id))
+
+    @staticmethod
+    def lc_lead(lc_id: str) -> AudienceSpec:
+        """
+        The lead(s) of a Learning Circle.
+        Used for: LC_JOIN_REQUEST (notify the lead when someone requests to join).
+        """
+        return AudienceSpec(type="LC_LEAD", lc_id=str(lc_id))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AudienceResolver — resolves an AudienceSpec into a set of user_id strings
+#
+# This is where the DB queries happen.
+# dispatch() calls resolver.resolve(audience, actor_id) once per dispatch.
+#
+# actor_id is always excluded from the result — the person who triggered
+# the action never receives their own notification.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class AudienceResolver:
+
+    def resolve(self, spec: AudienceSpec, actor_id: Optional[str] = None) -> set:
+        """
+        Resolves an AudienceSpec into a concrete set of user_id strings.
+
+        Args:
+            spec:     The audience declaration from the producer.
+            actor_id: The user who triggered the action. Always excluded.
+
+        Returns:
+            A set of user_id strings. Empty set = no one to notify.
+        """
+        ids = self._fetch_ids(spec)
+
+        # Remove the actor — they never receive their own notification
+        if actor_id:
+            ids.discard(str(actor_id))
+
+        return ids
+
+    def _fetch_ids(self, spec: AudienceSpec) -> set:
+        """
+        Runs the appropriate DB query for each audience type.
+        Lazily imports models to avoid circular imports at module load time.
+        """
+
+        # ── USER / USERS ──────────────────────────────────────────────────────
+        # No DB query needed — IDs are already known by the producer.
+
+        if spec.type == "USER":
+            return set(spec.ids)
+
+        if spec.type == "USERS":
+            return set(spec.ids)
+
+        # ── LC_MEMBERS ────────────────────────────────────────────────────────
+        # All members of the LC whose join was accepted (accepted=True).
+        # Excludes pending/invited members who haven't been approved yet.
+
+        if spec.type == "LC_MEMBERS":
+            from db.learning_circle import UserCircleLink
+            return set(
+                str(uid) for uid in
+                UserCircleLink.objects
+                    .filter(circle_id=spec.lc_id, accepted=True)
+                    .values_list("user_id", flat=True)
+            )
+
+        # ── LC_LEAD ───────────────────────────────────────────────────────────
+        # Only the lead(s) of the LC (lead=True).
+        # An LC can have one lead. Returns a set in case of future multi-lead support.
+
+        if spec.type == "LC_LEAD":
+            from db.learning_circle import UserCircleLink
+            return set(
+                str(uid) for uid in
+                UserCircleLink.objects
+                    .filter(circle_id=spec.lc_id, lead=True, accepted=True)
+                    .values_list("user_id", flat=True)
+            )
+
+        # ── Unknown type ──────────────────────────────────────────────────────
+        return set()

--- a/api/notification/notification_view.py
+++ b/api/notification/notification_view.py
@@ -1,5 +1,9 @@
+from datetime import datetime, time
+
 from django.utils import timezone
+from django.utils.dateparse import parse_date, parse_datetime
 from rest_framework.views import APIView
+from rest_framework import status
 
 from db.notification import Notification, BroadcastNotification
 from db.events import EventConnection, EventInterest
@@ -10,11 +14,292 @@ from . import serializers
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers as s
 
+ALLOWED_SORT_FIELDS = {'created_at', '-created_at'}
+
+
+def _parse_range_date(raw, end_of_day=False):
+    """
+    Parses an ISO date or datetime query param into a timezone-aware datetime.
+    A date-only value ("2026-08-14") is expanded to the start/end of that day
+    so fromDate/toDate behave as an inclusive range. Returns None for missing
+    or unparseable input — an invalid filter is dropped rather than raising.
+    """
+    if not raw:
+        return None
+    dt = parse_datetime(raw)
+    if dt is None:
+        d = parse_date(raw)
+        if d is None:
+            return None
+        dt = datetime.combine(d, time.max if end_of_day else time.min)
+    if timezone.is_naive(dt):
+        dt = timezone.make_aware(dt, timezone.get_current_timezone())
+    return dt
+
+
+def _notification_not_found():
+    """
+    404, not the CustomResponse default of 400. Ownership-isolation is a hard
+    requirement here (PRD §7): a non-owned or missing notification id must
+    return 404, never 403/400, so its existence is never disclosed by status
+    code alone.
+    """
+    return CustomResponse(general_message='Notification not found').get_failure_response(
+        status_code=404, http_status_code=status.HTTP_404_NOT_FOUND
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# v2 USER-FACING VIEWS  (PRD §7)
+# All views below work against the new notification table schema.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class NotificationListView(APIView):
+    """
+    GET /api/v1/notification/
+
+    Returns the authenticated user's notification feed.
+    Supports optional query params:
+        isRead (or is_read)     = true | false
+        type                    = e.g. LC_JOIN_APPROVED — repeatable: ?type=A&type=B
+        category                = e.g. LC
+        fromDate (or from_date) = ISO date/datetime — inclusive lower bound on created_at
+        toDate (or to_date)     = ISO date/datetime — inclusive upper bound on created_at
+        sortBy (or sort_by)     = 'created_at' | '-created_at' (default '-created_at')
+        page                    = page number (default 1)
+        page_size               = results per page (default 20, max 100)
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Notification'], description="List notifications for the authenticated user.")
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        params  = request.query_params
+
+        qs = Notification.objects.filter(user_id=user_id, is_archived=False)
+
+        # Optional filters
+        is_read     = params.get('isRead', params.get('is_read'))
+        notif_types = params.getlist('type')
+        category    = params.get('category')
+        from_date   = _parse_range_date(params.get('fromDate', params.get('from_date')))
+        to_date     = _parse_range_date(params.get('toDate', params.get('to_date')), end_of_day=True)
+        sort_by     = params.get('sortBy', params.get('sort_by', '-created_at'))
+
+        if is_read is not None:
+            qs = qs.filter(is_read=(is_read.lower() == 'true'))
+        if notif_types:
+            qs = qs.filter(type__in=notif_types)
+        if category:
+            qs = qs.filter(category=category)
+        if from_date:
+            qs = qs.filter(created_at__gte=from_date)
+        if to_date:
+            qs = qs.filter(created_at__lte=to_date)
+
+        # Whitelisted — sort_by is user input and must never reach order_by() raw
+        qs = qs.order_by(sort_by if sort_by in ALLOWED_SORT_FIELDS else '-created_at')
+
+        # Simple pagination
+        try:
+            page      = max(1, int(params.get('page', 1)))
+            page_size = min(100, max(1, int(params.get('page_size', 20))))
+        except ValueError:
+            page, page_size = 1, 20
+
+        offset     = (page - 1) * page_size
+        total      = qs.count()
+        page_qs    = qs.select_related('actor')[offset: offset + page_size]
+
+        return CustomResponse(response={
+            'count':      total,
+            'page':       page,
+            'page_size':  page_size,
+            'results':    serializers.NotificationSerializer(page_qs, many=True).data,
+        }).get_success_response()
+
+
+class UnreadCountView(APIView):
+    """
+    GET /api/v1/notification/unread-count/
+
+    Returns the number of unread, non-archived notifications for the user.
+    Phase 1: direct SQL COUNT (no Redis).
+    Phase 2: Redis-backed with SQL fallback.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Notification'], description="Get unread notification count.")
+    def get(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        count = Notification.objects.filter(
+            user_id=user_id, is_read=False, is_archived=False
+        ).count()
+        return CustomResponse(response={'unread_count': count}).get_success_response()
+
+
+class MarkReadView(APIView):
+    """
+    PATCH /api/v1/notification/<notification_id>/read/
+
+    Marks a single notification as read.
+    Returns 404 (not 403) for IDs that don't belong to the requesting user —
+    this prevents leaking whether another user's notification ID exists.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Notification'], description="Mark a notification as read.")
+    def patch(self, request, notification_id):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        notification = Notification.objects.filter(
+            id=notification_id, user_id=user_id
+        ).first()
+
+        if not notification:
+            return _notification_not_found()
+
+        if not notification.is_read:
+            notification.is_read = True
+            notification.read_at = timezone.now()
+            notification.save(update_fields=['is_read', 'read_at'])
+
+        return CustomResponse(
+            general_message='Notification marked as read'
+        ).get_success_response()
+
+
+class MarkReadBulkView(APIView):
+    """
+    PATCH /api/v1/notification/read/
+
+    Marks a specific list of the caller's own notifications as read.
+    Body: {"ids": ["<uuid>", ...]}
+
+    IDs that don't exist or aren't owned by the caller are just not counted
+    in the update — there's no single id here to 404 on the way the
+    single-notification endpoints do, so the response reports how many of
+    the submitted ids were actually matched and updated.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Notification'], description="Mark a specific list of notifications as read.")
+    def patch(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        ids = request.data.get('ids')
+
+        if not isinstance(ids, list) or not ids:
+            return CustomResponse(general_message="'ids' must be a non-empty list").get_failure_response()
+
+        updated = Notification.objects.filter(
+            id__in=ids, user_id=user_id, is_read=False
+        ).update(is_read=True, read_at=timezone.now())
+
+        return CustomResponse(
+            general_message=f'{updated} notification(s) marked as read'
+        ).get_success_response()
+
+
+class MarkAllReadView(APIView):
+    """
+    PATCH /api/v1/notification/read-all/
+
+    Marks all unread notifications as read for the authenticated user.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Notification'], description="Mark all notifications as read.")
+    def patch(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        now     = timezone.now()
+
+        updated = Notification.objects.filter(
+            user_id=user_id, is_read=False
+        ).update(is_read=True, read_at=now)
+
+        return CustomResponse(
+            general_message=f'{updated} notification(s) marked as read'
+        ).get_success_response()
+
+
+class ArchiveView(APIView):
+    """
+    PATCH /api/v1/notification/<notification_id>/archive/
+
+    Soft-hides the notification. It stays in the DB but is excluded
+    from the default feed (is_archived=False filter).
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Notification'], description="Archive a notification.")
+    def patch(self, request, notification_id):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        notification = Notification.objects.filter(
+            id=notification_id, user_id=user_id
+        ).first()
+
+        if not notification:
+            return _notification_not_found()
+
+        notification.is_archived = True
+        notification.save(update_fields=['is_archived'])
+
+        return CustomResponse(
+            general_message='Notification archived'
+        ).get_success_response()
+
+
+class DeleteOneView(APIView):
+    """
+    DELETE /api/v1/notification/<notification_id>/
+
+    Hard-deletes a single notification scoped to the requesting user.
+    Returns 404 for non-owned IDs — never 403 — to avoid leaking existence.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Notification'], description="Delete a single notification.")
+    def delete(self, request, notification_id):
+        user_id = JWTUtils.fetch_user_id(request)
+
+        notification = Notification.objects.filter(
+            id=notification_id, user_id=user_id
+        ).first()
+
+        if not notification:
+            return _notification_not_found()
+
+        notification.delete()
+        return CustomResponse(
+            general_message='Notification deleted'
+        ).get_success_response()
+
+
+class DeleteAllView(APIView):
+    """
+    DELETE /api/v1/notification/
+
+    Hard-deletes ALL notifications for the authenticated user.
+    """
+    authentication_classes = [CustomizePermission]
+
+    @extend_schema(tags=['Notification'], description="Delete all notifications for the current user.")
+    def delete(self, request):
+        user_id = JWTUtils.fetch_user_id(request)
+        deleted_count, _ = Notification.objects.filter(user_id=user_id).delete()
+        return CustomResponse(
+            general_message=f'{deleted_count} notification(s) deleted'
+        ).get_success_response()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LEGACY BROADCAST HELPERS  (kept — broadcast system still active)
+# ─────────────────────────────────────────────────────────────────────────────
 
 def _resolve_user_broadcasts(user_id: str):
     """
-    Return active (non-expired) BroadcastNotification rows that the user belongs to.
-
+    Return active (non-expired) BroadcastNotification rows the user qualifies for.
     Audience matching logic per target_type:
         'global'          -> always included
         'campus'          -> user is linked to that org (UserOrganizationLink)
@@ -26,19 +311,13 @@ def _resolve_user_broadcasts(user_id: str):
     from db.organization import UserOrganizationLink
     from db.task import UserIgLink
 
-    now = timezone.now()
+    now             = timezone.now()
     active_broadcasts = BroadcastNotification.objects.filter(expires_at__gt=now)
 
-    # --- Collect the user's memberships for efficient filtering ---
-
-    # Campus org IDs
     campus_org_ids = set(
-        UserOrganizationLink.objects.filter(
-            user_id=user_id, verified=True
-        ).values_list('org_id', flat=True)
+        UserOrganizationLink.objects.filter(user_id=user_id, verified=True)
+        .values_list('org_id', flat=True)
     )
-
-    # Active learner IG IDs
     learner_ig_ids = set(
         UserIgLink.objects.filter(
             user_id=user_id,
@@ -46,34 +325,25 @@ def _resolve_user_broadcasts(user_id: str):
             is_active=True,
         ).values_list('ig_id', flat=True)
     )
-
-    # Events the user expressed interest in
     interested_event_ids = set(
         EventInterest.objects.filter(user_id=user_id).values_list('event_id', flat=True)
     )
-
-    # Events the user co-owns
     coowned_event_ids = set(
         EventConnection.objects.filter(
             entity_id=user_id,
             entity_type=EventConnection.EntityType.CO_OWNER,
         ).values_list('event_id', flat=True)
     )
-
-    # Events the user created
     from db.events import Event
-    created_event_ids = set(
+    created_event_ids  = set(
         Event.objects.filter(created_by_id=user_id).values_list('id', flat=True)
     )
-
-    # All events where user is creator or co-owner (for event_coowners type)
     event_coowner_ids = coowned_event_ids | created_event_ids
 
     matched = []
     for b in active_broadcasts:
-        tt = b.target_type
+        tt  = b.target_type
         tid = b.target_id
-
         if tt == 'global':
             matched.append(b)
         elif tt == 'campus' and tid in campus_org_ids:
@@ -81,7 +351,6 @@ def _resolve_user_broadcasts(user_id: str):
         elif tt == 'interest_group' and tid in learner_ig_ids:
             matched.append(b)
         elif tt == 'campus_ig':
-            # Resolve the CampusIGChapter to check if the user is in both the org and the ig of that chapter
             from db.campus import CampusIGChapter
             chapter = CampusIGChapter.objects.filter(id=tid).first()
             if chapter and chapter.org_id in campus_org_ids and chapter.ig_id in learner_ig_ids:
@@ -94,101 +363,20 @@ def _resolve_user_broadcasts(user_id: str):
     return matched
 
 
-class NotificationListsAPI(APIView):
-    authentication_classes = [CustomizePermission]
-
-    @extend_schema(
-        tags=['Notification'],
-        description=(
-            "Retrieve all notifications for the authenticated user. "
-            "Returns two lists: `direct` (personal) and `broadcasts` (group/audience)."
-        ),
-        responses={200: inline_serializer(
-            name='NotificationListResponse',
-            fields={
-                'direct':     serializers.NotificationSerializer(many=True),
-                'broadcasts': serializers.BroadcastNotificationSerializer(many=True),
-            },
-        )},
-    )
-    def get(self, request):
-        """
-        Returns:
-            direct:     Personal notifications addressed to this user.
-            broadcasts: Active group-wide notifications the user qualifies for,
-                        resolved by audience membership at read time.
-        """
-        user_id = JWTUtils.fetch_user_id(request)
-
-        direct_qs = Notification.objects.filter(user_id=user_id)
-        broadcast_list = _resolve_user_broadcasts(user_id)
-
-        return CustomResponse(response={
-            'direct':     serializers.NotificationSerializer(direct_qs, many=True).data,
-            'broadcasts': serializers.BroadcastNotificationSerializer(broadcast_list, many=True).data,
-        }).get_success_response()
-
-
-class NotificationDeleteAPI(APIView):
-    authentication_classes = [CustomizePermission]
-
-    @extend_schema(tags=['Notification'], description="Delete Notification Delete.",
-        responses={200: serializers.NotificationSerializer},
-    )
-    def delete(self, request, notification_id):
-        """
-        Delete a single direct notification by its ID.
-        Broadcast notifications cannot be individually deleted;
-        they expire automatically via their expires_at timestamp.
-        """
-        user_id = JWTUtils.fetch_user_id(request)
-        notification = Notification.objects.filter(user_id=user_id, id=notification_id)
-        if not notification:
-            return CustomResponse(general_message='Notification not found').get_failure_response()
-
-        notification.delete()
-        return CustomResponse(general_message='Notification deleted successfully').get_success_response()
-
-
-class NotificationDeleteAllAPI(APIView):
-    authentication_classes = [CustomizePermission]
-
-    @extend_schema(tags=['Notification'], description="Delete Notification Delete All.",
-        responses={200: serializers.NotificationSerializer},
-    )
-    def delete(self, request):
-        """
-        Delete all direct notifications for the authenticated user.
-        Broadcast notifications are unaffected.
-        """
-        user_id = JWTUtils.fetch_user_id(request)
-        notification = Notification.objects.filter(user_id=user_id)
-        if not notification:
-            return CustomResponse(general_message='Notifications are empty').get_failure_response()
-
-        notification.delete()
-        return CustomResponse(general_message='All notification deleted successfully').get_success_response()
-
+# ─────────────────────────────────────────────────────────────────────────────
+# LEGACY BROADCAST VIEWS  (kept — endpoints still active)
+# ─────────────────────────────────────────────────────────────────────────────
 
 class BroadcastNotificationDeleteAPI(APIView):
     authentication_classes = [CustomizePermission]
 
-    @extend_schema(
-        tags=['Notification'],
-        description="Delete a single broadcast notification by its ID. Admin role required.",
-        responses={200: serializers.BroadcastNotificationSerializer},
-    )
+    @extend_schema(tags=['Notification'], description="Delete a broadcast notification. Admin only.")
     @role_required([RoleType.ADMIN.value])
     def delete(self, request, broadcast_id):
-        """
-        Delete a single BroadcastNotification by its ID.
-        Only accessible to users with the Admin role.
-        """
         try:
             broadcast = BroadcastNotification.objects.get(id=broadcast_id)
         except BroadcastNotification.DoesNotExist:
             return CustomResponse(general_message='Broadcast notification not found').get_failure_response()
-
         broadcast.delete()
         return CustomResponse(general_message='Broadcast notification deleted successfully').get_success_response()
 
@@ -196,48 +384,21 @@ class BroadcastNotificationDeleteAPI(APIView):
 class BroadcastNotificationDeleteAllAPI(APIView):
     authentication_classes = [CustomizePermission]
 
-    @extend_schema(
-        tags=['Notification'],
-        description="Delete all broadcast notifications. Admin role required.",
-        responses={200: serializers.BroadcastNotificationSerializer},
-    )
+    @extend_schema(tags=['Notification'], description="Delete all broadcast notifications. Admin only.")
     @role_required([RoleType.ADMIN.value])
     def delete(self, request):
-        """
-        Delete ALL BroadcastNotification records.
-        Only accessible to users with the Admin role.
-        """
         broadcasts = BroadcastNotification.objects.all()
         if not broadcasts.exists():
             return CustomResponse(general_message='No broadcast notifications to delete').get_failure_response()
-
         count = broadcasts.count()
         broadcasts.delete()
-        return CustomResponse(
-            general_message=f'All {count} broadcast notification(s) deleted successfully'
-        ).get_success_response()
+        return CustomResponse(general_message=f'All {count} broadcast notification(s) deleted successfully').get_success_response()
 
-
-# ─────────────────────────────────────────────────────────────────────────────
-# ADMIN BROADCAST CRUD — List / Create / Update
-# ─────────────────────────────────────────────────────────────────────────────
 
 class BroadcastNotificationListAPI(APIView):
-    """
-    GET /api/v1/notification/broadcast/list/all/
-    Admin-only: return all BroadcastNotification records with resolved target details.
-    """
     authentication_classes = [CustomizePermission]
 
-    @extend_schema(
-        tags=['Notification'],
-        description=(
-            "Admin only. List all broadcast notifications. "
-            "Each record includes a `target_details` field with the resolved "
-            "human-readable name of the target audience."
-        ),
-        responses={200: serializers.BroadcastNotificationAdminSerializer(many=True)},
-    )
+    @extend_schema(tags=['Notification'], description="Admin only. List all broadcast notifications.")
     @role_required([RoleType.ADMIN.value])
     def get(self, request):
         broadcasts = BroadcastNotification.objects.select_related('created_by').all()
@@ -246,24 +407,9 @@ class BroadcastNotificationListAPI(APIView):
 
 
 class BroadcastNotificationCreateAPI(APIView):
-    """
-    POST /api/v1/notification/broadcast/create/
-    Admin-only: create a new global BroadcastNotification announcement.
-
-    Required body fields:
-        title       (str, max 50)
-        description (str, max 200)
-        expires_at  (datetime ISO-8601)
-    Optional:
-        url         (str)  — deep-link path (max 100)
-    """
     authentication_classes = [CustomizePermission]
 
-    @extend_schema(
-        tags=['Notification'],
-        description="Admin only. Create a new global broadcast announcement.",
-        responses={201: serializers.BroadcastNotificationAdminSerializer},
-    )
+    @extend_schema(tags=['Notification'], description="Admin only. Create a new global broadcast announcement.")
     @role_required([RoleType.ADMIN.value])
     def post(self, request):
         user_id = JWTUtils.fetch_user_id(request)
@@ -273,12 +419,10 @@ class BroadcastNotificationCreateAPI(APIView):
             return CustomResponse(general_message=write_serializer.errors).get_failure_response()
 
         from db.user import User as UserModel
+        from utils.utils import DateTimeUtils
         creator = UserModel.objects.filter(id=user_id).first()
         if not creator:
             return CustomResponse(general_message='User not found').get_failure_response()
-
-        from utils.utils import DateTimeUtils
-        now = DateTimeUtils.get_current_utc_time()
 
         broadcast = BroadcastNotification.objects.create(
             title=write_serializer.validated_data['title'],
@@ -287,33 +431,19 @@ class BroadcastNotificationCreateAPI(APIView):
             target_type='global',
             target_id=None,
             created_by=creator,
-            created_at=now,
+            created_at=DateTimeUtils.get_current_utc_time(),
             expires_at=write_serializer.validated_data['expires_at'],
         )
-
-        response_data = serializers.BroadcastNotificationAdminSerializer(broadcast).data
         return CustomResponse(
             general_message='Broadcast notification created successfully.',
-            response=response_data,
+            response=serializers.BroadcastNotificationAdminSerializer(broadcast).data,
         ).get_success_response()
 
 
 class BroadcastNotificationUpdateAPI(APIView):
-    """
-    PATCH /api/v1/notification/broadcast/update/id/<broadcast_id>/
-    Admin-only: partially update an existing BroadcastNotification.
-    All body fields are optional (partial=True).
-    """
     authentication_classes = [CustomizePermission]
 
-    @extend_schema(
-        tags=['Notification'],
-        description=(
-            "Admin only. Partially update a broadcast notification by its ID. "
-            "All fields are optional."
-        ),
-        responses={200: serializers.BroadcastNotificationAdminSerializer},
-    )
+    @extend_schema(tags=['Notification'], description="Admin only. Partially update a broadcast notification.")
     @role_required([RoleType.ADMIN.value])
     def patch(self, request, broadcast_id):
         try:
@@ -322,18 +452,13 @@ class BroadcastNotificationUpdateAPI(APIView):
             return CustomResponse(general_message='Broadcast notification not found').get_failure_response()
 
         write_serializer = serializers.BroadcastNotificationWriteSerializer(
-            instance=broadcast,
-            data=request.data,
-            partial=True,
+            instance=broadcast, data=request.data, partial=True
         )
-
         if not write_serializer.is_valid():
             return CustomResponse(general_message=write_serializer.errors).get_failure_response()
 
         write_serializer.save()
-
-        response_data = serializers.BroadcastNotificationAdminSerializer(broadcast).data
         return CustomResponse(
             general_message='Broadcast notification updated successfully.',
-            response=response_data,
+            response=serializers.BroadcastNotificationAdminSerializer(broadcast).data,
         ).get_success_response()

--- a/api/notification/serializers.py
+++ b/api/notification/serializers.py
@@ -3,15 +3,54 @@ from rest_framework import serializers
 from db.notification import Notification, BroadcastNotification
 
 
-class NotificationSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Notification
-        fields = '__all__'
+# ─────────────────────────────────────────────────────────────────────────────
+# New v2 serializer — matches the new notification table schema (PRD §5.1)
+# ─────────────────────────────────────────────────────────────────────────────
 
+class NotificationSerializer(serializers.ModelSerializer):
+    """
+    Serializes a Notification row for the user-facing feed.
+    The actor field exposes id + full_name without revealing sensitive user data.
+    """
+    actor = serializers.SerializerMethodField()
+
+    class Meta:
+        model  = Notification
+        fields = [
+            'id',
+            'type',
+            'category',
+            'title',
+            'description',
+            'entity_type',
+            'entity_id',
+            'is_read',
+            'is_archived',
+            'created_at',
+            'read_at',
+            'actor',
+        ]
+
+    def get_actor(self, obj):
+        """Returns minimal actor info — who triggered this notification."""
+        if not obj.actor_id:
+            return None
+        return {
+            'id':          str(obj.actor_id),
+            'full_name':   getattr(obj.actor, 'full_name', None),
+            'muid':        getattr(obj.actor, 'muid', None),
+            'profile_pic': getattr(obj.actor, 'profile_pic', None),
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Legacy broadcast serializers — kept for backward-compat
+# These serve the existing broadcast endpoints which are still active.
+# ─────────────────────────────────────────────────────────────────────────────
 
 class BroadcastNotificationSerializer(serializers.ModelSerializer):
     class Meta:
-        model = BroadcastNotification
+        model  = BroadcastNotification
         fields = [
             'id', 'title', 'description', 'url',
             'target_type', 'target_id',
@@ -25,11 +64,11 @@ class BroadcastNotificationAdminSerializer(serializers.ModelSerializer):
     Adds a `target_details` field that resolves the human-readable name of
     the target entity from target_type + target_id.
     """
-    target_details = serializers.SerializerMethodField()
+    target_details  = serializers.SerializerMethodField()
     created_by_name = serializers.CharField(source='created_by.full_name', read_only=True)
 
     class Meta:
-        model = BroadcastNotification
+        model  = BroadcastNotification
         fields = [
             'id', 'title', 'description', 'url',
             'target_type', 'target_id', 'target_details',
@@ -39,19 +78,11 @@ class BroadcastNotificationAdminSerializer(serializers.ModelSerializer):
         read_only_fields = ['id', 'created_at', 'created_by', 'created_by_name', 'target_details']
 
     def get_target_details(self, obj):
-        """
-        Resolve the human-readable name of the broadcast target.
-
-        Returns a dict with:
-          - type: the target_type string
-          - name: resolved entity name (org title, IG name, event title, or 'Global')
-        """
-        tt = obj.target_type
+        tt  = obj.target_type
         tid = obj.target_id
 
         if tt == 'global':
             return {'type': 'global', 'name': 'Global (All Users)'}
-
         if not tid:
             return {'type': tt, 'name': None}
 
@@ -70,10 +101,7 @@ class BroadcastNotificationAdminSerializer(serializers.ModelSerializer):
                 from db.campus import CampusIGChapter
                 chapter = CampusIGChapter.objects.select_related('org', 'ig').filter(id=tid).first()
                 if chapter:
-                    return {
-                        'type': 'campus_ig',
-                        'name': f'{chapter.org.title} — {chapter.ig.name}',
-                    }
+                    return {'type': 'campus_ig', 'name': f'{chapter.org.title} — {chapter.ig.name}'}
                 return {'type': 'campus_ig', 'name': f'Unknown Chapter ({tid})'}
 
             if tt in ('event_interest', 'event_coowners'):
@@ -86,14 +114,9 @@ class BroadcastNotificationAdminSerializer(serializers.ModelSerializer):
 
         return {'type': tt, 'name': tid}
 
+
 class BroadcastNotificationWriteSerializer(serializers.ModelSerializer):
-    """
-    Write-only serializer used for Create and Update of BroadcastNotification.
-    Only allows specifying title, description, url, and expires_at,
-    forcing target_type and target_id to be set by the view.
-    """
+    """Write-only serializer for Create and Update of BroadcastNotification."""
     class Meta:
-        model = BroadcastNotification
-        fields = [
-            'title', 'description', 'url', 'expires_at',
-        ]
+        model  = BroadcastNotification
+        fields = ['title', 'description', 'url', 'expires_at']

--- a/api/notification/service.py
+++ b/api/notification/service.py
@@ -1,0 +1,223 @@
+import logging
+import uuid
+from enum import Enum
+from typing import Optional
+
+from django.conf import settings
+from django.db import transaction
+
+from api.notification.audience import Audience, AudienceResolver, AudienceSpec
+from api.notification.templates import render_template
+from api.notification.types import TYPE_META, NotificationType
+
+logger = logging.getLogger(__name__)
+
+
+def _plain(value):
+    """
+    Returns the raw string value of a (str, Enum) member, e.g. "LC_JOIN_REQUEST".
+
+    NotificationType/Category are `class X(str, Enum)`. On Python 3.11+, Enum's
+    __str__ was changed so f-strings and %-formatting on a member produce
+    "NotificationType.LC_JOIN_REQUEST" instead of "LC_JOIN_REQUEST" — only
+    plain concatenation and `.value` are unaffected. Route every place that
+    builds a string (dedupe_key, log messages) through this so the corrupted
+    form never leaks into a stored column or a log line.
+    """
+    return value.value if isinstance(value, Enum) else value
+
+
+class NotificationService:
+    """
+    Single entry point for all notifications in the system.
+
+    Producers call:
+        NotificationService.dispatch(
+            notif_type = NotificationType.LC_JOIN_APPROVED,
+            audience   = Audience.user(user_id),
+            context    = {"lc_name": "Web Dev Circle"},
+            entity_id  = str(lc.id),
+            occurrence = "1",
+            actor_id   = str(request.user.id),
+        )
+
+    Rules:
+    - dispatch() MUST be called inside the same DB transaction as the
+      business action. Notifications are only written after that transaction
+      commits. A rollback = zero notifications written.
+    - The actor is always excluded from recipients.
+    - Duplicate dispatches for the same (user, dedupe_key) are silently ignored.
+    """
+
+    _resolver = AudienceResolver()
+
+    @classmethod
+    def dispatch(
+        cls,
+        notif_type:  str,
+        audience:    AudienceSpec,
+        context:     dict,
+        entity_id:   Optional[str] = None,
+        occurrence:  str           = "1",
+        actor_id:    Optional[str] = None,
+        entity_type: Optional[str] = None,
+    ) -> None:
+        """
+        Register a notification to be written after the current DB transaction commits.
+
+        Args:
+            notif_type:  NotificationType value e.g. NotificationType.LC_JOIN_APPROVED
+            audience:    Who to notify — use Audience.user(), .users(), .lc_members() etc.
+            context:     Template variables dict e.g. {"lc_name": "Web Dev Circle"}
+            entity_id:   UUID of the entity this notification is about (for deep-linking)
+            occurrence:  Discriminator for dedupe key — "1" for once-per-entity events,
+                         entity.updated_at epoch for edit events, window id for reminders
+            actor_id:    Who triggered the action — excluded from recipients
+            entity_type: Override entity type string. If None, derived from notif_type.
+        """
+
+        # Normalize once — every downstream use (dedupe_key, storage, logging)
+        # reads notif_type_str/category_str instead of the raw enum member.
+        notif_type_str = _plain(notif_type)
+
+        # ── Step 1: Look up type metadata ────────────────────────────────────
+        meta = TYPE_META.get(notif_type)
+        if not meta:
+            logger.error(
+                "dispatch: unknown NotificationType=%s — add it to TYPE_META in types.py",
+                notif_type_str
+            )
+            return
+
+        # ── Step 2: Validate template exists for IN_APP ───────────────────────
+        # Render now (before on_commit) so template errors surface immediately
+        # during the request, not silently later.
+        rendered = render_template(notif_type, "IN_APP", context)
+        if not rendered:
+            logger.error(
+                "dispatch: no IN_APP template for type=%s — add it to TEMPLATES in templates.py",
+                notif_type_str
+            )
+            return
+
+        # ── Step 3: Resolve audience ──────────────────────────────────────────
+        # DB query runs here (e.g. fetches LC members from user_circle_link).
+        # Actor is excluded inside resolve().
+        recipient_ids = cls._resolver.resolve(audience, actor_id=actor_id)
+
+        if not recipient_ids:
+            logger.debug("dispatch: empty audience for type=%s — nothing to write", notif_type_str)
+            return
+
+        # ── Step 4: Derive entity_type from notif_type if not provided ────────
+        # Keeps producers clean — they don't need to know which entity type each
+        # notification maps to. Add more mappings here as modules are built.
+        resolved_entity_type = entity_type or _ENTITY_TYPE_MAP.get(notif_type)
+
+        # ── Step 5: Build dedupe key ──────────────────────────────────────────
+        # Format: "type:entity_id:occurrence"
+        # None when entity_id is not provided (safe — MySQL unique index allows NULLs)
+        dedupe_key = (
+            f"{notif_type_str}:{entity_id}:{occurrence}"
+            if entity_id else None
+        )
+
+        # ── Step 6: Register on_commit — nothing is written until COMMIT ─────
+        # This is the safety net: if the business transaction rolls back
+        # (e.g. LC save fails), this callback never fires and zero notification
+        # rows are written.
+        transaction.on_commit(lambda: cls._write_notifications(
+            notif_type          = notif_type_str,
+            category            = _plain(meta.category),
+            recipient_ids       = list(recipient_ids),
+            rendered            = rendered,
+            context             = context,
+            entity_type         = resolved_entity_type,
+            entity_id           = entity_id,
+            actor_id            = actor_id,
+            dedupe_key          = dedupe_key,
+        ))
+
+        logger.debug(
+            "dispatch: registered on_commit for type=%s recipients=%d",
+            notif_type_str, len(recipient_ids)
+        )
+
+    @classmethod
+    def _write_notifications(
+        cls,
+        notif_type:    str,
+        category:      str,
+        recipient_ids: list,
+        rendered:      dict,
+        context:       dict,
+        entity_type:   Optional[str],
+        entity_id:     Optional[str],
+        actor_id:      Optional[str],
+        dedupe_key:    Optional[str],
+    ) -> None:
+        """
+        Bulk inserts notification rows after the business transaction has committed.
+        Called by on_commit — never call this directly.
+        """
+        from db.notification import Notification
+
+        system_admin_id = settings.SYSTEM_ADMIN_ID
+
+        rows = [
+            Notification(
+                id           = uuid.uuid4(),
+                user_id      = uid,
+                type         = notif_type,
+                category     = category,
+                title        = rendered["title"],
+                description  = rendered["body"],
+                context      = context,
+                entity_type  = entity_type,
+                entity_id    = entity_id,
+                actor_id     = actor_id,
+                is_read      = False,
+                is_archived  = False,
+                dedupe_key   = dedupe_key,
+                created_by_id = system_admin_id,
+            )
+            for uid in recipient_ids
+        ]
+
+        # ignore_conflicts=True: if (user_id, dedupe_key) already exists
+        # (e.g. Celery retry or double-click), the row is silently skipped.
+        # No exception, no duplicate, no data corruption.
+        Notification.objects.bulk_create(
+            rows,
+            ignore_conflicts=True,
+            batch_size=1000,
+        )
+
+        logger.info(
+            "_write_notifications: type=%s attempted=%d",
+            notif_type, len(rows)
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Entity type map — derives entity_type from notif_type automatically
+#
+# Producers don't need to know which entity type each notification maps to.
+# Add entries here as modules are built. If a type is not here and no
+# entity_type is passed, entity_type will be NULL in the notification row.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_ENTITY_TYPE_MAP: dict[str, str] = {
+    # Learning Circle
+    NotificationType.LC_JOIN_REQUEST:      "learning_circle",
+    NotificationType.LC_JOIN_APPROVED:     "learning_circle",
+    NotificationType.LC_JOIN_REJECTED:     "learning_circle",
+    NotificationType.LC_MEETING_SCHEDULED: "learning_circle",
+    NotificationType.LC_MEMBER_REMOVED:    "learning_circle",
+    NotificationType.LC_INVITE:            "learning_circle",
+
+    # Add more as modules are built:
+    # NotificationType.SESSION_BOOKED:    "session",
+    # NotificationType.EVENT_PUBLISHED:   "event",
+    # NotificationType.JOB_APPLICATION_STATUS: "job_application",
+}

--- a/api/notification/templates.py
+++ b/api/notification/templates.py
@@ -1,0 +1,117 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Template Registry
+#
+# Maps (notification_type, render_target) → {title, body} string templates.
+# {placeholders} are filled from the context dict the producer passes.
+#
+# render_target values:
+#   "IN_APP"    → text shown in the notification bell / feed
+#   "WEBSOCKET" → same as IN_APP for now (same text, different delivery)
+#   "PUSH"      → added in Phase 2 (shorter, fits notification tray)
+#   "EMAIL"     → added in Phase 3 (longer, can be HTML)
+#
+# Only LC + IN_APP/WEBSOCKET targets are defined here.
+# Add more (type, target) pairs as modules and channels are built.
+# ─────────────────────────────────────────────────────────────────────────────
+
+TEMPLATES: dict[tuple, dict] = {
+
+    # ── LC_JOIN_REQUEST ───────────────────────────────────────────────────────
+    # Who gets it: LC lead
+    # Context keys: lc_name, requester_name
+    ("LC_JOIN_REQUEST", "IN_APP"): {
+        "title": "New Join Request",
+        "body":  "{requester_name} wants to join {lc_name}.",
+    },
+
+    # ── LC_JOIN_APPROVED ──────────────────────────────────────────────────────
+    # Who gets it: the requester
+    # Context keys: lc_name
+    ("LC_JOIN_APPROVED", "IN_APP"): {
+        "title": "Join Request Approved!",
+        "body":  "Your request to join {lc_name} has been approved.",
+    },
+
+    # ── LC_JOIN_REJECTED ──────────────────────────────────────────────────────
+    # Who gets it: the requester
+    # Context keys: lc_name
+    ("LC_JOIN_REJECTED", "IN_APP"): {
+        "title": "Join Request Rejected",
+        "body":  "Your request to join {lc_name} was not approved.",
+    },
+
+    # ── LC_MEETING_SCHEDULED ──────────────────────────────────────────────────
+    # Who gets it: all accepted members except the meeting creator
+    # Context keys: lc_name, meet_time
+    ("LC_MEETING_SCHEDULED", "IN_APP"): {
+        "title": "New Meeting Scheduled",
+        "body":  "A new meeting for {lc_name} has been scheduled on {meet_time}.",
+    },
+
+    # ── LC_MEMBER_REMOVED ─────────────────────────────────────────────────────
+    # Who gets it: the removed member
+    # Context keys: lc_name
+    ("LC_MEMBER_REMOVED", "IN_APP"): {
+        "title": "Removed from Circle",
+        "body":  "You have been removed from {lc_name}.",
+    },
+
+    # ── LC_INVITE ─────────────────────────────────────────────────────────────
+    # Who gets it: the invited user
+    # Context keys: lc_name
+    ("LC_INVITE", "IN_APP"): {
+        "title": "Circle Invitation",
+        "body":  "You have been invited to join {lc_name}.",
+    },
+
+}
+
+# Copy all IN_APP entries to WEBSOCKET automatically.
+# WebSocket uses the same title/body as IN_APP — it's just a different delivery pipe.
+# When PUSH and EMAIL templates differ (Phase 2/3), add them manually above.
+for (_type, _target), _tmpl in list(TEMPLATES.items()):
+    if _target == "IN_APP":
+        TEMPLATES[(_type, "WEBSOCKET")] = _tmpl
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# render_template(notif_type, target, context) → {title, body} or None
+#
+# Called by dispatch() to get the rendered title and body.
+# Returns None if:
+#   - no template registered for this (type, target) pair  → SKIPPED: NO_TEMPLATE
+#   - context is missing a required placeholder key        → SKIPPED: TEMPLATE_ERROR
+# ─────────────────────────────────────────────────────────────────────────────
+
+def render_template(notif_type: str, target: str, context: dict) -> dict | None:
+    """
+    Renders the title and body for a given (type, target) using context variables.
+
+    Args:
+        notif_type: NotificationType value e.g. "LC_JOIN_APPROVED"
+        target:     Render target e.g. "IN_APP", "WEBSOCKET", "PUSH", "EMAIL"
+        context:    Dict of variables from the producer e.g. {"lc_name": "Web Dev"}
+
+    Returns:
+        {"title": "...", "body": "..."} on success
+        None if no template found or context key is missing
+    """
+    template = TEMPLATES.get((notif_type, target))
+    if not template:
+        return None
+
+    try:
+        return {
+            "title": template["title"].format(**context),
+            "body":  template["body"].format(**context),
+        }
+    except KeyError as missing_key:
+        logger.warning(
+            "render_template: missing context key %s for type=%s target=%s context=%s",
+            missing_key, notif_type, target, context,
+        )
+        return None

--- a/api/notification/types.py
+++ b/api/notification/types.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import List
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. NotificationType — string constants for every notification event
+#
+# Use these instead of raw strings in producers:
+#   ✅  NotificationType.LC_JOIN_APPROVED
+#   ❌  "LC_JOIN_APPROVED"   ← typos cause silent failures
+#
+# Only LC types are defined now. Add other modules here as they are built.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class NotificationType(str, Enum):
+    # ── Learning Circle ───────────────────────────────────────────────────────
+    LC_JOIN_REQUEST      = "LC_JOIN_REQUEST"
+    LC_JOIN_APPROVED     = "LC_JOIN_APPROVED"
+    LC_JOIN_REJECTED     = "LC_JOIN_REJECTED"
+    LC_MEETING_SCHEDULED = "LC_MEETING_SCHEDULED"
+    LC_MEMBER_REMOVED    = "LC_MEMBER_REMOVED"
+    LC_INVITE            = "LC_INVITE"
+
+    # ── Add more modules below as they are built ──────────────────────────────
+    # MENTORSHIP, EVENTS, JOBS, INTERN, TASKS, ADMIN_BROADCAST ...
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Category — the product module a notification type belongs to
+#
+# Stored in notification.category column.
+# Used by frontend to filter: "show me only LC notifications."
+# Never set by a producer — dispatch() derives it from TYPE_META.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class Category(str, Enum):
+    LC = "LC"
+
+    # Add below as modules are built:
+    # MENTORSHIP     = "MENTORSHIP"
+    # EVENTS         = "EVENTS"
+    # JOBS           = "JOBS"
+    # COMPANY        = "COMPANY"
+    # INTERN         = "INTERN"
+    # TASKS          = "TASKS"
+    # ADMIN          = "ADMIN"
+    # ADMIN_BROADCAST = "ADMIN_BROADCAST"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. TypeMeta — the rules for each notification type
+#
+# category:    which Category this type belongs to
+# is_personal: True = this type is about ONE user's private data
+#              → structurally barred from Discord, even if a policy row exists
+# eligible:    which channels this type is ALLOWED to use
+#              (channel_policy and user settings can further restrict this,
+#               but they cannot ADD channels that are not in this list)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class TypeMeta:
+    category:    str
+    is_personal: bool
+    eligible:    List[str]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. TYPE_META — the lookup table dispatch() reads per notification type
+#
+# dispatch() does:
+#     meta = TYPE_META.get(notif_type)
+#     meta.category    → stored in notification.category
+#     meta.is_personal → gates Discord permanently
+#     meta.eligible    → passed to channel gate
+#
+# Adding a new module = adding entries here. Zero changes to dispatch().
+# ─────────────────────────────────────────────────────────────────────────────
+
+# fmt: off
+TYPE_META: dict[str, TypeMeta] = {
+
+    # ── Learning Circle — all personal, all 4 channels ────────────────────────
+    NotificationType.LC_JOIN_REQUEST: TypeMeta(
+        category    = Category.LC,
+        is_personal = True,
+        eligible    = ["IN_APP", "WEBSOCKET", "PUSH", "EMAIL"],
+    ),
+    NotificationType.LC_JOIN_APPROVED: TypeMeta(
+        category    = Category.LC,
+        is_personal = True,
+        eligible    = ["IN_APP", "WEBSOCKET", "PUSH", "EMAIL"],
+    ),
+    NotificationType.LC_JOIN_REJECTED: TypeMeta(
+        category    = Category.LC,
+        is_personal = True,
+        eligible    = ["IN_APP", "WEBSOCKET", "PUSH", "EMAIL"],
+    ),
+    NotificationType.LC_MEETING_SCHEDULED: TypeMeta(
+        category    = Category.LC,
+        is_personal = True,
+        eligible    = ["IN_APP", "WEBSOCKET", "PUSH", "EMAIL"],
+    ),
+    NotificationType.LC_MEMBER_REMOVED: TypeMeta(
+        category    = Category.LC,
+        is_personal = True,
+        eligible    = ["IN_APP", "WEBSOCKET", "PUSH", "EMAIL"],
+    ),
+    NotificationType.LC_INVITE: TypeMeta(
+        category    = Category.LC,
+        is_personal = True,
+        eligible    = ["IN_APP", "WEBSOCKET", "PUSH", "EMAIL"],
+    ),
+
+}
+# fmt: on

--- a/api/notification/urls.py
+++ b/api/notification/urls.py
@@ -1,22 +1,23 @@
 from django.urls import path
-
 from . import notification_view
 
 urlpatterns = [
-    path('list/', notification_view.NotificationListsAPI.as_view(), name='list-notification'),
-    path('delete/id/<str:notification_id>/', notification_view.NotificationDeleteAPI.as_view(),
-         name='delete-notification'),
-    path('delete/all/', notification_view.NotificationDeleteAllAPI.as_view(), name='delete-all-notification'),
-    # Broadcast — delete (admin only)
-    path('broadcast/delete/id/<str:broadcast_id>/', notification_view.BroadcastNotificationDeleteAPI.as_view(),
-         name='delete-broadcast-notification'),
-    path('broadcast/delete/all/', notification_view.BroadcastNotificationDeleteAllAPI.as_view(),
-         name='delete-all-broadcast-notification'),
-    # Broadcast — admin CRUD
-    path('broadcast/list/all/', notification_view.BroadcastNotificationListAPI.as_view(),
-         name='list-all-broadcast-notifications'),
-    path('broadcast/create/', notification_view.BroadcastNotificationCreateAPI.as_view(),
-         name='create-broadcast-notification'),
-    path('broadcast/update/id/<str:broadcast_id>/', notification_view.BroadcastNotificationUpdateAPI.as_view(),
-         name='update-broadcast-notification'),
+
+    # ── v2 User-facing notification endpoints ─────────────────────────────────
+    path('',               notification_view.NotificationListView.as_view(),  name='notification-list'),
+    path('unread-count/',  notification_view.UnreadCountView.as_view(),        name='notification-unread-count'),
+    path('read-all/',      notification_view.MarkAllReadView.as_view(),        name='notification-read-all'),
+    path('read/',          notification_view.MarkReadBulkView.as_view(),       name='notification-read-bulk'),
+    path('<str:notification_id>/read/',    notification_view.MarkReadView.as_view(),   name='notification-mark-read'),
+    path('<str:notification_id>/archive/', notification_view.ArchiveView.as_view(),    name='notification-archive'),
+    path('<str:notification_id>/',         notification_view.DeleteOneView.as_view(),  name='notification-delete-one'),
+    path('delete/all/',    notification_view.DeleteAllView.as_view(),          name='notification-delete-all'),
+
+    # ── Legacy broadcast endpoints (admin) ────────────────────────────────────
+    path('broadcast/delete/id/<str:broadcast_id>/',  notification_view.BroadcastNotificationDeleteAPI.as_view(),    name='delete-broadcast-notification'),
+    path('broadcast/delete/all/',                    notification_view.BroadcastNotificationDeleteAllAPI.as_view(), name='delete-all-broadcast-notification'),
+    path('broadcast/list/all/',                      notification_view.BroadcastNotificationListAPI.as_view(),      name='list-all-broadcast-notifications'),
+    path('broadcast/create/',                        notification_view.BroadcastNotificationCreateAPI.as_view(),    name='create-broadcast-notification'),
+    path('broadcast/update/id/<str:broadcast_id>/',  notification_view.BroadcastNotificationUpdateAPI.as_view(),    name='update-broadcast-notification'),
+
 ]

--- a/db/notification.py
+++ b/db/notification.py
@@ -1,42 +1,85 @@
 import uuid
 
 from django.db import models
+from django.conf import settings
 
 from db.user import User
-
-from django.conf import settings
 
 # fmt: off
 # noinspection PyPep8
 
+
 class Notification(models.Model):
     id          = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # Who receives this notification
     user        = models.ForeignKey(User, on_delete=models.CASCADE, related_name="notifications")
-    title       = models.CharField(max_length=50, blank=False)
-    description = models.CharField(max_length=200, blank=False)
-    button      = models.CharField(max_length=10, blank=True, null=True)
+
+    # ── What happened ──────────────────────────────────────────────────────────
+    # type:     which specific event — one of 42 NotificationType values
+    #           old rows carry "LEGACY", new rows always have a real type
+    # category: which product module — derived from type by dispatch()
+    #           never set by a producer directly
+    type        = models.CharField(max_length=50,  default="LEGACY")
+    category    = models.CharField(max_length=20,  default="SYSTEM")
+
+    # ── What to show ───────────────────────────────────────────────────────────
+    title       = models.CharField(max_length=100)
+    description = models.CharField(max_length=300)
+
+    # ── Raw producer variables ─────────────────────────────────────────────────
+    # Stored so future channels (email, push) can re-render without a schema change
+    context     = models.JSONField(null=True, blank=True)
+
+    # ── What the notification is about (powers frontend deep-linking) ──────────
+    entity_type = models.CharField(max_length=40,  null=True, blank=True)
+    entity_id   = models.CharField(max_length=36,  null=True, blank=True)
+
+    # ── Who triggered the action ───────────────────────────────────────────────
+    # SET_NULL so deleting a user never orphans notification rows
+    actor       = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        db_column="actor_id", related_name="caused_notifications"
+    )
+
+    # ── Read state ─────────────────────────────────────────────────────────────
+    is_read     = models.BooleanField(default=False)
+    read_at     = models.DateTimeField(null=True, blank=True)
+
+    # ── Soft hide ──────────────────────────────────────────────────────────────
+    is_archived = models.BooleanField(default=False)
+
+    # ── Duplicate prevention ───────────────────────────────────────────────────
+    # Format: "type:entity_id:occurrence"
+    # DB has UNIQUE INDEX on (user_id, dedupe_key) — bulk_create(ignore_conflicts=True)
+    # silently rejects duplicates without crashing
+    dedupe_key  = models.CharField(max_length=160, null=True, blank=True)
+
+    # ── Admin broadcast only ───────────────────────────────────────────────────
+    redirect_url = models.CharField(max_length=255, null=True, blank=True)
+    batch_id     = models.CharField(max_length=36,  null=True, blank=True)
+
+    # ── Legacy fields — do not use in new code ─────────────────────────────────
+    button      = models.CharField(max_length=10,  blank=True, null=True)
     url         = models.CharField(max_length=100, blank=True, null=True)
+
+    # ── Audit ──────────────────────────────────────────────────────────────────
     created_at  = models.DateTimeField(auto_now_add=True)
-    created_by  = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column="created_by", related_name="created_notifications")
+    created_by  = models.ForeignKey(
+        User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+        db_column="created_by", related_name="created_notifications"
+    )
 
     class Meta:
-        managed = False
+        managed  = False
         db_table = "notification"
-        ordering = ["created_at"]
+        ordering = ["-created_at"]   # newest-first (old ascending order was a bug)
 
 
 class BroadcastNotification(models.Model):
     """
-    One row per group-wide broadcast announcement.
-    Recipients are resolved dynamically at read time via target_type + target_id.
-
-    target_type values:
-        'campus'          → all users linked to target_id (org_id)
-        'interest_group'  → all learners with an active link to target_id (ig_id)
-        'campus_ig'       → all learners in a campus-IG chapter (target_id = campus_ig composite id)
-        'event_interest'  → all users who expressed interest in target_id (event_id)
-        'event_coowners'  → event creator + all co-owners of target_id (event_id)
-        'global'          → all active users (target_id is NULL)
+    LEGACY — pre-v2 broadcast system. Do not use for new code.
+    New broadcasts go through NotificationService.dispatch() with ADMIN_BROADCAST type.
     """
     id          = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     title       = models.CharField(max_length=50)
@@ -49,6 +92,6 @@ class BroadcastNotification(models.Model):
     expires_at  = models.DateTimeField()
 
     class Meta:
-        managed = False
-        db_table  = "broadcast_notification"
-        ordering  = ["-created_at"]
+        managed  = False
+        db_table = "broadcast_notification"
+        ordering = ["-created_at"]


### PR DESCRIPTION
## Summary

Implements **PR1** of the new notification system rollout, establishing the core notification infrastructure and wiring all Learning Circle notification triggers through the new service layer. 

This PR introduces the foundational notification architecture (dispatch service, audience resolver, type registry, template engine) and updates the Learning Circle module to use structured `NotificationService.dispatch()` calls instead of legacy `NotificationUtils.insert_notification()` calls.

---

## What's Included

### 1. Core Notification Infrastructure (`api/notification/`)
- **`service.py`**: Added `NotificationService.dispatch()` to handle template rendering, audience resolution, actor filtering, deduplication key generation (`dedupe_key`), and bulk database insertion atomically.
- **`types.py`**: Defined `NotificationType` enum and `TYPE_META` mapping types to categories, entity models, and display labels.
- **`audience.py`**: Implemented `Audience` builder and `AudienceResolver` to dynamically resolve recipients (`lc_lead`, `lc_members`, `user`) at dispatch time.
- **`templates.py`**: Added `TemplateEngine` for context-driven Jinja-style message formatting.
- **`serializers.py`**: Updated `NotificationSerializer` to include `actor` details (`id`, `full_name`, `muid`, `profile_pic`), `entity_type`, `entity_id`, `category`, and `is_archived`.

### 2. User-Facing Notification APIs (`api/notification/notification_view.py`)
- `GET /api/v1/notification/`: Paginated user feed supporting `isRead`, `type`, `category`, `fromDate`, `toDate`, and `sortBy` filters.
- `GET /api/v1/notification/unread-count/`: Direct SQL count of unread, non-archived notifications.
- `PATCH /api/v1/notification/<id>/read/`: Mark single notification as read.
- `PATCH /api/v1/notification/read-all/`: Mark all user notifications as read.
- `PATCH /api/v1/notification/read/`: Bulk mark specified IDs as read.
- `PATCH /api/v1/notification/<id>/archive/`: Soft-archive a notification.
- `DELETE /api/v1/notification/<id>/`: Hard-delete a single notification.
- `DELETE /api/v1/notification/delete/all/`: Hard-delete all notifications for the authenticated user.

### 3. Learning Circle Triggers & API Updates (`api/dashboard/learningcircle/`)
Wired 5 notification triggers to `NotificationService.dispatch()`:
- `LC_JOIN_REQUEST`: Member sends a join request $\rightarrow$ Notifies LC Lead
- `LC_JOIN_APPROVED`: Lead approves join request $\rightarrow$ Notifies Requester
- `LC_JOIN_REJECTED`: Lead rejects join request $\rightarrow$ Notifies Requester
- `LC_MEETING_SCHEDULED`: Member schedules a meeting $\rightarrow$ Notifies all LC Members (except creator)
- `LC_INVITE`: Lead invites user to LC $\rightarrow$ Notifies Invited User

Also added/updated helper APIs:
- `POST /join/<circle_id>/`, `GET /join/<circle_id>/`, `PATCH /join/<circle_id>/`
- `POST /members/add/<circle_id>/`
- `POST /invite/<circle_id>/`, `GET /invite/status/`, `POST /invite/status/<link_id>/`, `GET /invite/sent/<circle_id>/`
- `POST /transfer-lead/<circle_id>/`
- `GET /user-circles/`

---

## Files Changed

| File | Changes |
|---|---|
| `api/notification/service.py` | **New** — Notification dispatch & bulk insert service |
| `api/notification/audience.py` | **New** — Audience resolution logic |
| `api/notification/templates.py` | **New** — Notification string template renderer |
| `api/notification/types.py` | **New** — Notification type definitions & metadata |
| `api/notification/notification_view.py` | Overhauled notification endpoints & CRUD handlers |
| `api/notification/serializers.py` | Updated serializer fields for expanded notification schema |
| `api/notification/urls.py` | Updated routes for user notifications |
| `db/notification.py` | Extended `Notification` model with new fields & metadata |
| `api/dashboard/learningcircle/learningcircle_views.py` | Integrated `NotificationService.dispatch()` & new LC API handlers |

---

Test Plan

- [ ] LC Join Request: User A requests to join User B's LC. Verify User B receives an LC_JOIN_REQUEST notification row.
- [ ] LC Join Response: User B approves/rejects User A. Verify User A receives LC_JOIN_APPROVED or LC_JOIN_REJECTED.
- [ ] Meeting Scheduled: User A schedules a meeting in the circle. Verify User B receives LC_MEETING_SCHEDULED, and User A receives nothing (actor excluded).
- [ ] LC Invite: User B invites User C to join. Verify User C receives LC_INVITE.
- [ ] Feed & Status APIs: Test /notification/, /notification/unread-count/, /read/, /archive/, and /delete/ to confirm accurate counts and feed state.
- [ ] Deduplication Check: Trigger duplicate requests; confirm uq_notif_dedupe prevents duplicate records.

