### PR TITLE
fix(TransferLeadAPi):current campus lead role can be removed

### DIFF
--- a/api/dashboard/campus/campus_views.py
+++ b/api/dashboard/campus/campus_views.py
@@ -563,10 +563,13 @@ class TransferLeadRoleAPI(APIView):
             ).get_failure_response()
 
         with transaction.atomic():
-            UserRoleLink.objects.filter(
-                user__id=user_id,
-                role__id=role_id,
-            ).delete()
+            current_lead = UserRoleLink.objects.filter(
+            user__user_organization_link_user__org=user_org_link.org,
+            user__user_organization_link_user__org__org_type=OrganizationType.COLLEGE.value,
+            role__id=role_id,
+            ).first()
+            if current_lead:
+                current_lead.delete()
 
             serializer = serializers.UserRoleLinkSerializer(
                 data={


### PR DESCRIPTION
This pull request updates the logic for deleting a user's role link in the `post` method of `campus_views.py`. Instead of deleting all matching `UserRoleLink` objects by user and role, the code now specifically finds and deletes only the current lead associated with the user's organization and organization type.

Changes to user role link deletion logic:

* The code now filters `UserRoleLink` objects by the user's organization and ensures the organization type is `COLLEGE` before deleting the current lead, rather than deleting all links matching the user and role indiscriminately.