### PR TITLE
fix(API):multiple members can hold same campus role and custom role i…

### DIFF
--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -10,7 +10,7 @@ from utils.permission import CustomizePermission, JWTUtils, role_required
 from utils.response import CustomResponse
 from utils.types import OrganizationType, RoleType
 from utils.utils import CommonUtils
-from db.campus import CampusIGChapter
+from db.campus import CampusIGChapter, CampusExecomRole
 from db.task import InterestGroup
 import uuid
 from . import serializers as campus_serializers
@@ -299,17 +299,13 @@ class CampusExecomAPI(APIView):
                 updated_by_id=user_id,
                 is_execom_role=True,
             )
+            # Link auto-created role to this campus
+            CampusExecomRole.objects.get_or_create(
+                org=org,
+                role=role,
+                defaults={"created_by_id": user_id, "updated_by_id": user_id}
+            )
 
-        # Remove existing holder of this role in the campus
-        campus_user_ids = UserOrganizationLink.objects.filter(
-            org=org,
-            org__org_type=OrganizationType.COLLEGE.value,
-        ).values_list("user_id", flat=True)
-
-        UserRoleLink.objects.filter(
-            user_id__in=campus_user_ids,
-            role=role,
-        ).delete()
 
         # Assign new role — follows UserRoleLinkSerializer pattern
         serializer = campus_serializers.UserRoleLinkSerializer(
@@ -458,8 +454,13 @@ class CampusExecomRoleAPI(APIView):
             RoleType.IG_CAMPUS_LEAD_ROLE(code)
             for code in InterestGroup.objects.values_list("code", flat=True)
         ]
+        campus_role_ids = CampusExecomRole.objects.filter(
+            org=org, is_active=True
+        ).values_list("role_id", flat=True)
+
         custom_execom_roles = Role.objects.filter(
-            is_execom_role=True
+            id__in=campus_role_ids,
+            is_execom_role=True,
         ).exclude(
             title__in=ig_campus_lead_titles
         ).values_list("title", flat=True)
@@ -479,6 +480,9 @@ class CampusExecomRoleAPI(APIView):
         if not role_title:
             return CustomResponse(general_message="role_title is required").get_failure_response()
 
