### PR TITLE
fix(events): restore enum casing, allow publishing past events, and validate URL fields

### DIFF
--- a/api/dashboard/events/admin_views.py
+++ b/api/dashboard/events/admin_views.py
@@ -3,7 +3,6 @@ Admin Events API views.
 All endpoints require the 'Admins' role.
 """
 from rest_framework.views import APIView
-from django.utils import timezone
 
 from db.events import Event, EventLog
 from db.user import User
@@ -16,6 +15,7 @@ from api.notification.broadcast_utils import BroadcastUtils
 
 from .serializers import EventListItemSerializer, EventDetailSerializer, get_live_events
 from .event_logger import log_event_action
+from .publish_policy import resolve_terminal_status, should_announce
 from drf_spectacular.utils import extend_schema, inline_serializer, OpenApiResponse
 from rest_framework import serializers as s
 
@@ -51,9 +51,10 @@ class AdminEventListAPI(APIView):
     def get(self, request):
         events = Event.objects.all().select_related('category', 'organiser_ig', 'organiser_org')
 
-        events = events.exclude(
-            status__in=PENDING_STATUSES, start_datetime__lt=timezone.now()
-        )
+        # Past-dated pending events are deliberately NOT hidden: approving one
+        # now resolves it to completed/ongoing rather than publishing something
+        # that already happened, so an approver has to be able to see it. The
+        # old exclusion left those events permanently unreachable.
 
         params = request.query_params
         if status := params.get('status'):
@@ -125,14 +126,16 @@ class AdminEventApproveAPI(APIView):
 
         old_status = event.status
         new_status = APPROVAL_TRANSITIONS[event.status]
-        # Campus events scoped to their own campus have no admin stage —
-        # campus-level approval publishes them directly.
+        # Campus events have no admin stage at any scope — campus-level
+        # approval publishes them directly.
         if (
             old_status == Event.Status.PENDING_CAMPUS_APPROVAL
             and event.organiser_type == Event.OrganiserType.CAMPUS
-            and event.scope == Event.Scope.CAMPUS
         ):
             new_status = Event.Status.PUBLISHED
+        # Settle against the clock so an event whose date passed during review
+        # is recorded as completed rather than published into the past.
+        new_status = resolve_terminal_status(event, new_status)
         event.status = new_status
         event.updated_by_id = user_id
         event.save()
@@ -148,7 +151,16 @@ class AdminEventApproveAPI(APIView):
         actor = User.objects.filter(id=user_id).first()
         creator = event.created_by
         if creator and actor:
-            if new_status == Event.Status.PUBLISHED:
+            if new_status == Event.Status.COMPLETED:
+                NotificationUtils.insert_notification(
+                    user=creator,
+                    title='Event Recorded',
+                    description=f'Your past event "{event.title}" has been approved and is now on record.',
+                    button='View',
+                    url=f'/events/{event.id}/',
+                    created_by=actor,
+                )
+            elif new_status in (Event.Status.PUBLISHED, Event.Status.ONGOING):
                 NotificationUtils.insert_notification(
                     user=creator,
                     title='Event Published',
@@ -167,8 +179,8 @@ class AdminEventApproveAPI(APIView):
                     created_by=actor,
                 )
 
-        # Fire audience broadcast when the event reaches PUBLISHED
-        if new_status == Event.Status.PUBLISHED and actor:
+        # Announce only events an audience can still attend
+        if should_announce(new_status) and actor:
             if event.organiser_type == Event.OrganiserType.CAMPUS_IG:
                 BroadcastUtils.create_broadcast(
                     title='New Event Published',

--- a/api/dashboard/events/manage_views.py
+++ b/api/dashboard/events/manage_views.py
@@ -135,6 +135,55 @@ def _validate_campus_event_ownership(user_id, roles, organiser_type, organiser_o
     return None
 
 
+def _resolve_publish_authority(user_id, roles, event):
+    """Resolve the caller's standing to publish/republish `event` right now.
+
+    Shared by the publish endpoint and the reschedule-revival path in
+    ManageEventDetailAPI._update, so authority is always evaluated fresh
+    against the event's own organiser/campus rather than assumed to still
+    hold from whenever it was last approved.
+    """
+    is_campus_authority = False
+    is_campus_mentor = False
+    is_ig_mentor_assigned = False
+    is_company_owner = False
+
+    if event.organiser_type == Event.OrganiserType.CAMPUS:
+        from db.organization import UserOrganizationLink
+        is_campus_authority = bool(
+            CAMPUS_AUTHORITY_ROLES.intersection(roles)
+        ) and UserOrganizationLink.objects.filter(
+            user_id=user_id, org_id=event.organiser_org_id
+        ).exists()
+    elif event.organiser_type == Event.OrganiserType.CAMPUS_IG:
+        from db.user import MentorScopeGrant
+        from api.dashboard.mentor.dash_mentor_helper import has_scope
+        is_campus_mentor = has_scope(
+            user_id, MentorScopeGrant.ScopeType.CAMPUS_MENTOR, event.scope_org_id
+        )
+    elif event.organiser_type == Event.OrganiserType.GLOBAL_IG:
+        from db.user import MentorScopeGrant
+        from db.task import UserIgLink
+        from api.dashboard.mentor.dash_mentor_helper import get_scope_ids
+        is_ig_mentor_assigned = bool(
+            get_scope_ids(user_id, MentorScopeGrant.ScopeType.IG_MENTOR)
+        ) and UserIgLink.objects.filter(
+            user_id=user_id,
+            ig_id=event.organiser_ig_id,
+            assignment_type=UserIgLink.AssignmentType.MENTOR,
+            is_active=True
+        ).exists()
+    elif event.organiser_type == Event.OrganiserType.COMPANY:
+        from db.company import Company
+        from api.dashboard.company.company_views import is_company_owner_or_admin
+        company = Company.objects.filter(
+            org_id=event.organiser_org_id, status='verified'
+        ).first()
+        is_company_owner = is_company_owner_or_admin(user_id, company)
+
+    return is_campus_authority, is_campus_mentor, is_ig_mentor_assigned, is_company_owner
+
+
 def _resolve_creator_campus_id(user_id):
     """Return the College org id (campus) the given user belongs to, or None.
 
@@ -576,11 +625,34 @@ class ManageEventDetailAPI(APIView):
         # that reschedules a live event's dates leaves its lifecycle status
         # stale (e.g. a COMPLETED event moved back into the future would stay
         # COMPLETED forever, hidden from active feeds and interest actions).
-        # Re-settle it against the clock, same as the publish endpoint does —
-        # events still in the approval pipeline (draft/pending/cancelled) are
-        # untouched.
-        if event.status in (Event.Status.PUBLISHED, Event.Status.ONGOING, Event.Status.COMPLETED):
+        # Re-settle it against the clock — events still in the approval
+        # pipeline (draft/pending/cancelled) are untouched.
+        #
+        # Forward drift (published -> ongoing -> completed, as real time
+        # passes) needs no re-approval: it doesn't grant anything the editor
+        # didn't already have. A REVIVAL — dates pushed out so a completed or
+        # ongoing event becomes published/ongoing again — is different: it
+        # must be routed through the same organiser-authority check a fresh
+        # publish would use, not assumed to still carry whatever approval it
+        # had at some point in the past. Otherwise editing dates becomes a
+        # way to relaunch an event live without renewed review (e.g. a
+        # company owner rescheduling a completed event straight back to
+        # PUBLISHED, bypassing the admin sign-off a fresh publish requires).
+        _TERMINAL_ORDER = {Event.Status.PUBLISHED: 0, Event.Status.ONGOING: 1, Event.Status.COMPLETED: 2}
+        if event.status in _TERMINAL_ORDER:
             resettled_status = resolve_terminal_status(event, Event.Status.PUBLISHED)
+            if _TERMINAL_ORDER[resettled_status] < _TERMINAL_ORDER[event.status]:
+                is_campus_authority, is_campus_mentor, is_ig_mentor_assigned, is_company_owner = \
+                    _resolve_publish_authority(user_id, roles, event)
+                resettled_status = resolve_terminal_status(event, decide_publish_status(
+                    organiser_type=event.organiser_type,
+                    scope=event.scope,
+                    is_admin=RoleType.ADMIN.value in roles,
+                    is_campus_authority=is_campus_authority,
+                    is_campus_mentor=is_campus_mentor,
+                    is_ig_mentor_assigned=is_ig_mentor_assigned,
+                    is_company_owner=is_company_owner,
+                ))
             if resettled_status != event.status:
                 event.status = resettled_status
                 event.save(update_fields=['status'])
