### PR TITLE
Add descriptions to event metadata

### DIFF
--- a/api/dashboard/events/meta_views.py
+++ b/api/dashboard/events/meta_views.py
@@ -193,7 +193,7 @@ class OrganizerOptionsAPI(APIView):
                     'id': company.org.id,
                     'title': company.org.title,
                 }
-                    
+
         if RoleType.MENTOR.value in roles:
             from db.user import MentorScopeGrant
             from db.task import UserIgLink
@@ -348,21 +348,69 @@ class EventTypesScopesAPI(APIView):
         responses={200: inline_serializer(
             name='EventTypesScopesResponse',
             fields={
-                'event_type': s.ListField(child=s.CharField()),
-                'event_scope': s.ListField(child=s.CharField()),
+                'event_type': s.ListField(child=inline_serializer(
+                    name='EventTypeItem',
+                    fields={
+                        'value': s.CharField(),
+                        'label': s.CharField(),
+                        'description': s.CharField(),
+                    }
+                )),
+                'event_scope': s.ListField(child=inline_serializer(
+                    name='EventScopeItem',
+                    fields={
+                        'value': s.CharField(),
+                        'label': s.CharField(),
+                        'description': s.CharField(),
+                    }
+                )),
             }
         )},
     )
     def get(self, request):