+        # Normalize: strip extra whitespace
+        role_title = " ".join(role_title.strip().split())
+
         blacklist = [
             RoleType.ADMIN.value, RoleType.FELLOW.value, RoleType.APPRAISER.value,
             RoleType.ZONAL_CAMPUS_LEAD.value, RoleType.DISTRICT_CAMPUS_LEAD.value,
@@ -492,23 +496,38 @@ class CampusExecomRoleAPI(APIView):
         if role_title in blacklist:
             return CustomResponse(general_message=f"Cannot create highly privileged system role: {role_title}").get_failure_response()
 
-        role = Role.objects.filter(title=role_title).first()
+        # Resolve campus
+        if not (user_org_link := get_user_college_link(user_id)):
+            return CustomResponse(general_message="User has no organization").get_failure_response()
+        org = user_org_link.org
+        if org is None:
+            return CustomResponse(general_message="Campus lead has no college").get_failure_response()
+
+        # Global case-insensitive lookup — reuse existing role if title matches
+        role = Role.objects.filter(title__iexact=role_title).first()
+
         if role:
             if not role.is_execom_role:
                 return CustomResponse(
                     general_message=f"'{role_title}' is already in use by another feature and cannot be created as an execom role"
                 ).get_failure_response()
-            return CustomResponse(general_message="Role already exists").get_success_response()
+        else:
+            role = Role.objects.create(
+                id=str(uuid.uuid4()),
+                title=role_title,
+                created_by_id=user_id,
+                updated_by_id=user_id,
+                is_execom_role=True,
+            )
 
-        Role.objects.create(
-            id=str(uuid.uuid4()),
-            title=role_title,
-            created_by_id=user_id,
-            updated_by_id=user_id,
-            is_execom_role=True,
+        # Link role to this campus (no-op if already linked)
+        _, created = CampusExecomRole.objects.get_or_create(
+            org=org,
+            role=role,
+            defaults={"created_by_id": user_id, "updated_by_id": user_id}
         )
-
-        return CustomResponse(general_message="Role created successfully").get_success_response()
+        message = "Role created successfully" if created else "Role already linked to this campus"
+        return CustomResponse(general_message=message).get_success_response()
 
 
 class CampusUserSearchAPI(APIView):

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -285,26 +285,47 @@ class CampusExecomAPI(APIView):
                 general_message="User is not a member of your campus"
             ).get_failure_response()
 
-        # Fetch role by title
-        role = Role.objects.filter(title=role_title).first()
-        if role is not None and not role.is_execom_role:
+        if role_title in [RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value]:
             return CustomResponse(
-                general_message=f"'{role_title}' is already in use by another feature and cannot be assigned as an execom role"
+                general_message=f"Cannot assign '{role_title}' via this endpoint. Please use the transfer-lead-role or transfer-enabler-role endpoint."
             ).get_failure_response()
-        if role is None:
-            role = Role.objects.create(
-                id=str(uuid.uuid4()),
-                title=role_title,
-                created_by_id=user_id,
-                updated_by_id=user_id,
-                is_execom_role=True,
-            )
-            # Link auto-created role to this campus
-            CampusExecomRole.objects.get_or_create(
-                org=org,
-                role=role,
-                defaults={"created_by_id": user_id, "updated_by_id": user_id}
-            )
+
+        # Fetch role by title
+        role = Role.objects.filter(title=role_title, is_execom_role=True).first()
+        if not role:
+            return CustomResponse(
+                general_message=f"Role '{role_title}' does not exist as an Execom role. Please create the role first."
+            ).get_failure_response()
+
+        # Check if role is an allowed standard default role, active IG chapter role, or linked to this campus
+        GENERAL_EXECOM_DEFAULT_ROLES = [
+            RoleType.ENABLER.value,
+            RoleType.IG_LEAD.value,
+        ]
+
+        active_ig_codes = CampusIGChapter.objects.filter(
+            org=org, is_active=True
+        ).values_list("ig__code", flat=True)
+
+        allowed_ig_roles = set()
+        for code in active_ig_codes:
+            allowed_ig_roles.add(f"{code} CampusLead")
+            allowed_ig_roles.add(f"{code} IGLead")
+
+        is_campus_custom_role = CampusExecomRole.objects.filter(
+            org=org, role=role, is_active=True
+        ).exists()
+
+        is_valid_role = (
+            role_title in GENERAL_EXECOM_DEFAULT_ROLES
+            or role_title in allowed_ig_roles
+            or is_campus_custom_role
+        )
+
+        if not is_valid_role:
+            return CustomResponse(
+                general_message=f"Role '{role_title}' is not active or available for your campus. Please create/enable it first."
+            ).get_failure_response()
 
 
         # Assign new role — follows UserRoleLinkSerializer pattern

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -1,5 +1,6 @@
 from collections import Counter
 
+from django.db import transaction
 from django.db.models import Q
 from rest_framework.views import APIView
 
@@ -285,70 +286,50 @@ class CampusExecomAPI(APIView):
                 general_message="User is not a member of your campus"
             ).get_failure_response()
 
-        if role_title in [RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value]:
-            return CustomResponse(
-                general_message=f"Cannot assign '{role_title}' via this endpoint. Please use the transfer-lead-role or transfer-enabler-role endpoint."
-            ).get_failure_response()
+        # Wrap multi-table mutation in a single atomic transaction
+        with transaction.atomic():
+            # Fetch role by title
+            role = Role.objects.filter(title=role_title).first()
+            if role is not None and not role.is_execom_role:
+                return CustomResponse(
+                    general_message=f"'{role_title}' is already in use by another feature and cannot be assigned as an execom role"
+                ).get_failure_response()
+            if role is None:
+                role = Role.objects.create(
+                    id=str(uuid.uuid4()),
+                    title=role_title,
+                    created_by_id=user_id,
+                    updated_by_id=user_id,
+                    is_execom_role=True,
+                )
+                # Link auto-created role to this campus
+                CampusExecomRole.objects.get_or_create(
+                    org=org,
+                    role=role,
+                    defaults={"created_by_id": user_id, "updated_by_id": user_id}
+                )
 
