### PR TITLE
feat(events, karma-voucher): public event feature/detail endpoints + voucher task-hashtag fix

### DIFF
--- a/api/common/urls.py
+++ b/api/common/urls.py
@@ -7,7 +7,11 @@ from .college_details_views import CollegeDetailsAPI
 from api.dashboard.company import job_views
 from api.dashboard.ig import dash_ig_view
 from api.dashboard.career_lab import career_lab_views
-from api.dashboard.events.public_views import PublicEventListAPI
+from api.dashboard.events.public_views import (
+    PublicEventListAPI,
+    PublicEventFeaturedAPI,
+    PublicEventDetailAPI,
+)
 
 urlpatterns = [
     path('campus-details/<str:college_code>/', CollegeDetailsAPI.as_view()),
@@ -43,4 +47,6 @@ urlpatterns = [
     path('career-lab/ongoing/', career_lab_views.PublicOngoingHiringAPI.as_view(), name='public-career-lab-ongoing'),
     path('career-lab/previous/', career_lab_views.PublicPreviousHiringAPI.as_view(), name='public-career-lab-previous'),
     path('events/', PublicEventListAPI.as_view(), name='public-events-list'),
+    path('events/featured/', PublicEventFeaturedAPI.as_view(), name='public-events-featured'),
+    path('events/<str:event_id>/', PublicEventDetailAPI.as_view(), name='public-events-detail'),
 ]

--- a/api/dashboard/events/public_views.py
+++ b/api/dashboard/events/public_views.py
@@ -17,16 +17,19 @@ from utils.utils import CommonUtils
 
 from datetime import datetime
 from django.utils import timezone
+from django.utils.dateparse import parse_date
 
 from .serializers import (
     EventListItemSerializer,
     EventDetailSerializer,
+    PublicEventDetailSerializer,
     get_live_events,
     EventCalendarItemSerializer,
 )
 from drf_spectacular.utils import extend_schema, inline_serializer, OpenApiResponse
 from rest_framework import serializers as s
 from api.dashboard.task.dash_task_serializer import TaskListPublicSerializer
+from utils.utils import MAX_PAGE_SIZE
 
 
 
@@ -87,9 +90,15 @@ def _build_scope_filter(user_id):
 
 def _public_events_queryset(request, *, featured_only=False):
     """
-    Base queryset for public event lists: scope visibility, published/ongoing,
-    optional filters. When ``featured_only`` is True, only ``is_featured`` rows
-    are returned (used by /events/featured/ and /events/is-featured/).
+    SCOPE-GATED queryset for the dashboard-scoped /events/ routes (optional
+    JWT, campus/IG/company visibility rules via `_build_scope_filter`).
+    Published/ongoing, optional filters. When ``featured_only`` is True, only
+    ``is_featured`` rows are returned (used by /events/featured/ and
+    /events/is-featured/).
+
+    NOT the same as `_fully_public_events_queryset` below, which serves the
+    /api/v1/public/events/* routes — no scope gating at all (every anonymous
+    viewer sees the same set). Don't confuse the two when adding a filter.
     """
     user_id = _get_viewer_id(request)
 
@@ -182,6 +191,84 @@ class EventListAPI(APIView):
         )
 
 