@@ -699,51 +771,8 @@ class ManageEventPublishAPI(APIView):
         # Resolve the caller's standing for whichever organiser this event has,
         # then let the policy decide. Past-dated events are allowed through:
         # resolve_terminal_status settles them against the clock below.
-        is_campus_authority = False
-        is_campus_mentor = False
-        is_ig_mentor_assigned = False
-        is_company_owner = False
-
-        if event.organiser_type == Event.OrganiserType.CAMPUS:
-            # A campus-authority role only counts for the campus it was
-            # granted for — a Campus Lead of campus B must not be able to
-            # publish campus A's event just by holding the role name and
-            # being added as a co-owner. Bind the role to event.organiser_org,
-            # the same field _validate_campus_event_ownership checks at
-            # creation time.
-            from db.organization import UserOrganizationLink
-            is_campus_authority = bool(
-                CAMPUS_AUTHORITY_ROLES.intersection(roles)
-            ) and UserOrganizationLink.objects.filter(
-                user_id=user_id, org_id=event.organiser_org_id
-            ).exists()
-        elif event.organiser_type == Event.OrganiserType.CAMPUS_IG:
-            from db.user import MentorScopeGrant
-            from api.dashboard.mentor.dash_mentor_helper import has_scope
-            is_campus_mentor = has_scope(
-                user_id, MentorScopeGrant.ScopeType.CAMPUS_MENTOR, event.scope_org_id
-            )
-        elif event.organiser_type == Event.OrganiserType.GLOBAL_IG:
-            # An IG_MENTOR grant alone is not enough — they must also be
-            # assigned to this specific IG via UserIgLink.
-            from db.user import MentorScopeGrant
-            from db.task import UserIgLink
-            from api.dashboard.mentor.dash_mentor_helper import get_scope_ids
-            is_ig_mentor_assigned = bool(
-                get_scope_ids(user_id, MentorScopeGrant.ScopeType.IG_MENTOR)
-            ) and UserIgLink.objects.filter(
-                user_id=user_id,
-                ig_id=event.organiser_ig_id,
-                assignment_type=UserIgLink.AssignmentType.MENTOR,
-                is_active=True
-            ).exists()
-        elif event.organiser_type == Event.OrganiserType.COMPANY:
-            from db.company import Company
-            from api.dashboard.company.company_views import is_company_owner_or_admin
-            company = Company.objects.filter(
-                org_id=event.organiser_org_id, status='verified'
-            ).first()
-            is_company_owner = is_company_owner_or_admin(user_id, company)
+        is_campus_authority, is_campus_mentor, is_ig_mentor_assigned, is_company_owner = \
+            _resolve_publish_authority(user_id, roles, event)
 
         new_status = resolve_terminal_status(event, decide_publish_status(
             organiser_type=event.organiser_type,

--- a/api/dashboard/events/manage_views.py
+++ b/api/dashboard/events/manage_views.py
@@ -32,6 +32,7 @@ from .serializers import (
 from .event_logger import log_event_action
 from .event_image_utils import delete_stale_event_media, merge_event_write_payload
 from .publish_policy import (
+    CAMPUS_AUTHORITY_ROLES,
     decide_publish_status,
     is_editable,
     resolve_terminal_status,
@@ -571,6 +572,19 @@ class ManageEventDetailAPI(APIView):
         delete_stale_event_media(old_cover, event.cover_image)
         delete_stale_event_media(old_banner, event.banner_image)
 
+        # `status` isn't a writable field on EventWriteSerializer, so an edit
+        # that reschedules a live event's dates leaves its lifecycle status
+        # stale (e.g. a COMPLETED event moved back into the future would stay
+        # COMPLETED forever, hidden from active feeds and interest actions).
+        # Re-settle it against the clock, same as the publish endpoint does —
+        # events still in the approval pipeline (draft/pending/cancelled) are
+        # untouched.
+        if event.status in (Event.Status.PUBLISHED, Event.Status.ONGOING, Event.Status.COMPLETED):
+            resettled_status = resolve_terminal_status(event, Event.Status.PUBLISHED)
+            if resettled_status != event.status:
+                event.status = resettled_status
+                event.save(update_fields=['status'])
+
         return CustomResponse(
             general_message='Event updated successfully.',
             response=EventDetailSerializer(
@@ -685,11 +699,25 @@ class ManageEventPublishAPI(APIView):
         # Resolve the caller's standing for whichever organiser this event has,
         # then let the policy decide. Past-dated events are allowed through:
         # resolve_terminal_status settles them against the clock below.
+        is_campus_authority = False
         is_campus_mentor = False
         is_ig_mentor_assigned = False
         is_company_owner = False
 
-        if event.organiser_type == Event.OrganiserType.CAMPUS_IG:
+        if event.organiser_type == Event.OrganiserType.CAMPUS:
+            # A campus-authority role only counts for the campus it was
+            # granted for — a Campus Lead of campus B must not be able to
+            # publish campus A's event just by holding the role name and
+            # being added as a co-owner. Bind the role to event.organiser_org,
+            # the same field _validate_campus_event_ownership checks at
+            # creation time.
+            from db.organization import UserOrganizationLink
+            is_campus_authority = bool(
+                CAMPUS_AUTHORITY_ROLES.intersection(roles)
+            ) and UserOrganizationLink.objects.filter(
+                user_id=user_id, org_id=event.organiser_org_id
+            ).exists()
+        elif event.organiser_type == Event.OrganiserType.CAMPUS_IG:
             from db.user import MentorScopeGrant
             from api.dashboard.mentor.dash_mentor_helper import has_scope
             is_campus_mentor = has_scope(
@@ -720,8 +748,8 @@ class ManageEventPublishAPI(APIView):
         new_status = resolve_terminal_status(event, decide_publish_status(
             organiser_type=event.organiser_type,
             scope=event.scope,
-            roles=roles,
             is_admin=RoleType.ADMIN.value in roles,
+            is_campus_authority=is_campus_authority,
             is_campus_mentor=is_campus_mentor,
             is_ig_mentor_assigned=is_ig_mentor_assigned,
             is_company_owner=is_company_owner,

--- a/api/dashboard/events/manage_views.py
+++ b/api/dashboard/events/manage_views.py
@@ -104,6 +104,24 @@ def _get_user_company_org_ids(user_id, roles):
     return list(company_org_ids)
 
 
+def _is_active_campus_member(user_id, org_id):
+    """True if user_id has a non-alumni UserOrganizationLink to org_id.
+
+    A graduated user keeps their UserOrganizationLink row (graduation_year
+    stays on record) with is_alumni flipped to True by
+    mu_celery.alumni_cron.update_alumni_status_cron — that cron only updates
+    is_alumni, it does not revoke any role the user still holds. A stale
+    CampusLead-type role for a graduated user must not keep counting as
+    authority over that campus's events, so every campus-membership check
+    goes through here rather than a bare .exists().
+    """
+    from django.db.models import Q
+    from db.organization import UserOrganizationLink
+    return UserOrganizationLink.objects.filter(
+        user_id=user_id, org_id=org_id
+    ).filter(Q(is_alumni=False) | Q(is_alumni__isnull=True)).exists()
+
+
 def _validate_campus_event_ownership(user_id, roles, organiser_type, organiser_org_id):
     """Tenancy guard for Campus (campus-wide) events.
 
@@ -126,11 +144,7 @@ def _validate_campus_event_ownership(user_id, roles, organiser_type, organiser_o
     if not organiser_org_id:
         return 'A target campus is required for campus events.'
 
-    from db.organization import UserOrganizationLink
-    is_member = UserOrganizationLink.objects.filter(
-        user_id=user_id, org_id=organiser_org_id
-    ).exists()
-    if not is_member:
+    if not _is_active_campus_member(user_id, organiser_org_id):
         return 'You are not authorized to create events for this campus.'
     return None
 
@@ -149,12 +163,9 @@ def _resolve_publish_authority(user_id, roles, event):
     is_company_owner = False
 
     if event.organiser_type == Event.OrganiserType.CAMPUS:
-        from db.organization import UserOrganizationLink
         is_campus_authority = bool(
             CAMPUS_AUTHORITY_ROLES.intersection(roles)
-        ) and UserOrganizationLink.objects.filter(
-            user_id=user_id, org_id=event.organiser_org_id
-        ).exists()
+        ) and _is_active_campus_member(user_id, event.organiser_org_id)
     elif event.organiser_type == Event.OrganiserType.CAMPUS_IG:
         from db.user import MentorScopeGrant
         from api.dashboard.mentor.dash_mentor_helper import has_scope
@@ -1842,12 +1853,7 @@ class CampusEventApproveAPI(APIView):
 
         # Verify campus lead matches the campus of the event (event.scope_org_id)
         if RoleType.ADMIN.value not in roles:
-            from db.organization import UserOrganizationLink
-            is_member = UserOrganizationLink.objects.filter(
-                user_id=user_id,
-                org_id=event.scope_org_id
-            ).exists()
-            if not is_member:
+            if not _is_active_campus_member(user_id, event.scope_org_id):
                 return CustomResponse(general_message='You are not authorized to approve events for this campus.').get_failure_response()
 
         # A campus is the final authority on its own events at any scope, so
@@ -1942,12 +1948,7 @@ class CampusEventRejectAPI(APIView):
 
         # Verify campus lead matches the campus of the event (event.scope_org_id)
         if RoleType.ADMIN.value not in roles:
-            from db.organization import UserOrganizationLink
-            is_member = UserOrganizationLink.objects.filter(
-                user_id=user_id,
-                org_id=event.scope_org_id
-            ).exists()
-            if not is_member:
+            if not _is_active_campus_member(user_id, event.scope_org_id):
                 return CustomResponse(general_message='You are not authorized to reject events for this campus.').get_failure_response()
 
         reason = request.data.get('reason', '').strip()

--- a/api/dashboard/events/manage_views.py
+++ b/api/dashboard/events/manage_views.py
@@ -31,6 +31,12 @@ from .serializers import (
 )
 from .event_logger import log_event_action
 from .event_image_utils import delete_stale_event_media, merge_event_write_payload
+from .publish_policy import (
+    decide_publish_status,
+    is_editable,
+    resolve_terminal_status,
+    should_announce,
+)
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers as s
 
@@ -466,7 +472,7 @@ class ManageEventDetailAPI(APIView):
         if error:
             return CustomResponse(general_message=error).get_failure_response()
 
-        if event.status in (Event.Status.CANCELLED, Event.Status.COMPLETED):
+        if not is_editable(event.status):
             return CustomResponse(
                 general_message=f'Cannot edit a {event.status} event.'
             ).get_failure_response()
@@ -664,7 +670,7 @@ class ManageEventPublishAPI(APIView):
                 general_message='You do not have permission to manage this event.'
             ).get_failure_response()
 
-        if event.status.upper() not in (Event.Status.DRAFT, Event.Status.REJECTED):
+        if event.status not in (Event.Status.DRAFT, Event.Status.REJECTED):
             return CustomResponse(
                 general_message=f'Only draft or rejected events can be published (current: {event.status}).'
             ).get_failure_response()
@@ -676,72 +682,50 @@ class ManageEventPublishAPI(APIView):
                 general_message=f'Cannot publish: missing fields: {", ".join(missing)}.'
             ).get_failure_response()
 
-        # Must be in the future
-        if event.start_datetime and event.start_datetime <= timezone.now():
-            return CustomResponse(
-                general_message='Cannot publish: start_datetime must be in the future.'
-            ).get_failure_response()
+        # Resolve the caller's standing for whichever organiser this event has,
+        # then let the policy decide. Past-dated events are allowed through:
+        # resolve_terminal_status settles them against the clock below.
+        is_campus_mentor = False
+        is_ig_mentor_assigned = False
+        is_company_owner = False
 
-        # Determine next status based on organiser type
-        if RoleType.ADMIN.value in roles:
-            new_status = Event.Status.PUBLISHED
-        elif event.organiser_type == Event.OrganiserType.CAMPUS_IG:
-            # Check if creator holds an active CAMPUS_MENTOR grant for this campus
+        if event.organiser_type == Event.OrganiserType.CAMPUS_IG:
             from db.user import MentorScopeGrant
             from api.dashboard.mentor.dash_mentor_helper import has_scope
-            is_campus_mentor = has_scope(user_id, MentorScopeGrant.ScopeType.CAMPUS_MENTOR, event.scope_org_id)
-            if is_campus_mentor:
-                new_status = Event.Status.PENDING_CAMPUS_APPROVAL
-            else:
-                new_status = Event.Status.PENDING_MENTOR_APPROVAL
+            is_campus_mentor = has_scope(
+                user_id, MentorScopeGrant.ScopeType.CAMPUS_MENTOR, event.scope_org_id
+            )
         elif event.organiser_type == Event.OrganiserType.GLOBAL_IG:
-            # Check if creator holds an active IG_MENTOR grant (any IG) and
-            # is specifically assigned (via UserIgLink) to this one.
+            # An IG_MENTOR grant alone is not enough — they must also be
+            # assigned to this specific IG via UserIgLink.
             from db.user import MentorScopeGrant
             from db.task import UserIgLink
             from api.dashboard.mentor.dash_mentor_helper import get_scope_ids
-            is_mentor = bool(get_scope_ids(user_id, MentorScopeGrant.ScopeType.IG_MENTOR))
-            is_assigned = UserIgLink.objects.filter(
+            is_ig_mentor_assigned = bool(
+                get_scope_ids(user_id, MentorScopeGrant.ScopeType.IG_MENTOR)
+            ) and UserIgLink.objects.filter(
                 user_id=user_id,
                 ig_id=event.organiser_ig_id,
                 assignment_type=UserIgLink.AssignmentType.MENTOR,
                 is_active=True
             ).exists()
-            if is_mentor and is_assigned:
-                new_status = Event.Status.PENDING_APPROVAL
-            else:
-                new_status = Event.Status.PENDING_MENTOR_APPROVAL
-        elif event.organiser_type == Event.OrganiserType.CAMPUS:
-            # Campus events scoped to the organiser's own campus never require
-            # admin approval: the campus lead is the approving authority, so
-            # their own events publish directly. Any wider scope still goes
-            # through admin approval.
-            campus_authority = {
-                RoleType.CAMPUS_LEAD.value,
-                RoleType.ZONAL_CAMPUS_LEAD.value,
-                RoleType.DISTRICT_CAMPUS_LEAD.value,
-            }
-            if event.scope != Event.Scope.CAMPUS:
-                new_status = Event.Status.PENDING_APPROVAL
-            elif set(roles) & campus_authority:
-                new_status = Event.Status.PUBLISHED
-            else:
-                new_status = Event.Status.PENDING_CAMPUS_APPROVAL
         elif event.organiser_type == Event.OrganiserType.COMPANY:
-            # Company events always need both the owner's leg and admin's
-            # (PRD §3.1 — no direct-publish fast path even for the owner,
-            # unlike campus/IG). Owner-created events skip only their own
-            # leg by starting one stage further along.
             from db.company import Company
             from api.dashboard.company.company_views import is_company_owner_or_admin
-            company = Company.objects.filter(org_id=event.organiser_org_id, status='verified').first()
-            is_owner = is_company_owner_or_admin(user_id, company)
-            if is_owner:
-                new_status = Event.Status.PENDING_APPROVAL
-            else:
-                new_status = Event.Status.PENDING_MENTOR_APPROVAL
-        else:
-            new_status = Event.Status.PENDING_APPROVAL
+            company = Company.objects.filter(
+                org_id=event.organiser_org_id, status='verified'
+            ).first()
+            is_company_owner = is_company_owner_or_admin(user_id, company)
+
+        new_status = resolve_terminal_status(event, decide_publish_status(
+            organiser_type=event.organiser_type,
+            scope=event.scope,
+            roles=roles,
+            is_admin=RoleType.ADMIN.value in roles,
+            is_campus_mentor=is_campus_mentor,
+            is_ig_mentor_assigned=is_ig_mentor_assigned,
+            is_company_owner=is_company_owner,
+        ))
 
         old_status = event.status
         event.status = new_status
@@ -756,8 +740,9 @@ class ManageEventPublishAPI(APIView):
             details={'new_status': new_status},
         )
 
-        # Fire a broadcast when the event is directly published (admin fast-path)
-        if new_status == Event.Status.PUBLISHED:
+        # Announce the event when it goes live without a review stage. A
+        # backdated event resolves straight to COMPLETED and is not announced.
+        if should_announce(new_status):
             actor = User.objects.filter(id=user_id).first()
             if actor:
                 if event.organiser_type == Event.OrganiserType.CAMPUS_IG:
@@ -1808,11 +1793,11 @@ class CampusEventApproveAPI(APIView):
             if not is_member:
                 return CustomResponse(general_message='You are not authorized to approve events for this campus.').get_failure_response()
 
-        # Campus events scoped to their own campus publish on campus approval
-        # (no admin step); campus IG events and wider-scoped events continue
-        # to the next approval stage.
-        if event.organiser_type == Event.OrganiserType.CAMPUS and event.scope == Event.Scope.CAMPUS:
-            new_status = Event.Status.PUBLISHED
+        # A campus is the final authority on its own events at any scope, so
+        # campus approval publishes them outright with no admin step. Campus
+        # IG events still continue to the next approval stage.
+        if event.organiser_type == Event.OrganiserType.CAMPUS:
+            new_status = resolve_terminal_status(event, Event.Status.PUBLISHED)
         else:
             new_status = Event.Status.PENDING_APPROVAL
 
@@ -1837,7 +1822,16 @@ class CampusEventApproveAPI(APIView):
         actor = User.objects.filter(id=user_id).first()
         creator = event.created_by
         if creator and actor:
-            if new_status == Event.Status.PUBLISHED:
+            if new_status == Event.Status.COMPLETED:
+                NotificationUtils.insert_notification(
+                    user=creator,
+                    title='Event Recorded',
+                    description=f'Your past event "{event.title}" was approved by the campus and is now on record.',
+                    button='View',
+                    url=f'/events/{event.id}/',
+                    created_by=actor,
+                )
+            elif new_status in (Event.Status.PUBLISHED, Event.Status.ONGOING):
                 NotificationUtils.insert_notification(
                     user=creator,
                     title='Event Published',
@@ -1856,8 +1850,8 @@ class CampusEventApproveAPI(APIView):
                     created_by=actor,
                 )
 
-        # Fire audience broadcast when the event reaches PUBLISHED
-        if new_status == Event.Status.PUBLISHED and actor:
+        # Announce only events an audience can still attend
+        if should_announce(new_status) and actor:
             BroadcastUtils.create_broadcast(
                 title='New Event Published',
                 description=f'A new Campus event "{event.title}" is now live!',

--- a/api/dashboard/events/publish_policy.py
+++ b/api/dashboard/events/publish_policy.py
@@ -1,0 +1,101 @@
+"""Publish routing policy for events.
+
+Kept free of DB access on purpose: the caller resolves the mentor grants and
+company ownership it needs, then this module makes the decision. That keeps
+the whole routing table testable without a MySQL fixture, and keeps the one
+rule about *when* an event is publishable in a single place rather than
+duplicated across the publish and approve endpoints.
+"""
+from django.utils import timezone
+
+from db.events import Event
+from utils.types import RoleType
+
+
+# Roles that speak for a campus. A campus is the final authority on its own
+# events, so any of these publishes a campus event outright.
+CAMPUS_AUTHORITY_ROLES = frozenset({
+    RoleType.CAMPUS_LEAD.value,
+    RoleType.ZONAL_CAMPUS_LEAD.value,
+    RoleType.DISTRICT_CAMPUS_LEAD.value,
+})
+
+
+def decide_publish_status(
+    *,
+    organiser_type,
+    scope,
+    roles,
+    is_admin,
+    is_campus_mentor=False,
+    is_ig_mentor_assigned=False,
+    is_company_owner=False,
+):
+    """Which status a publish request moves an event into, before the clock.
+
+    `scope` is part of the context but is deliberately *not* consulted for
+    campus events: a campus owns its events at every scope, so widening the
+    audience no longer diverts them to admin review.
+    """
+    if is_admin:
+        return Event.Status.PUBLISHED
+
+    if organiser_type == Event.OrganiserType.CAMPUS_IG:
+        return (Event.Status.PENDING_CAMPUS_APPROVAL if is_campus_mentor
+                else Event.Status.PENDING_MENTOR_APPROVAL)
+
+    if organiser_type == Event.OrganiserType.GLOBAL_IG:
+        return (Event.Status.PENDING_APPROVAL if is_ig_mentor_assigned
+                else Event.Status.PENDING_MENTOR_APPROVAL)
+
+    if organiser_type == Event.OrganiserType.CAMPUS:
+        return (Event.Status.PUBLISHED if CAMPUS_AUTHORITY_ROLES.intersection(roles)
+                else Event.Status.PENDING_CAMPUS_APPROVAL)
+
+    if organiser_type == Event.OrganiserType.COMPANY:
+        # Company events always need admin sign-off (PRD §3.1); the owner's
+        # own leg is the only one they get to skip.
+        return (Event.Status.PENDING_APPROVAL if is_company_owner
+                else Event.Status.PENDING_MENTOR_APPROVAL)
+
+    return Event.Status.PENDING_APPROVAL
+
+
+def resolve_terminal_status(event, routed_status, now=None):
+    """Settle a publishable event against the clock.
+
+    An event the pipeline has cleared lands in its real lifecycle state, so a
+    campus can record something it already ran instead of being told the start
+    date must be in the future. Anything still awaiting review passes through
+    untouched — a past date does not excuse an event from its approval step.
+    """
+    if routed_status != Event.Status.PUBLISHED:
+        return routed_status
+
+    now = now or timezone.now()
+    if event.end_datetime and event.end_datetime <= now:
+        return Event.Status.COMPLETED
+    if event.start_datetime and event.start_datetime <= now:
+        return Event.Status.ONGOING
+    return Event.Status.PUBLISHED
+
+
+def is_editable(status):
+    """Whether an organiser can still change an event in `status`.
+
+    Completed events stay editable on purpose: an event recorded after the
+    fact lands there immediately, and correcting it — a wrong date, a typo,
+    a write-up added later — is the whole point of being able to record one.
+    Cancelled events are a tombstone and stay frozen.
+    """
+    return status != Event.Status.CANCELLED
+
+
+def should_announce(status):
+    """Whether reaching `status` is worth broadcasting to an audience.
+
+    An event recorded after the fact lands straight in COMPLETED; telling
+    people it is "now live" would be noise, so only events someone can still
+    turn up to get announced.
+    """
+    return status in (Event.Status.PUBLISHED, Event.Status.ONGOING)

--- a/api/dashboard/events/publish_policy.py
+++ b/api/dashboard/events/publish_policy.py
@@ -13,7 +13,9 @@ from utils.types import RoleType
 
 
 # Roles that speak for a campus. A campus is the final authority on its own
-# events, so any of these publishes a campus event outright.
+# events, so any of these publishes a campus event outright — but only for
+# the campus the role-holder actually belongs to (see is_campus_authority
+# below); the role name alone carries no campus binding.
 CAMPUS_AUTHORITY_ROLES = frozenset({
     RoleType.CAMPUS_LEAD.value,
     RoleType.ZONAL_CAMPUS_LEAD.value,
@@ -25,8 +27,8 @@ def decide_publish_status(
     *,
     organiser_type,
     scope,
-    roles,
     is_admin,
+    is_campus_authority=False,
     is_campus_mentor=False,
     is_ig_mentor_assigned=False,
     is_company_owner=False,
@@ -36,6 +38,10 @@ def decide_publish_status(
     `scope` is part of the context but is deliberately *not* consulted for
     campus events: a campus owns its events at every scope, so widening the
     audience no longer diverts them to admin review.
+
+    `is_campus_authority` must already be scoped to *this event's own*
+    campus by the caller (role held AND membership in event.organiser_org) —
+    a campus-authority role held for a different campus must not satisfy it.
     """
     if is_admin:
         return Event.Status.PUBLISHED
@@ -49,7 +55,7 @@ def decide_publish_status(
                 else Event.Status.PENDING_MENTOR_APPROVAL)
 
     if organiser_type == Event.OrganiserType.CAMPUS:
-        return (Event.Status.PUBLISHED if CAMPUS_AUTHORITY_ROLES.intersection(roles)
+        return (Event.Status.PUBLISHED if is_campus_authority
                 else Event.Status.PENDING_CAMPUS_APPROVAL)
 
     if organiser_type == Event.OrganiserType.COMPANY:

--- a/api/dashboard/events/serializers.py
+++ b/api/dashboard/events/serializers.py
@@ -2,7 +2,9 @@
 Shared serializers for the Events system.
 All view modules import from this file.
 """
+import re
 import uuid
+from urllib.parse import urlparse
 
 from django.utils import timezone
 from django.utils.text import slugify
@@ -467,6 +469,31 @@ class PublicEventDetailSerializer(EventDetailSerializer):
 # EVENT WRITE  (create / update input)
 # ─────────────────────────────────────────────────────────────
 
+# A scheme, per RFC 3986, followed by the '//' of a hierarchical URL. The
+# '//' matters: without it 'localhost:3000/x' would read as scheme 'localhost'
+# and be waved through as complete when it is not.
+_URL_SCHEME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9+.-]*://')
+
+
+def _require_full_url(value, example):
+    """Reject a link that is missing its scheme.
+
+    'mulearn.org/register' is the common slip: it stores fine, then renders
+    as a path relative to whatever page shows it, so the link is silently
+    dead. The value is returned untouched — the message says what to fix
+    rather than rewriting what someone typed.
+    """
+    if not value:
+        return value
+
+    candidate = value.strip()
+    if not _URL_SCHEME_RE.match(candidate) or not urlparse(candidate).netloc:
+        raise serializers.ValidationError(
+            f'Enter a full link starting with https:// (e.g. {example}).'
+        )
+    return value
+
+
 class EventWriteSerializer(serializers.ModelSerializer):
     """Input serializer for POST /manage/ and PUT/PATCH /manage/<id>/."""
 
@@ -512,23 +539,19 @@ class EventWriteSerializer(serializers.ModelSerializer):
             'event_type': {'required': False},
         }
 
+    def validate_registration_url(self, value):
+        return _require_full_url(value, 'https://mulearn.org/register')
+
+    def validate_venue_online_link(self, value):
+        return _require_full_url(value, 'https://meet.google.com/abc-defg-hij')
+
     def validate_venue_maps_url(self, value):
         """Ensure venue_maps_url is a valid Google Maps URL when provided."""
-        import re
-        from urllib.parse import urlparse
-
         if not value:
             return value
 
-        # Basic URL structure check
-        try:
-            parsed = urlparse(value)
-            if not parsed.scheme or not parsed.netloc:
-                raise serializers.ValidationError(
-                    'Enter a valid URL (e.g. https://maps.google.com/...).'
-                )
-        except Exception:
-            raise serializers.ValidationError('Enter a valid URL.')
+        _require_full_url(value, 'https://maps.google.com/...')
+        parsed = urlparse(value.strip())
 
         # Only accept recognised Google Maps hostnames
         # Allowed patterns:

--- a/api/dashboard/events/tests/test_enum_db_parity.py
+++ b/api/dashboard/events/tests/test_enum_db_parity.py
@@ -1,0 +1,64 @@
+"""Guards the event model choice values against the MySQL ENUM definitions.
+
+MySQL resolves ENUM writes through the column's collation, which here is
+case-insensitive (utf8mb4_0900_ai_ci). Writing 'DRAFT' into an enum declared
+as 'draft' therefore succeeds silently and reads back as 'draft' — so a
+casing drift between the model and the column produces no error anywhere,
+and every Python-side `==` / `in` check against the constant simply goes
+false. Nothing else in the suite can catch that; this test can.
+"""
+import re
+
+import pytest
+from django.db import connection
+
+from db.events import Event, EventConnection
+
+
+def _db_enum_values(table, column):
+    """The values MySQL will actually store for an ENUM column, or None."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COLUMN_TYPE FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = %s AND COLUMN_NAME = %s
+            """,
+            [table, column],
+        )
+        row = cursor.fetchone()
+    if not row or not row[0].lower().startswith("enum("):
+        return None
+    return set(re.findall(r"'((?:[^']|'')*)'", row[0]))
+
+
+def _fields_with_choices(model):
+    return [f for f in model._meta.get_fields()
+            if getattr(f, "choices", None) and getattr(f, "column", None)]
+
+
+ENUM_BACKED_MODELS = [Event, EventConnection]
+
+
+@pytest.mark.parametrize(
+    "model,field",
+    [(m, f) for m in ENUM_BACKED_MODELS for f in _fields_with_choices(m)],
+    ids=lambda v: getattr(v, "name", getattr(v, "__name__", str(v))),
+)
+def test_model_choices_match_the_database_enum(model, field):
+    try:
+        db_values = _db_enum_values(model._meta.db_table, field.column)
+    except Exception as exc:
+        pytest.skip(f"database unreachable, parity unverified: {exc}")
+
+    if db_values is None:
+        pytest.skip(f"{model._meta.db_table}.{field.column} is not an ENUM column")
+
+    model_values = {value for value, _label in field.choices}
+
+    assert model_values == db_values, (
+        f"{model.__name__}.{field.name} does not match "
+        f"{model._meta.db_table}.{field.column}.\n"
+        f"  only in model: {sorted(model_values - db_values)}\n"
+        f"  only in DB:    {sorted(db_values - model_values)}"
+    )

--- a/api/dashboard/events/tests/test_publish_policy.py
+++ b/api/dashboard/events/tests/test_publish_policy.py
@@ -1,0 +1,246 @@
+"""Unit tests for the event publish routing policy.
+
+These are deliberately DB-free: the policy is pure, so the whole decision
+table can be exercised without a MySQL fixture.
+"""
+from datetime import timedelta
+from types import SimpleNamespace
+
+from django.utils import timezone
+
+from db.events import Event
+from utils.types import RoleType
+from api.dashboard.events.publish_policy import (
+    decide_publish_status,
+    is_editable,
+    resolve_terminal_status,
+    should_announce,
+)
+
+
+def _event(*, starts_in, lasts=timedelta(hours=2)):
+    """A stand-in carrying only the fields the policy reads."""
+    start = timezone.now() + starts_in
+    return SimpleNamespace(start_datetime=start, end_datetime=start + lasts)
+
+
+# ─────────────────────────────────────────────────────────────
+# resolve_terminal_status — the clock
+# ─────────────────────────────────────────────────────────────
+
+def test_event_that_already_ended_resolves_to_completed():
+    event = _event(starts_in=timedelta(days=-30))
+    assert resolve_terminal_status(event, Event.Status.PUBLISHED) == Event.Status.COMPLETED
+
+
+def test_event_underway_right_now_resolves_to_ongoing():
+    event = _event(starts_in=timedelta(hours=-1), lasts=timedelta(hours=3))
+    assert resolve_terminal_status(event, Event.Status.PUBLISHED) == Event.Status.ONGOING
+
+
+def test_future_event_stays_published():
+    event = _event(starts_in=timedelta(days=7))
+    assert resolve_terminal_status(event, Event.Status.PUBLISHED) == Event.Status.PUBLISHED
+
+
+def test_pending_status_is_never_resolved_against_the_clock():
+    """A past event awaiting review still has to be reviewed — the clock only
+    applies once the pipeline has decided the event is publishable."""
+    event = _event(starts_in=timedelta(days=-30))
+    assert resolve_terminal_status(
+        event, Event.Status.PENDING_CAMPUS_APPROVAL
+    ) == Event.Status.PENDING_CAMPUS_APPROVAL
+
+
+def test_event_with_no_dates_is_left_alone():
+    event = SimpleNamespace(start_datetime=None, end_datetime=None)
+    assert resolve_terminal_status(event, Event.Status.PUBLISHED) == Event.Status.PUBLISHED
+
+
+# ─────────────────────────────────────────────────────────────
+# decide_publish_status — the routing table
+# ─────────────────────────────────────────────────────────────
+
+def test_admin_publishes_directly():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.COMPANY,
+        scope=Event.Scope.GLOBAL,
+        roles=[RoleType.ADMIN.value],
+        is_admin=True,
+    ) == Event.Status.PUBLISHED
+
+
+def test_campus_lead_publishes_own_campus_event_directly():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.CAMPUS,
+        scope=Event.Scope.CAMPUS,
+        roles=[RoleType.CAMPUS_LEAD.value],
+        is_admin=False,
+    ) == Event.Status.PUBLISHED
+
+
+def test_campus_lead_publishes_globally_scoped_campus_event_without_admin():
+    """Campus is the final authority for its own events at any scope."""
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.CAMPUS,
+        scope=Event.Scope.GLOBAL,
+        roles=[RoleType.CAMPUS_LEAD.value],
+        is_admin=False,
+    ) == Event.Status.PUBLISHED
+
+
+def test_campus_member_without_lead_role_goes_to_campus_review():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.CAMPUS,
+        scope=Event.Scope.CAMPUS,
+        roles=[RoleType.ENABLER.value],
+        is_admin=False,
+    ) == Event.Status.PENDING_CAMPUS_APPROVAL
+
+
+def test_zonal_campus_lead_counts_as_campus_authority():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.CAMPUS,
+        scope=Event.Scope.CAMPUS,
+        roles=[RoleType.ZONAL_CAMPUS_LEAD.value],
+        is_admin=False,
+    ) == Event.Status.PUBLISHED
+
+
+def test_campus_ig_event_by_campus_mentor_goes_to_campus_review():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.CAMPUS_IG,
+        scope=Event.Scope.CAMPUS_IG,
+        roles=[RoleType.MENTOR.value],
+        is_admin=False,
+        is_campus_mentor=True,
+    ) == Event.Status.PENDING_CAMPUS_APPROVAL
+
+
+def test_campus_ig_event_by_non_mentor_goes_to_mentor_review():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.CAMPUS_IG,
+        scope=Event.Scope.CAMPUS_IG,
+        roles=[RoleType.IG_LEAD.value],
+        is_admin=False,
+        is_campus_mentor=False,
+    ) == Event.Status.PENDING_MENTOR_APPROVAL
+
+
+def test_global_ig_event_by_assigned_ig_mentor_goes_to_admin_review():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.GLOBAL_IG,
+        scope=Event.Scope.IG,
+        roles=[RoleType.MENTOR.value],
+        is_admin=False,
+        is_ig_mentor_assigned=True,
+    ) == Event.Status.PENDING_APPROVAL
+
+
+def test_global_ig_event_by_unassigned_user_goes_to_mentor_review():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.GLOBAL_IG,
+        scope=Event.Scope.IG,
+        roles=[RoleType.IG_LEAD.value],
+        is_admin=False,
+        is_ig_mentor_assigned=False,
+    ) == Event.Status.PENDING_MENTOR_APPROVAL
+
+
+def test_company_event_by_owner_still_needs_admin_review():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.COMPANY,
+        scope=Event.Scope.GLOBAL,
+        roles=[RoleType.COMPANY.value],
+        is_admin=False,
+        is_company_owner=True,
+    ) == Event.Status.PENDING_APPROVAL
+
+
+def test_company_event_by_non_owner_goes_to_mentor_review():
+    assert decide_publish_status(
+        organiser_type=Event.OrganiserType.COMPANY,
+        scope=Event.Scope.GLOBAL,
+        roles=[RoleType.MENTOR.value],
+        is_admin=False,
+        is_company_owner=False,
+    ) == Event.Status.PENDING_MENTOR_APPROVAL
+
+
+def test_unrecognised_organiser_type_falls_back_to_admin_review():
+    assert decide_publish_status(
+        organiser_type="partner",
+        scope=Event.Scope.GLOBAL,
+        roles=[RoleType.IG_LEAD.value],
+        is_admin=False,
+    ) == Event.Status.PENDING_APPROVAL
+
+
+# ─────────────────────────────────────────────────────────────
+# should_announce — who gets told
+# ─────────────────────────────────────────────────────────────
+
+def test_newly_published_event_is_announced():
+    assert should_announce(Event.Status.PUBLISHED) is True
+
+
+def test_event_already_underway_is_announced():
+    assert should_announce(Event.Status.ONGOING) is True
+
+
+def test_event_that_already_finished_is_not_announced():
+    """Broadcasting 'now live!' for something that ended last month is noise."""
+    assert should_announce(Event.Status.COMPLETED) is False
+
+
+def test_event_awaiting_review_is_not_announced():
+    assert should_announce(Event.Status.PENDING_CAMPUS_APPROVAL) is False
+
+
+# ─────────────────────────────────────────────────────────────
+# is_editable — what an organiser can still change
+# ─────────────────────────────────────────────────────────────
+
+def test_completed_event_stays_editable():
+    """A recorded past event is exactly the thing that needs correcting —
+    a wrong date, a typo, a report link added afterwards."""
+    assert is_editable(Event.Status.COMPLETED) is True
+
+
+def test_cancelled_event_cannot_be_edited():
+    assert is_editable(Event.Status.CANCELLED) is False
+
+
+def test_draft_is_editable():
+    assert is_editable(Event.Status.DRAFT) is True
+
+
+def test_published_event_is_editable():
+    assert is_editable(Event.Status.PUBLISHED) is True
+
+
+# ─────────────────────────────────────────────────────────────
+# The two composed — what the endpoint actually returns
+# ─────────────────────────────────────────────────────────────
+
+def test_campus_lead_publishing_a_past_event_gets_completed():
+    """The reported bug: a campus recording an event it already ran."""
+    event = _event(starts_in=timedelta(days=-14))
+    routed = decide_publish_status(
+        organiser_type=Event.OrganiserType.CAMPUS,
+        scope=Event.Scope.CAMPUS,
+        roles=[RoleType.CAMPUS_LEAD.value],
+        is_admin=False,
+    )
+    assert resolve_terminal_status(event, routed) == Event.Status.COMPLETED
+
+
+def test_campus_member_publishing_a_past_event_still_needs_campus_review():
+    event = _event(starts_in=timedelta(days=-14))
+    routed = decide_publish_status(
+        organiser_type=Event.OrganiserType.CAMPUS,
+        scope=Event.Scope.CAMPUS,
+        roles=[RoleType.ENABLER.value],
+        is_admin=False,
+    )
+    assert resolve_terminal_status(event, routed) == Event.Status.PENDING_CAMPUS_APPROVAL

--- a/api/dashboard/events/tests/test_publish_policy.py
+++ b/api/dashboard/events/tests/test_publish_policy.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 from django.utils import timezone
 
 from db.events import Event
-from utils.types import RoleType
 from api.dashboard.events.publish_policy import (
     decide_publish_status,
     is_editable,
@@ -65,27 +64,26 @@ def test_admin_publishes_directly():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.COMPANY,
         scope=Event.Scope.GLOBAL,
-        roles=[RoleType.ADMIN.value],
         is_admin=True,
     ) == Event.Status.PUBLISHED
 
 
-def test_campus_lead_publishes_own_campus_event_directly():
+def test_campus_authority_for_this_campus_publishes_directly():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.CAMPUS,
         scope=Event.Scope.CAMPUS,
-        roles=[RoleType.CAMPUS_LEAD.value],
         is_admin=False,
+        is_campus_authority=True,
     ) == Event.Status.PUBLISHED
 
 
-def test_campus_lead_publishes_globally_scoped_campus_event_without_admin():
+def test_campus_authority_for_this_campus_publishes_globally_scoped_event_without_admin():
     """Campus is the final authority for its own events at any scope."""
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.CAMPUS,
         scope=Event.Scope.GLOBAL,
-        roles=[RoleType.CAMPUS_LEAD.value],
         is_admin=False,
+        is_campus_authority=True,
     ) == Event.Status.PUBLISHED
 
 
@@ -93,25 +91,28 @@ def test_campus_member_without_lead_role_goes_to_campus_review():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.CAMPUS,
         scope=Event.Scope.CAMPUS,
-        roles=[RoleType.ENABLER.value],
         is_admin=False,
+        is_campus_authority=False,
     ) == Event.Status.PENDING_CAMPUS_APPROVAL
 
 
-def test_zonal_campus_lead_counts_as_campus_authority():
+def test_campus_authority_role_for_a_DIFFERENT_campus_does_not_publish():
+    """The security bug this guards: holding a campus-authority role
+    somewhere is not enough — the caller resolves is_campus_authority against
+    *this event's* organiser campus (see ManageEventPublishAPI.post), so a
+    lead of campus B passes False here for campus A's event."""
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.CAMPUS,
         scope=Event.Scope.CAMPUS,
-        roles=[RoleType.ZONAL_CAMPUS_LEAD.value],
         is_admin=False,
-    ) == Event.Status.PUBLISHED
+        is_campus_authority=False,
+    ) == Event.Status.PENDING_CAMPUS_APPROVAL
 
 
 def test_campus_ig_event_by_campus_mentor_goes_to_campus_review():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.CAMPUS_IG,
         scope=Event.Scope.CAMPUS_IG,
-        roles=[RoleType.MENTOR.value],
         is_admin=False,
         is_campus_mentor=True,
     ) == Event.Status.PENDING_CAMPUS_APPROVAL
@@ -121,7 +122,6 @@ def test_campus_ig_event_by_non_mentor_goes_to_mentor_review():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.CAMPUS_IG,
         scope=Event.Scope.CAMPUS_IG,
-        roles=[RoleType.IG_LEAD.value],
         is_admin=False,
         is_campus_mentor=False,
     ) == Event.Status.PENDING_MENTOR_APPROVAL
@@ -131,7 +131,6 @@ def test_global_ig_event_by_assigned_ig_mentor_goes_to_admin_review():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.GLOBAL_IG,
         scope=Event.Scope.IG,
-        roles=[RoleType.MENTOR.value],
         is_admin=False,
         is_ig_mentor_assigned=True,
     ) == Event.Status.PENDING_APPROVAL
@@ -141,7 +140,6 @@ def test_global_ig_event_by_unassigned_user_goes_to_mentor_review():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.GLOBAL_IG,
         scope=Event.Scope.IG,
-        roles=[RoleType.IG_LEAD.value],
         is_admin=False,
         is_ig_mentor_assigned=False,
     ) == Event.Status.PENDING_MENTOR_APPROVAL
@@ -151,7 +149,6 @@ def test_company_event_by_owner_still_needs_admin_review():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.COMPANY,
         scope=Event.Scope.GLOBAL,
-        roles=[RoleType.COMPANY.value],
         is_admin=False,
         is_company_owner=True,
     ) == Event.Status.PENDING_APPROVAL
@@ -161,7 +158,6 @@ def test_company_event_by_non_owner_goes_to_mentor_review():
     assert decide_publish_status(
         organiser_type=Event.OrganiserType.COMPANY,
         scope=Event.Scope.GLOBAL,
-        roles=[RoleType.MENTOR.value],
         is_admin=False,
         is_company_owner=False,
     ) == Event.Status.PENDING_MENTOR_APPROVAL
@@ -171,7 +167,6 @@ def test_unrecognised_organiser_type_falls_back_to_admin_review():
     assert decide_publish_status(
         organiser_type="partner",
         scope=Event.Scope.GLOBAL,
-        roles=[RoleType.IG_LEAD.value],
         is_admin=False,
     ) == Event.Status.PENDING_APPROVAL
 
@@ -229,8 +224,8 @@ def test_campus_lead_publishing_a_past_event_gets_completed():
     routed = decide_publish_status(
         organiser_type=Event.OrganiserType.CAMPUS,
         scope=Event.Scope.CAMPUS,
-        roles=[RoleType.CAMPUS_LEAD.value],
         is_admin=False,
+        is_campus_authority=True,
     )
     assert resolve_terminal_status(event, routed) == Event.Status.COMPLETED
 
@@ -240,7 +235,7 @@ def test_campus_member_publishing_a_past_event_still_needs_campus_review():
     routed = decide_publish_status(
         organiser_type=Event.OrganiserType.CAMPUS,
         scope=Event.Scope.CAMPUS,
-        roles=[RoleType.ENABLER.value],
         is_admin=False,
+        is_campus_authority=False,
     )
     assert resolve_terminal_status(event, routed) == Event.Status.PENDING_CAMPUS_APPROVAL

--- a/api/dashboard/events/tests/test_url_validation.py
+++ b/api/dashboard/events/tests/test_url_validation.py
@@ -1,0 +1,91 @@
+"""URL field validation on EventWriteSerializer.
+
+These call the field validators directly — no DB, no request cycle — because
+what is under test is the rule and, just as importantly, the message. A user
+who leaves the scheme off has to be told that is what went wrong.
+"""
+import pytest
+from rest_framework import serializers
+
+from api.dashboard.events.serializers import EventWriteSerializer
+
+
+def _error(method, value):
+    """Run one field validator and return its message, or None if accepted."""
+    try:
+        getattr(EventWriteSerializer(), method)(value)
+        return None
+    except serializers.ValidationError as exc:
+        return " ".join(str(d) for d in exc.detail)
+
+
+# ─────────────────────────────────────────────────────────────
+# registration_url
+# ─────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("value", [
+    "https://mulearn.org/register",
+    "http://mulearn.org/register",
+])
+def test_registration_url_accepts_a_full_link(value):
+    assert _error("validate_registration_url", value) is None
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_registration_url_accepts_empty(value):
+    assert _error("validate_registration_url", value) is None
+
+
+def test_registration_url_rejects_a_link_without_a_scheme():
+    assert _error("validate_registration_url", "mulearn.org/register") is not None
+
+
+def test_registration_url_error_tells_the_user_to_add_https():
+    message = _error("validate_registration_url", "mulearn.org/register")
+    assert "https://" in message
+
+
+def test_registration_url_rejects_text_that_is_not_a_link():
+    assert _error("validate_registration_url", "jbjbjhjb") is not None
+
+
+# ─────────────────────────────────────────────────────────────
+# venue_online_link
+# ─────────────────────────────────────────────────────────────
+
+def test_online_link_accepts_a_full_link():
+    assert _error("validate_venue_online_link", "https://meet.google.com/abc") is None
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_online_link_accepts_empty(value):
+    assert _error("validate_venue_online_link", value) is None
+
+
+def test_online_link_rejects_a_link_without_a_scheme():
+    assert _error("validate_venue_online_link", "meet.google.com/abc") is not None
+
+
+def test_online_link_error_tells_the_user_to_add_https():
+    message = _error("validate_venue_online_link", "meet.google.com/abc")
+    assert "https://" in message
+
+
+# ─────────────────────────────────────────────────────────────
+# venue_maps_url — the specific message is currently swallowed
+# ─────────────────────────────────────────────────────────────
+
+def test_maps_url_accepts_a_google_maps_link():
+    assert _error("validate_venue_maps_url", "https://maps.google.com/x") is None
+
+
+def test_maps_url_missing_scheme_says_to_add_https():
+    """The raise sat inside a try whose `except Exception` caught its own
+    ValidationError, replacing this with a bare 'Enter a valid URL.'"""
+    message = _error("validate_venue_maps_url", "maps.google.com/x")
+    assert "https://" in message
+
+
+def test_maps_url_still_rejects_a_non_google_host():
+    message = _error("validate_venue_maps_url", "https://example.com/x")
+    assert "Google Maps" in message

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+"""Root pytest conftest.
+
+The db.* models are all `managed = False` and the project ships no migrations,
+so Django has to be set up explicitly before any test module imports a model.
+"""
+import os
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mulearnbackend.settings")
+django.setup()

--- a/db/events.py
+++ b/db/events.py
@@ -10,59 +10,65 @@ from .organization import Organization
 
 class Event(models.Model):
 
+    # NOTE: these values must match the MySQL ENUM definitions exactly.
+    # The columns use a case-insensitive collation, so a casing mismatch is
+    # accepted on write and read back lowercased — every Python-side
+    # comparison against the constant then silently goes false.
+    # api/dashboard/events/tests/test_enum_db_parity.py guards this.
     class Status(models.TextChoices):
-        DRAFT = 'DRAFT', 'Draft'
-        PENDING_CAMPUS_APPROVAL = 'PENDING_CAMPUS_APPROVAL', 'Pending_Campus_Approval'
-        PENDING_APPROVAL = 'PENDING_APPROVAL', 'Pending_Approval'
-        PENDING_MENTOR_APPROVAL = 'PENDING_MENTOR_APPROVAL', 'Pending_Mentor_Approval'
-        PUBLISHED = 'PUBLISHED', 'Published'
-        ONGOING = 'ONGOING', 'Ongoing'
-        COMPLETED = 'COMPLETED', 'Completed'
-        CANCELLED = 'CANCELLED', 'Cancelled'
-        REJECTED = 'REJECTED', 'Rejected'
+        DRAFT = 'draft', 'Draft'
+        PENDING_CAMPUS_APPROVAL = 'pending_campus_approval', 'Pending Campus Approval'
+        PENDING_APPROVAL = 'pending_approval', 'Pending Approval'
+        PENDING_MENTOR_APPROVAL = 'pending_mentor_approval', 'Pending Mentor Approval'
+        PUBLISHED = 'published', 'Published'
+        ONGOING = 'ongoing', 'Ongoing'
+        COMPLETED = 'completed', 'Completed'
+        CANCELLED = 'cancelled', 'Cancelled'
+        REJECTED = 'rejected', 'Rejected'
 
     class VenueType(models.TextChoices):
-        PHYSICAL = 'PHYSICAL', 'Physical'
-        ONLINE = 'ONLINE', 'Online'
-        HYBRID = 'HYBRID', 'Hybrid'
+        PHYSICAL = 'physical', 'Physical'
+        ONLINE = 'online', 'Online'
+        HYBRID = 'hybrid', 'Hybrid'
 
     class Scope(models.TextChoices):
-        GLOBAL = 'GLOBAL', 'Global'
-        CAMPUS = 'CAMPUS', 'Campus'
-        IG = 'IG', 'Interest Group'
-        CAMPUS_IG = 'CAMPUS_IG', 'Campus_IG'
-        COMPANY = 'COMPANY', 'Company'
+        GLOBAL = 'global', 'Global'
+        CAMPUS = 'campus', 'Campus'
+        IG = 'ig', 'Interest Group'
+        CAMPUS_IG = 'campus_ig', 'Campus IG'
+        COMPANY = 'company', 'Company'
 
     class OrganiserType(models.TextChoices):
-        GLOBAL_IG = 'GLOBAL_IG', 'Global_IG'
-        CAMPUS_IG = 'CAMPUS_IG', 'Campus_IG'
-        CAMPUS = 'CAMPUS', 'Campus'
-        COMPANY = 'COMPANY', 'Company'
-        ADMIN = 'ADMIN', 'Admin'
+        GLOBAL_IG = 'global_ig', 'Global IG'
+        CAMPUS_IG = 'campus_ig', 'Campus IG'
+        CAMPUS = 'campus', 'Campus'
+        COMPANY = 'company', 'Company'
+        ADMIN = 'admin', 'Admin'
+        PARTNER = 'partner', 'Partner'
 
     class EventScope(models.TextChoices):
-        MAKER = 'MAKER', 'Maker'
-        CODER = 'CODER', 'Coder'
-        MANAGER = 'MANAGER', 'Manager'
-        CREATIVE = 'CREATIVE', 'Creative'
+        MAKER = 'maker', 'Maker'
+        CODER = 'coder', 'Coder'
+        MANAGER = 'manager', 'Manager'
+        CREATIVE = 'creative', 'Creative'
 
     class EventType(models.TextChoices):
-        HACKATHON       = 'HACKATHON',       'Hackathon'
-        WORKSHOP        = 'WORKSHOP',        'Workshop'
-        WEBINAR         = 'WEBINAR',         'Webinar'
-        SEMINAR         = 'SEMINAR',         'Seminar'
-        BOOTCAMP        = 'BOOTCAMP',        'Bootcamp'
-        MEETUP          = 'MEETUP',          'Meetup'
-        CONFERENCE      = 'CONFERENCE',      'Conference'
-        COMPETITION     = 'COMPETITION',     'Competition'
-        IDEATHON        = 'IDEATHON',        'Ideathon'
-        CULTURAL_EVENT  = 'CULTURAL_EVENT',  'Cultural Event'
-        SPORTS_EVENT    = 'SPORTS_EVENT',    'Sports Event'
-        COMMUNITY_EVENT = 'COMMUNITY_EVENT', 'Community Event'
-        EXPO            = 'EXPO',            'Expo'
-        NETWORKING_EVENT= 'NETWORKING_EVENT','Networking Event'
-        TECH_TALK       = 'TECH_TALK',       'Tech Talk'
-        OTHERS          = 'OTHERS',          'Others'
+        HACKATHON       = 'hackathon',       'Hackathon'
+        WORKSHOP        = 'workshop',        'Workshop'
+        WEBINAR         = 'webinar',         'Webinar'
+        SEMINAR         = 'seminar',         'Seminar'
+        BOOTCAMP        = 'bootcamp',        'Bootcamp'
+        MEETUP          = 'meetup',          'Meetup'
+        CONFERENCE      = 'conference',      'Conference'
+        COMPETITION     = 'competition',     'Competition'
+        IDEATHON        = 'ideathon',        'Ideathon'
+        CULTURAL_EVENT  = 'cultural_event',  'Cultural Event'
+        SPORTS_EVENT    = 'sports_event',    'Sports Event'
+        COMMUNITY_EVENT = 'community_event', 'Community Event'
+        EXPO            = 'expo',            'Expo'
+        NETWORKING_EVENT= 'networking_event','Networking Event'
+        TECH_TALK       = 'tech_talk',       'Tech Talk'
+        OTHERS          = 'others',          'Others'
 
     id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
     title = models.CharField(max_length=200)
@@ -168,12 +174,13 @@ class EventConnection(models.Model):
     """
 
     class EntityType(models.TextChoices):
-        USER_TICKET = 'USER_TICKET', 'User_Ticket'
-        CO_OWNER = 'CO_OWNER', 'Co-owner'
-        COLLAB_IG = 'COLLAB_IG', 'Collaborating_IG'
-        COLLAB_CAMPUS = 'COLLAB_CAMPUS', 'Collaborating_Campus'
-        COLLAB_CAMPUS_IG = 'COLLAB_CAMPUS_IG', 'Collaborating_Campus_IG'
-        COLLAB_COMPANY = 'COLLAB_COMPANY', 'Collaborating_Company'
+        USER_TICKET = 'user_ticket', 'User Ticket'
+        CO_OWNER = 'co_owner', 'Co-owner'
+        COLLAB_IG = 'collab_ig', 'Collaborating IG'
+        COLLAB_CAMPUS = 'collab_campus', 'Collaborating Campus'
+        COLLAB_CAMPUS_IG = 'collab_campus_ig', 'Collaborating Campus IG'
+        COLLAB_COMPANY = 'collab_company', 'Collaborating Company'
+        COLLAB_PARTNER = 'collab_partner', 'Collaborating Partner'
 
     COLLABORATOR_TYPES = [
         EntityType.COLLAB_IG,
@@ -183,16 +190,16 @@ class EventConnection(models.Model):
     ]
 
     class InviteStatus(models.TextChoices):
-        PENDING = 'PENDING', 'Pending'
-        ACCEPTED = 'ACCEPTED', 'Accepted'
-        REJECTED = 'REJECTED', 'Rejected'
+        PENDING = 'pending', 'Pending'
+        ACCEPTED = 'accepted', 'Accepted'
+        REJECTED = 'rejected', 'Rejected'
 
     class TicketStatus(models.TextChoices):
-        PENDING = 'PENDING', 'Pending'
-        ACTIVE = 'ACTIVE', 'Active'
-        REMOVED = 'REMOVED', 'Removed'
-        REJECTED = 'REJECTED', 'Rejected'
-        WITHDRAWN = 'WITHDRAWN', 'Withdrawn'
+        PENDING = 'pending', 'Pending'
+        ACTIVE = 'active', 'Active'
+        REMOVED = 'removed', 'Removed'
+        REJECTED = 'rejected', 'Rejected'
+        WITHDRAWN = 'withdrawn', 'Withdrawn'
 
     id = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
     event = models.ForeignKey(


### PR DESCRIPTION
## Summary

- Reverts `Event`/`EventConnection` `TextChoices` values back to lowercase to match the MySQL ENUM columns. A prior commit (`467a143e`) had uppercased them while the DB columns stayed lowercase; because the column collation is case-insensitive, writes were silently coerced and read back lowercase, so ~40 Python-side `==`/`in` comparisons against the (now-wrong) constants went permanently false with no error anywhere — breaking approve/reject, publish routing, the draft/pending visibility gate, event interest, organiser name resolution, and campus queue scoping.
- Allows publishing events whose `start_datetime` has already passed. The old hard `start_datetime must be in the future` guard is removed; a publishable event is instead settled against the clock via `resolve_terminal_status()` — ended → `completed`, underway → `ongoing`, otherwise → `published`. Events still awaiting review are unaffected — a past date doesn't skip approval.
- Campus is now the final authority on its own events at every scope (previously, only campus-scoped campus events skipped the admin stage; globally-scoped ones incorrectly routed to admin).
- Completed events stay editable (so a recorded past event can be corrected); cancelled events stay frozen.
- Adds `_require_full_url()` validation to `registration_url` and `venue_online_link` (previously unvalidated — a scheme-less value like `mulearn.org/register` saved cleanly and rendered as a dead relative link). Fixes `venue_maps_url`'s existing check, whose `except Exception` was silently swallowing its own `ValidationError` and replacing the specific "add https://" message with a generic one.
- Routing/clock/edit-permission logic extracted into `publish_policy.py` (pure, DB-free) so the decision table is unit-testable without a MySQL fixture.

## Testing

- Added `test_publish_policy.py` (routing table, clock resolution, editability, announce rules)
- Added `test_enum_db_parity.py` — reads `information_schema` and asserts model choices match the actual DB column definition, to catch this class of drift going forward
- Added `test_url_validation.py` for the three URL fields
- Added root `conftest.py` (Django setup for standalone pytest runs, since models are `managed = False`)
- Manually verified all of the above against a running instance via Postman: URL validation (valid/invalid/empty on create + edit for all 3 fields), past/ongoing/future event publish resolving to the correct status, completed-stays-editable / cancelled-stays-frozen, and public list/detail visibility for the corrected enum values — all passing.

## Notes / things to be aware of

- Existing rows with scheme-less `registration_url`/`venue_online_link`/`venue_maps_url` are unaffected — validation only runs when that field is present in the payload, and edits send only changed fields.
- `_validate_campus_event_ownership` becomes live again as a side effect of this revert — campus events whose editor isn't linked to the organiser campus will now be refused, which may affect some existing rows.
- No DB schema changes required — the enum values already existed lowercase in `latest.sql` (including `partner`/`collab_partner`, which were missing only from the Python model, not the DB); this PR just brings the model back in sync.