-        # Fetch role by title
-        role = Role.objects.filter(title=role_title, is_execom_role=True).first()
-        if not role:
-            return CustomResponse(
-                general_message=f"Role '{role_title}' does not exist as an Execom role. Please create the role first."
-            ).get_failure_response()
+            # Assign new role — follows UserRoleLinkSerializer pattern
+            serializer = campus_serializers.UserRoleLinkSerializer(
+                data={"user": new_user.id, "role": role.id},
+                context={"user_id": user_id},
+            )
+            if serializer.is_valid():
+                serializer.save()
 
-        # Check if role is an allowed standard default role, active IG chapter role, or linked to this campus
-        GENERAL_EXECOM_DEFAULT_ROLES = [
-            RoleType.ENABLER.value,
-            RoleType.IG_LEAD.value,
-        ]
+                if role_title.endswith("CampusLead") and role_title not in [RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value]:
+                    ig_code = role_title.replace("CampusLead", "").strip()
+                    chapter = CampusIGChapter.objects.filter(org=org, ig__code=ig_code, is_active=True).first()
+                    if chapter:
+                        chapter.lead = new_user
+                        chapter.updated_by_id = user_id
+                        chapter.save()
 
-        active_ig_codes = CampusIGChapter.objects.filter(
-            org=org, is_active=True
-        ).values_list("ig__code", flat=True)
+                return CustomResponse(
+                    general_message="Role assigned successfully"
+                ).get_success_response()
 