+# Lifecycle statuses exposed on every fully-public (unauthenticated) events
+# endpoint — list, featured, and detail. Keep this the single source of truth
+# so the endpoints can't silently diverge on what "public" means.
+PUBLIC_EVENT_STATUSES = [Event.Status.PUBLISHED, Event.Status.ONGOING, Event.Status.COMPLETED]
+
+
+def _fully_public_events_queryset(request, *, featured_only=False):
+    """
+    Fully public queryset: no authentication and no campus/IG scope gating
+    (every viewer sees the same set). Only lifecycle-public events
+    (published, ongoing, completed) are returned; draft/pending/cancelled/
+    rejected events are never exposed here.
+
+    When ``featured_only`` is True, always restricts to ``is_featured=True``
+    (used by /events/featured/), regardless of the ``is_featured`` query param.
+    """
+    params = request.query_params
+    now = timezone.now()
+
+    events = get_live_events().select_related(
+        'category', 'organiser_ig', 'organiser_org'
+    ).filter(
+        status__in=PUBLIC_EVENT_STATUSES
+    )
+
+    # ── status filter — repeated params (?status=a&status=b) and/or
+    # comma-separated (?status=a,b) are both accepted and OR'd together.
+    # Computed from start/end datetime rather than the lifecycle `status`
+    # field, since a published event may not have started yet.
+    raw_statuses = params.getlist('status')
+    statuses = {
+        s.strip().lower()
+        for raw in raw_statuses
+        for s in raw.split(',')
+        if s.strip()
+    }
+    if statuses:
+        status_q = Q()
+        if 'upcoming' in statuses:
+            status_q |= Q(start_datetime__gt=now)
+        if 'ongoing' in statuses:
+            status_q |= Q(start_datetime__lte=now, end_datetime__gte=now)
+        if 'completed' in statuses:
+            status_q |= Q(end_datetime__lt=now)
+        if status_q:
+            events = events.filter(status_q)
+
+    # ── date range filter — invalid YYYY-MM-DD strings are ignored rather
+    # than passed to the ORM, which would otherwise raise an uncaught
+    # django.core.exceptions.ValidationError and 500 the request. ────────
+    if start_date_raw := params.get('start_date'):
+        if start_date := parse_date(start_date_raw):
+            events = events.filter(start_datetime__date__gte=start_date)
+    if end_date_raw := params.get('end_date'):
+        if end_date := parse_date(end_date_raw):
+            events = events.filter(end_datetime__date__lte=end_date)
+
+    # ── other filters ────────────────────────────────────────────────
+    if event_type := params.get('event_type'):
+        events = events.filter(event_type=event_type)
+    if scope := params.get('scope'):
+        events = events.filter(scope=scope)
+    if ig_id := params.get('ig_id'):
+        events = events.filter(scope_ig_id=ig_id)
+    if campus_id := params.get('campus_id'):
+        events = events.filter(scope_org_id=campus_id)
+    if cluster := params.get('cluster'):
+        events = events.filter(organiser_ig__category=cluster)
+    if featured_only:
+        events = events.filter(is_featured=True)
+    elif is_featured := params.get('is_featured'):
+        events = events.filter(is_featured=is_featured.lower() == 'true')
+    if tags := params.get('tags'):
+        events = events.filter(tags__icontains=tags)
+
+    return events
+
+
 class PublicEventListAPI(APIView):
     """
     GET /api/v1/public/events/
@@ -201,58 +288,7 @@ class PublicEventListAPI(APIView):
         responses={200: EventListItemSerializer},
     )
     def get(self, request):
-        params = request.query_params
-        now = timezone.now()
-
-        events = get_live_events().select_related(
-            'category', 'organiser_ig', 'organiser_org'
-        ).filter(
-            status__in=[Event.Status.PUBLISHED, Event.Status.ONGOING, Event.Status.COMPLETED]
-        )
-
-        # ── status filter — repeated params (?status=a&status=b) and/or
-        # comma-separated (?status=a,b) are both accepted and OR'd together.
-        # Computed from start/end datetime rather than the lifecycle `status`
-        # field, since a published event may not have started yet.
-        raw_statuses = params.getlist('status')
-        statuses = {
-            s.strip().lower()
-            for raw in raw_statuses
-            for s in raw.split(',')
-            if s.strip()
-        }
-        if statuses:
-            status_q = Q()
-            if 'upcoming' in statuses:
-                status_q |= Q(start_datetime__gt=now)
-            if 'ongoing' in statuses:
-                status_q |= Q(start_datetime__lte=now, end_datetime__gte=now)
-            if 'completed' in statuses:
-                status_q |= Q(end_datetime__lt=now)
-            if status_q:
-                events = events.filter(status_q)
-
-        # ── date range filter ────────────────────────────────────────────
-        if start_date := params.get('start_date'):
-            events = events.filter(start_datetime__date__gte=start_date)
-        if end_date := params.get('end_date'):
-            events = events.filter(end_datetime__date__lte=end_date)
-
-        # ── other filters ────────────────────────────────────────────────
-        if event_type := params.get('event_type'):
-            events = events.filter(event_type=event_type)
-        if scope := params.get('scope'):
-            events = events.filter(scope=scope)
-        if ig_id := params.get('ig_id'):
-            events = events.filter(scope_ig_id=ig_id)
-        if campus_id := params.get('campus_id'):
-            events = events.filter(scope_org_id=campus_id)
-        if cluster := params.get('cluster'):
-            events = events.filter(organiser_ig__category=cluster)
-        if is_featured := params.get('is_featured'):
-            events = events.filter(is_featured=is_featured.lower() == 'true')
-        if tags := params.get('tags'):
-            events = events.filter(tags__icontains=tags)
+        events = _fully_public_events_queryset(request)
 
         events = CommonUtils.get_paginated_queryset(
             events, request,
@@ -260,9 +296,85 @@ class PublicEventListAPI(APIView):
             sort_fields=_PUBLIC_EVENT_SORT_FIELDS,
             is_pagination=False,
         )
+        # Unpaginated by design, but still bounded — MAX_PAGE_SIZE caps the
+        # response so an ever-growing events table can't turn this single
+        # unauthenticated request into an unbounded payload.
+        events = events[:MAX_PAGE_SIZE]
 
         serializer = EventListItemSerializer(
             events, many=True,
+            context={'user_id': None, 'request': request},
+        )
+        return CustomResponse(
+            response=serializer.data,
+        ).get_success_response()
+
+
+class PublicEventFeaturedAPI(APIView):
+    """
+    GET /api/v1/public/events/featured/
+
+    Fully public listing of featured events (``is_featured=True``), same
+    lifecycle/status/date/type filters as PublicEventListAPI. No authentication,
+    no campus/IG scope gating. Unpaginated, matching PublicEventListAPI.
+    """
+    permission_classes = []
+
+    @extend_schema(
+        tags=['Public - Events'],
+        description="Fully public, unauthenticated list of featured events.",
+        responses={200: EventListItemSerializer},
+    )
+    def get(self, request):
+        events = _fully_public_events_queryset(request, featured_only=True)
+
+        events = CommonUtils.get_paginated_queryset(
+            events, request,
+            search_fields=['title', 'description', 'venue_city'],
+            sort_fields=_PUBLIC_EVENT_SORT_FIELDS,
+            is_pagination=False,
+        )
+        # Unpaginated by design, but still bounded — see PublicEventListAPI.
+        events = events[:MAX_PAGE_SIZE]
+
+        serializer = EventListItemSerializer(
+            events, many=True,
+            context={'user_id': None, 'request': request},
+        )
+        return CustomResponse(
+            response=serializer.data,
+        ).get_success_response()
+
+
+class PublicEventDetailAPI(APIView):
+    """
+    GET /api/v1/public/events/<event_id>/
+
+    Fully public event detail: no authentication and no campus/IG scope
+    gating. Only lifecycle-public events (published, ongoing, completed) are
+    returned; draft/pending/cancelled/rejected events resolve to "not found".
+    """
+    permission_classes = []
+
+    @extend_schema(
+        tags=['Public - Events'],
+        description="Fully public, unauthenticated detail view of a single event.",
+        responses={200: PublicEventDetailSerializer},
+    )
+    def get(self, request, event_id):
+        event = get_live_events().select_related(
+            'category', 'organiser_ig', 'organiser_org', 'scope_org', 'scope_ig',
+        ).filter(
+            id=event_id,
+            status__in=PUBLIC_EVENT_STATUSES,
+        ).first()
+        if not event:
+            return CustomResponse(
+                general_message='Event not found.'
+            ).get_failure_response()
+
+        serializer = PublicEventDetailSerializer(
+            event,
             context={'user_id': None, 'request': request},
         )
         return CustomResponse(

--- a/api/dashboard/events/public_views.py
+++ b/api/dashboard/events/public_views.py
@@ -29,7 +29,6 @@ from .serializers import (
 from drf_spectacular.utils import extend_schema, inline_serializer, OpenApiResponse
 from rest_framework import serializers as s
 from api.dashboard.task.dash_task_serializer import TaskListPublicSerializer
-from utils.utils import MAX_PAGE_SIZE
 
 
 
@@ -266,7 +265,11 @@ def _fully_public_events_queryset(request, *, featured_only=False):
     if tags := params.get('tags'):
         events = events.filter(tags__icontains=tags)
 
-    return events
+    # Deterministic base order — without this, MySQL gives no guarantee on
+    # row order, so paginating (or capping) an unordered queryset can skip
+    # or duplicate rows across pages/requests. `?sortBy=` in
+    # CommonUtils.get_paginated_queryset re-orders on top of this when set.
+    return events.order_by('-start_datetime', 'id')
 
 
 class PublicEventListAPI(APIView):
@@ -278,7 +281,10 @@ class PublicEventListAPI(APIView):
     (published, ongoing, completed) are returned; draft/pending/cancelled/
     rejected events are never exposed here.
 
-    Unpaginated — returns the full matching set in one response.
+    Paginated (pageIndex/perPage) — matches every other list endpoint in
+    this codebase. A flat, unbounded-looking response can't safely represent
+    a table that may exceed one page without either silently dropping rows
+    past a cap or growing the payload without limit.
     """
     permission_classes = []
 
