### PR TITLE
fix: format event type labels

### DIFF
--- a/api/dashboard/events/meta_views.py
+++ b/api/dashboard/events/meta_views.py
@@ -358,7 +358,7 @@ class EventTypesScopesAPI(APIView):
             general_message='Event types and scopes retrieved.',
             response={
                 "event_type": [
-                    {"value": v, "label": l}
+                    {"value": v, "label": l.replace("_", " ")}
                     for v, l in zip(Event.EventType.values, Event.EventType.labels)
                 ],
                 "event_scope": [

--- a/api/dashboard/events/meta_views.py
+++ b/api/dashboard/events/meta_views.py
@@ -358,7 +358,7 @@ class EventTypesScopesAPI(APIView):
             general_message='Event types and scopes retrieved.',
             response={
                 "event_type": [
-                    {"value": v, "label": l.replace("_", " ")}
+                    {"value": v, "label": l}
                     for v, l in zip(Event.EventType.values, Event.EventType.labels)
                 ],
                 "event_scope": [

--- a/api/dashboard/events/tests/test_meta_views.py
+++ b/api/dashboard/events/tests/test_meta_views.py
@@ -9,8 +9,8 @@ def api_client():
 @pytest.mark.django_db
 def test_event_types_scopes_api(api_client):
     """
-    Verify that EventTypesScopesAPI replaces underscores with spaces in
-    event_type labels, leaves values intact, and returns HTTP 200.
+    Verify that EventTypesScopesAPI returns valid event_type labels without underscores,
+    leaves values intact, and returns HTTP 200.
     """
     resp = api_client.get("/api/v1/dashboard/events/meta/event-type-scope/")
     
@@ -36,6 +36,6 @@ def test_event_types_scopes_api(api_client):
         # Labels should not contain underscores
         assert "_" not in lbl, f"Label {lbl} should not contain underscores"
         
-        # Label should exactly match original, but with underscores replaced
-        expected_label = original_type_map[val].replace("_", " ")
+        # Label should exactly match original
+        expected_label = original_type_map[val]
         assert lbl == expected_label, f"Expected label '{expected_label}', got '{lbl}'"

--- a/api/dashboard/events/tests/test_meta_views.py
+++ b/api/dashboard/events/tests/test_meta_views.py
@@ -1,0 +1,41 @@
+import pytest
+from rest_framework.test import APIClient
+from db.events import Event
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+@pytest.mark.django_db
+def test_event_types_scopes_api(api_client):
+    """
+    Verify that EventTypesScopesAPI replaces underscores with spaces in
+    event_type labels, leaves values intact, and returns HTTP 200.
+    """
+    resp = api_client.get("/api/v1/dashboard/events/meta/event-type-scope/")
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    
+    assert "response" in data
+    assert "event_type" in data["response"]
+    
+    event_types = data["response"]["event_type"]
+    assert len(event_types) > 0
+    
+    # Build dictionary of original labels for comparison
+    original_type_map = dict(zip(Event.EventType.values, Event.EventType.labels))
+    
+    for item in event_types:
+        val = item["value"]
+        lbl = item["label"]
+        
+        # Values must remain unchanged and exist in originals
+        assert val in original_type_map, f"Value {val} not found in model choices"
+        
+        # Labels should not contain underscores
+        assert "_" not in lbl, f"Label {lbl} should not contain underscores"
+        
+        # Label should exactly match original, but with underscores replaced
+        expected_label = original_type_map[val].replace("_", " ")
+        assert lbl == expected_label, f"Expected label '{expected_label}', got '{lbl}'"

--- a/db/events.py
+++ b/db/events.py
@@ -56,12 +56,12 @@ class Event(models.Model):
         CONFERENCE      = 'CONFERENCE',      'Conference'
         COMPETITION     = 'COMPETITION',     'Competition'
         IDEATHON        = 'IDEATHON',        'Ideathon'
-        CULTURAL_EVENT  = 'CULTURAL_EVENT',  'Cultural_Event'
-        SPORTS_EVENT    = 'SPORTS_EVENT',    'Sports_Event'
-        COMMUNITY_EVENT = 'COMMUNITY_EVENT', 'Community_Event'
+        CULTURAL_EVENT  = 'CULTURAL_EVENT',  'Cultural Event'
+        SPORTS_EVENT    = 'SPORTS_EVENT',    'Sports Event'
+        COMMUNITY_EVENT = 'COMMUNITY_EVENT', 'Community Event'
         EXPO            = 'EXPO',            'Expo'
-        NETWORKING_EVENT= 'NETWORKING_EVENT','Networking_Event'
-        TECH_TALK       = 'TECH_TALK',       'Tech_Talk'
+        NETWORKING_EVENT= 'NETWORKING_EVENT','Networking Event'
+        TECH_TALK       = 'TECH_TALK',       'Tech Talk'
         OTHERS          = 'OTHERS',          'Others'
 
     id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)


### PR DESCRIPTION
Updated the event type labels in the event metadata API to replace underscores with spaces for better readability, while keeping the original event type values unchanged.

Testing:
- Verified the `/api/v1/dashboard/events/meta/event-type-scope/` endpoint.
- Confirmed the API returns status code 200.
- Verified event type labels are displayed without underscores.