-        allowed_ig_roles = set()
-        for code in active_ig_codes:
-            allowed_ig_roles.add(f"{code} CampusLead")
-            allowed_ig_roles.add(f"{code} IGLead")
-
-        is_campus_custom_role = CampusExecomRole.objects.filter(
-            org=org, role=role, is_active=True
-        ).exists()
-
-        is_valid_role = (
-            role_title in GENERAL_EXECOM_DEFAULT_ROLES
-            or role_title in allowed_ig_roles
-            or is_campus_custom_role
-        )
-
-        if not is_valid_role:
-            return CustomResponse(
-                general_message=f"Role '{role_title}' is not active or available for your campus. Please create/enable it first."
-            ).get_failure_response()
-
-
-        # Assign new role — follows UserRoleLinkSerializer pattern
-        serializer = campus_serializers.UserRoleLinkSerializer(
-            data={"user": new_user.id, "role": role.id},
-            context={"user_id": user_id},
-        )
-        if serializer.is_valid():
-            serializer.save()
-
-            if role_title.endswith("CampusLead") and role_title not in [RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value]:
-                ig_code = role_title.replace("CampusLead", "").strip()
-                chapter = CampusIGChapter.objects.filter(org=org, ig__code=ig_code, is_active=True).first()
-                if chapter:
-                    chapter.lead = new_user
-                    chapter.updated_by_id = user_id
-                    chapter.save()
-
-            return CustomResponse(
-                general_message="Role assigned successfully"
-            ).get_success_response()
-
-        return CustomResponse(message=serializer.errors).get_failure_response()
+            return CustomResponse(message=serializer.errors).get_failure_response()
 
     @role_required([RoleType.CAMPUS_LEAD.value,RoleType.LEAD_ENABLER.value])
     @extend_schema(tags=['Dashboard - Campus'], description="Delete Campus Execom.",
@@ -524,31 +505,32 @@ class CampusExecomRoleAPI(APIView):
         if org is None:
             return CustomResponse(general_message="Campus lead has no college").get_failure_response()
 
-        # Global case-insensitive lookup — reuse existing role if title matches
-        role = Role.objects.filter(title__iexact=role_title).first()
+        with transaction.atomic():
+            # Global case-insensitive lookup — reuse existing role if title matches
+            role = Role.objects.filter(title__iexact=role_title).first()
 
-        if role:
-            if not role.is_execom_role:
-                return CustomResponse(
-                    general_message=f"'{role_title}' is already in use by another feature and cannot be created as an execom role"
-                ).get_failure_response()
-        else:
-            role = Role.objects.create(
-                id=str(uuid.uuid4()),
-                title=role_title,
-                created_by_id=user_id,
-                updated_by_id=user_id,
-                is_execom_role=True,
+            if role:
+                if not role.is_execom_role:
+                    return CustomResponse(
+                        general_message=f"'{role_title}' is already in use by another feature and cannot be created as an execom role"
+                    ).get_failure_response()
+            else:
+                role = Role.objects.create(
+                    id=str(uuid.uuid4()),
+                    title=role_title,
+                    created_by_id=user_id,
+                    updated_by_id=user_id,
+                    is_execom_role=True,
+                )
+
+            # Link role to this campus (no-op if already linked)
+            _, created = CampusExecomRole.objects.get_or_create(
+                org=org,
+                role=role,
+                defaults={"created_by_id": user_id, "updated_by_id": user_id}
             )
-
-        # Link role to this campus (no-op if already linked)
-        _, created = CampusExecomRole.objects.get_or_create(
-            org=org,
-            role=role,
-            defaults={"created_by_id": user_id, "updated_by_id": user_id}
-        )
-        message = "Role created successfully" if created else "Role already linked to this campus"
-        return CustomResponse(general_message=message).get_success_response()
+            message = "Role created successfully" if created else "Role already linked to this campus"
+            return CustomResponse(general_message=message).get_success_response()
 
 
 class CampusUserSearchAPI(APIView):

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -500,12 +500,20 @@ class UserRoleLinkSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         user_id = self.context.get("user_id")
-        validated_data["created_by_id"] = user_id
-        validated_data["id"] = uuid.uuid4()
-        validated_data["verified"] = True
 
-        user_role_link = UserRoleLink.objects.create(**validated_data)
-        return user_role_link
+        link, created = UserRoleLink.objects.get_or_create(
+            user=validated_data["user"],
+            role=validated_data["role"],
+            defaults={
+                "id": str(uuid.uuid4()),
+                "created_by_id": user_id,
+                "verified": True,
+            }
+        )
+        if not created:
+            from rest_framework.exceptions import ValidationError
+            raise ValidationError("User already has this role.")
+        return link
 
 
 class CampusEventListSerializer(serializers.ModelSerializer):

--- a/db/campus.py
+++ b/db/campus.py
@@ -47,3 +47,21 @@ class CampusSocialLink(models.Model):
     class Meta:
         managed = False
         db_table = 'campus_social_link'
+
+
+class CampusExecomRole(models.Model):
+    id         = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    org        = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='campus_execom_roles')
+    role       = models.ForeignKey('db.Role', on_delete=models.CASCADE, related_name='campus_execom_role_links')
+    is_active  = models.BooleanField(default=True)
+    created_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+                                   db_column='created_by', related_name='campus_execom_role_created_by')
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+                                   db_column='updated_by', related_name='campus_execom_role_updated_by')
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        managed = False
+        db_table = 'campus_execom_role'
+        unique_together = [('org', 'role')]


### PR DESCRIPTION
This pull request introduces a new model, `CampusExecomRole`, to explicitly link execom roles to specific campuses and updates the campus events API to use this new association. The changes improve the management of campus-specific execom roles, prevent duplicate or inappropriate role assignments, and enhance data integrity.

**Campus execom role management improvements:**

* Added a new model, `CampusExecomRole`, to represent the association between a campus (`org`) and an execom role, with unique constraints and metadata.
* Updated the role assignment logic in the campus events API to use `CampusExecomRole` for linking roles to campuses, replacing the previous approach of removing and reassigning roles.
* Enhanced the retrieval of custom execom roles to filter by those linked via `CampusExecomRole` and active for the current campus.

**Role creation and validation enhancements:**

* Improved the role creation endpoint to normalize role titles, perform a case-insensitive lookup to reuse existing roles if possible, and ensure that roles are linked to the campus using `CampusExecomRole`. [[1]](diffhunk://#diff-b614d4257cc04f1490e7758f9604b34d61154db7dc03d5ce5bad044b3b8e7f7dR483-R485) [[2]](diffhunk://#diff-b614d4257cc04f1490e7758f9604b34d61154db7dc03d5ce5bad044b3b8e7f7dL495-R530)
* Added validation to ensure the user is associated with a campus before creating or linking a role, and clarified error messages for privileged or duplicate roles.…s availabe to specific campus whom they created