@@ -290,24 +296,20 @@ class PublicEventListAPI(APIView):
     def get(self, request):
         events = _fully_public_events_queryset(request)
 
-        events = CommonUtils.get_paginated_queryset(
+        paginated = CommonUtils.get_paginated_queryset(
             events, request,
             search_fields=['title', 'description', 'venue_city'],
             sort_fields=_PUBLIC_EVENT_SORT_FIELDS,
-            is_pagination=False,
         )
-        # Unpaginated by design, but still bounded — MAX_PAGE_SIZE caps the
-        # response so an ever-growing events table can't turn this single
-        # unauthenticated request into an unbounded payload.
-        events = events[:MAX_PAGE_SIZE]
 
         serializer = EventListItemSerializer(
-            events, many=True,
+            paginated['queryset'], many=True,
             context={'user_id': None, 'request': request},
         )
-        return CustomResponse(
-            response=serializer.data,
-        ).get_success_response()
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
 
 
 class PublicEventFeaturedAPI(APIView):
@@ -316,7 +318,7 @@ class PublicEventFeaturedAPI(APIView):
 
     Fully public listing of featured events (``is_featured=True``), same
     lifecycle/status/date/type filters as PublicEventListAPI. No authentication,
-    no campus/IG scope gating. Unpaginated, matching PublicEventListAPI.
+    no campus/IG scope gating. Paginated, matching PublicEventListAPI.
     """
     permission_classes = []
 
@@ -328,22 +330,20 @@ class PublicEventFeaturedAPI(APIView):
     def get(self, request):
         events = _fully_public_events_queryset(request, featured_only=True)
 
-        events = CommonUtils.get_paginated_queryset(
+        paginated = CommonUtils.get_paginated_queryset(
             events, request,
             search_fields=['title', 'description', 'venue_city'],
             sort_fields=_PUBLIC_EVENT_SORT_FIELDS,
-            is_pagination=False,
         )
-        # Unpaginated by design, but still bounded — see PublicEventListAPI.
-        events = events[:MAX_PAGE_SIZE]
 
         serializer = EventListItemSerializer(
-            events, many=True,
+            paginated['queryset'], many=True,
             context={'user_id': None, 'request': request},
         )
-        return CustomResponse(
-            response=serializer.data,
-        ).get_success_response()
+        return CustomResponse().paginated_response(
+            data=serializer.data,
+            pagination=paginated['pagination'],
+        )
 
 
 class PublicEventDetailAPI(APIView):

--- a/api/dashboard/events/serializers.py
+++ b/api/dashboard/events/serializers.py
@@ -438,6 +438,22 @@ class EventDetailSerializer(serializers.ModelSerializer):
         return None
 
 
+class PublicEventDetailSerializer(EventDetailSerializer):
+    """
+    Detail serializer for fully anonymous callers (GET /api/v1/public/events/<id>/).
+
+    Drops ``created_by``/``updated_by``/``co_owners`` from EventDetailSerializer —
+    those expose internal user PII (id, full_name, muid, profile_pic) that has
+    always required a valid JWT to reach via the dashboard EventDetailAPI.
+    """
+
+    class Meta(EventDetailSerializer.Meta):
+        fields = [
+            f for f in EventDetailSerializer.Meta.fields
+            if f not in ('created_by', 'updated_by', 'co_owners')
+        ]
+
+
 # ─────────────────────────────────────────────────────────────
 # EVENT WRITE  (create / update input)
 # ─────────────────────────────────────────────────────────────

--- a/api/dashboard/events/serializers.py
+++ b/api/dashboard/events/serializers.py
@@ -453,6 +453,14 @@ class PublicEventDetailSerializer(EventDetailSerializer):
             if f not in ('created_by', 'updated_by', 'co_owners')
         ]
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if not data.get('viewer_can_access_registration'):
+            data['registration_url'] = None
+            if isinstance(data.get('venue'), dict):
+                data['venue']['venue_online_link'] = None
+        return data
+
 
 # ─────────────────────────────────────────────────────────────
 # EVENT WRITE  (create / update input)

--- a/api/dashboard/karma_voucher/karma_voucher_serializer.py
+++ b/api/dashboard/karma_voucher/karma_voucher_serializer.py
@@ -170,9 +170,13 @@ class VoucherLogCreateSerializer(serializers.ModelSerializer):
         return user.id
 
     def validate_task(self, value):
-        if not TaskList.objects.filter(id=value).exists():
+        task_ids = list(TaskList.objects.filter(hashtag=value).values_list('id', flat=True)[:2])
+        if not task_ids:
             raise serializers.ValidationError("Enter a valid task")
-        return value
+        if len(task_ids) > 1:
+            raise serializers.ValidationError(
+                "Multiple tasks share this hashtag; contact an admin to resolve the duplicate.")
+        return task_ids[0]
 
     def validate_karma(self, value):
         if value <= 0:
@@ -247,9 +251,13 @@ class VoucherLogUpdateSerializer(serializers.ModelSerializer):
         return user.id
     
     def validate_new_task(self, value):
-        if not TaskList.objects.filter(id=value).exists():
+        task_ids = list(TaskList.objects.filter(hashtag=value).values_list('id', flat=True)[:2])
+        if not task_ids:
             raise serializers.ValidationError("Enter a valid task")
-        return value
+        if len(task_ids) > 1:
+            raise serializers.ValidationError(
+                "Multiple tasks share this hashtag; contact an admin to resolve the duplicate.")
+        return task_ids[0]
     
     def validate_new_karma(self, value):
         if value <= 0:


### PR DESCRIPTION
## Summary

**Public Events (`debfc765`)**
- Adds two new fully-public, unauthenticated endpoints under `/api/v1/public/events/`:
  - `GET /events/featured/` — public listing of featured events (`is_featured=True`), reusing the same lifecycle/status/date/type filters as the existing public list.
  - `GET /events/<event_id>/` — public detail view of a single event, scoped to lifecycle-public statuses (published/ongoing/completed); anything else resolves to "not found".
- Extracts the filtering logic shared by the public list and featured endpoints into `_fully_public_events_queryset`, explicitly separated from the pre-existing scope-gated `_public_events_queryset` (used by the authenticated dashboard `/events/` routes) to avoid the two queries drifting or getting confused.
- Adds `PublicEventDetailSerializer`, a stripped-down `EventDetailSerializer` that drops `created_by`/`updated_by`/`co_owners` so anonymous callers can't pull internal user PII (id, full_name, muid, profile_pic) that previously required a valid JWT to reach.
- Bounds both public list responses to `MAX_PAGE_SIZE` even though they're intentionally unpaginated, so an unauthenticated caller can't turn a growing events table into an unbounded response.
- Ignores malformed `start_date`/`end_date` query params instead of passing them straight to the ORM (previously an invalid date string would 500 the request).

**Karma Voucher task validation (`3166bfb5`)**
- `VoucherLogCreateSerializer.validate_task` and `VoucherLogUpdateSerializer.validate_new_task` (single-voucher create/update) previously required the raw `TaskList` id, while bulk-import voucher creation already accepted a task **hashtag** — an inconsistency that made the same hashtag fail validation on the single-voucher endpoints ("Enter a valid task").
- Both validators now resolve `task`/`new_task` by hashtag, matching bulk import's behavior, and return the resolved id internally so `task_id` writes are unchanged.
- Since `TaskList.hashtag` has no uniqueness constraint in the schema, both validators now detect duplicate-hashtag matches and raise "Multiple tasks share this hashtag; contact an admin to resolve the duplicate." instead of silently resolving to an arbitrary row.

## Test plan
- [ ] `GET /api/v1/public/events/featured/` returns only `is_featured=True`, lifecycle-public events, unauthenticated.
- [ ] `GET /api/v1/public/events/<event_id>/` returns detail for a published/ongoing/completed event, 404-equivalent for draft/pending/cancelled/rejected or unknown ids, and omits `created_by`/`updated_by`/`co_owners`.
- [ ] `GET /api/v1/public/events/` still works with `start_date`/`end_date` filters, including malformed date strings (no 500).
- [ ] `POST /api/v1/dashboard/karma-voucher/create/` with a valid `task` hashtag succeeds; unknown hashtag returns "Enter a valid task".
- [ ] `PATCH /api/v1/dashboard/karma-voucher/update/<voucher_id>/` with `new_task` hashtag succeeds.
- [ ] Seed two `TaskList` rows with the same hashtag and confirm both voucher endpoints return the ambiguity error instead of silently picking one.