+        type_descriptions = {
+            Event.EventType.HACKATHON.value: 'An intensive, collaborative coding event focused on building software projects.',
+            Event.EventType.WORKSHOP.value: 'An interactive, hands-on session focusing on learning specific skills or techniques.',
+            Event.EventType.WEBINAR.value: 'An online educational presentation or seminar.',
+            Event.EventType.SEMINAR.value: 'A formal presentation or educational session on a specific topic.',
+            Event.EventType.BOOTCAMP.value: 'A short, intensive training program designed to teach practical skills quickly.',
+            Event.EventType.MEETUP.value: 'An informal gathering of individuals with a shared interest or profession.',
+            Event.EventType.CONFERENCE.value: 'A formal meeting for discussion and presentations within a specific field.',
+            Event.EventType.COMPETITION.value: 'An event where individuals or teams compete against each other for a prize.',
+            Event.EventType.IDEATHON.value: 'A short, intensive brainstorming event that focuses on generating new ideas.',
+            Event.EventType.CULTURAL_EVENT.value: 'An event celebrating arts, music, or other cultural activities.',
+            Event.EventType.SPORTS_EVENT.value: 'An athletic competition or physical activity event.',
+            Event.EventType.COMMUNITY_EVENT.value: 'A gathering or activity designed to bring the community together.',
+            Event.EventType.EXPO.value: 'A large-scale exhibition showcasing products, services, or innovations.',
+            Event.EventType.NETWORKING_EVENT.value: 'A gathering specifically designed for professionals to connect and build relationships.',
+            Event.EventType.TECH_TALK.value: 'A concise presentation on a technical topic, tool, or innovation.',
+            Event.EventType.OTHERS.value: 'Any event that does not fit into the standard categories.',
+        }
+
+        scope_descriptions = {
+            Event.EventScope.MAKER.value: 'Events focused on hardware, electronics, and physical prototyping.',
+            Event.EventScope.CODER.value: 'Events focused on software development and programming.',
+            Event.EventScope.MANAGER.value: 'Events focused on leadership, product management, and business.',
+            Event.EventScope.CREATIVE.value: 'Events focused on design, digital art, and creative media.',
+        }
+
         return CustomResponse(
             general_message='Event types and scopes retrieved.',
             response={
                 "event_type": [
-                    {"value": v, "label": l}
+                    {
+                        "value": v,
+                        "label": l,
+                        "description": type_descriptions.get(v, "")
+                    }
                     for v, l in zip(Event.EventType.values, Event.EventType.labels)
                 ],
                 "event_scope": [
-                    {"value": v, "label": l}
+                    {
+                        "value": v,
+                        "label": l,
+                        "description": scope_descriptions.get(v, "")
+                    }
                     for v, l in zip(Event.EventScope.values, Event.EventScope.labels)
                 ],
             },

--- a/api/dashboard/events/tests/test_meta_views.py
+++ b/api/dashboard/events/tests/test_meta_views.py
@@ -1,11 +1,9 @@
 import pytest
 from rest_framework.test import APIClient
 from db.events import Event
-
 @pytest.fixture
 def api_client():
     return APIClient()
-
 @pytest.mark.django_db
 def test_event_types_scopes_api(api_client):
     """
@@ -13,29 +11,58 @@ def test_event_types_scopes_api(api_client):
     leaves values intact, and returns HTTP 200.
     """
     resp = api_client.get("/api/v1/dashboard/events/meta/event-type-scope/")
-    
     assert resp.status_code == 200
     data = resp.json()
-    
     assert "response" in data
     assert "event_type" in data["response"]
-    
     event_types = data["response"]["event_type"]
     assert len(event_types) > 0
-    
     # Build dictionary of original labels for comparison
     original_type_map = dict(zip(Event.EventType.values, Event.EventType.labels))
-    
+    expected_type_descriptions = {
+        'HACKATHON': 'An intensive, collaborative coding event focused on building software projects.',
+        'WORKSHOP': 'An interactive, hands-on session focusing on learning specific skills or techniques.',
+        'WEBINAR': 'An online educational presentation or seminar.',
+        'SEMINAR': 'A formal presentation or educational session on a specific topic.',
+        'BOOTCAMP': 'A short, intensive training program designed to teach practical skills quickly.',
+        'MEETUP': 'An informal gathering of individuals with a shared interest or profession.',
+        'CONFERENCE': 'A formal meeting for discussion and presentations within a specific field.',
+        'COMPETITION': 'An event where individuals or teams compete against each other for a prize.',
+        'IDEATHON': 'A short, intensive brainstorming event that focuses on generating new ideas.',
+        'CULTURAL_EVENT': 'An event celebrating arts, music, or other cultural activities.',
+        'SPORTS_EVENT': 'An athletic competition or physical activity event.',
+        'COMMUNITY_EVENT': 'A gathering or activity designed to bring the community together.',
+        'EXPO': 'A large-scale exhibition showcasing products, services, or innovations.',
+        'NETWORKING_EVENT': 'A gathering specifically designed for professionals to connect and build relationships.',
+        'TECH_TALK': 'A concise presentation on a technical topic, tool, or innovation.',
+        'OTHERS': 'Any event that does not fit into the standard categories.',
+    }
     for item in event_types:
         val = item["value"]
         lbl = item["label"]
-        
+        desc = item.get("description")
         # Values must remain unchanged and exist in originals
         assert val in original_type_map, f"Value {val} not found in model choices"
-        
         # Labels should not contain underscores
         assert "_" not in lbl, f"Label {lbl} should not contain underscores"
-        
         # Label should exactly match original
         expected_label = original_type_map[val]
         assert lbl == expected_label, f"Expected label '{expected_label}', got '{lbl}'"
+        assert desc == expected_type_descriptions.get(val, "")
+    assert "event_scope" in data["response"]
+    event_scopes = data["response"]["event_scope"]
+    assert len(event_scopes) > 0
+    original_scope_map = dict(zip(Event.EventScope.values, Event.EventScope.labels))
+    expected_descriptions = {
+        'MAKER': 'Events focused on hardware, electronics, and physical prototyping.',
+        'CODER': 'Events focused on software development and programming.',
+        'MANAGER': 'Events focused on leadership, product management, and business.',
+        'CREATIVE': 'Events focused on design, digital art, and creative media.',
+    }
+    for item in event_scopes:
+        val = item["value"]
+        lbl = item["label"]
+        desc = item.get("description")
+        assert val in original_scope_map
+        assert lbl == original_scope_map[val]
+        assert desc == expected_descriptions.get(val, "")

--- a/api/dashboard/events/tests/test_meta_views.py
+++ b/api/dashboard/events/tests/test_meta_views.py
@@ -48,7 +48,9 @@ def test_event_types_scopes_api(api_client):
         # Label should exactly match original
         expected_label = original_type_map[val]
         assert lbl == expected_label, f"Expected label '{expected_label}', got '{lbl}'"
-        assert desc == expected_type_descriptions.get(val, "")
+        assert desc, f"Description for event_type '{val}' must not be empty."
+        if val in expected_type_descriptions:
+            assert desc == expected_type_descriptions[val]
     assert "event_scope" in data["response"]
     event_scopes = data["response"]["event_scope"]
     assert len(event_scopes) > 0
@@ -65,4 +67,6 @@ def test_event_types_scopes_api(api_client):
         desc = item.get("description")
         assert val in original_scope_map
         assert lbl == original_scope_map[val]
-        assert desc == expected_descriptions.get(val, "")
+        assert desc, f"Description for event_scope '{val}' must not be empty."
+        if val in expected_descriptions:
+            assert desc == expected_descriptions[val]


### PR DESCRIPTION
## What does this PR do?

Adds informative descriptions to event types and event scopes in the event metadata API.

## Changes
- Added descriptions for all event types
- Added descriptions for all event scopes
- Preserved existing values and labels
- Updated API schema
- Added/updated tests

## Testing
- Verified the API endpoint returns HTTP 200 successfully.
- Automated tests were blocked by the local MySQL test database permission issue.