### PR TITLE
Campus execom roles: global directory, IG co-lead, permission-leak fixes

### DIFF
--- a/api/dashboard/campus/dash_campus_helper.py
+++ b/api/dashboard/campus/dash_campus_helper.py
@@ -154,14 +154,19 @@ def ensure_ig_execom_catalog_entries(ig_code, ig_name, acting_user_id):
         RoleType.IG_CAMPUS_LEAD_ROLE(ig_code),
         RoleType.IG_CAMPUS_COLEAD_ROLE(ig_code),
     ):
-        if not CampusExecomRole.objects.filter(title__iexact=title).exists():
-            CampusExecomRole.objects.create(
-                id=str(uuid.uuid4()),
-                title=title,
-                description=f"{ig_name} Interest Group role",
-                created_by_id=acting_user_id,
-                updated_by_id=acting_user_id,
-            )
+        # Atomic get-or-create: title has a case-insensitive unique constraint, so a
+        # separate check-then-create is racy under concurrent chapter creation — two
+        # requests can both pass the check and then one hits an IntegrityError on
+        # insert. get_or_create retries the lookup on that IntegrityError instead.
+        CampusExecomRole.objects.get_or_create(
+            title=title,
+            defaults={
+                "id": str(uuid.uuid4()),
+                "description": f"{ig_name} Interest Group role",
+                "created_by_id": acting_user_id,
+                "updated_by_id": acting_user_id,
+            },
+        )
 
 
 def validate_campus_member(user_id, org_id):
@@ -185,7 +190,7 @@ def get_campus_ig_chapters(org_id):
 def assign_ig_campus_lead(chapter, new_lead, acting_user_id):
     """
     Assign a new campus-level IG lead for a chapter.
-    - Removes the old lead's UserRoleLink for "{ig_code} CampusLead" at this campus.
+    - Removes the old lead's UserRoleLink for "{ig_code} CampusIGLead" at this campus.
     - Creates a new UserRoleLink for the new lead.
     - Updates the chapter's lead field.
     Mirrors the role-transfer logic in TransferIGRoleAPI.post().

--- a/api/dashboard/campus/dash_campus_helper.py
+++ b/api/dashboard/campus/dash_campus_helper.py
@@ -1,7 +1,7 @@
 import uuid
 
 from db.organization import UserOrganizationLink
-from db.campus import CampusIGChapter
+from db.campus import CampusIGChapter, CampusExecomRole
 from db.user import Role, UserRoleLink
 from utils.types import OrganizationType, RoleType
 
@@ -97,6 +97,73 @@ def get_campus_context(request):
     return link.org, None
 
 
+def normalize_role_title(raw_title):
+    """
+    Collapse whitespace and Title Case a brand-new execom role title.
+    Only call this when actually creating a new CampusExecomRole row — an
+    existing row's stored casing should always win over re-normalizing it
+    (str.title() mis-cases things like "IG Lead" -> "Ig Lead" on repeat submits).
+    """
+    return " ".join(raw_title.strip().split()).title()
+
+
+def ig_synthetic_titles_for_org(org):
+    """
+    The dynamically-computed set of IG-derived execom-assignable titles valid for this campus —
+    a CampusIGLead + CampusIGCoLead pair per active CampusIGChapter. This is the single source of
+    truth both CampusExecomRoleAPI.get (merge) and CampusExecomAPI.post (validation) use, so the
+    two never drift apart.
+
+    Deliberately excludes "{code} IGLead" — that title is a plain, non-execom IG membership role
+    (is_execom_role=False, see assign_ig_campus_lead) and must never appear in an execom roles
+    fetcher response.
+    """
+    titles = set()
+    for chapter in CampusIGChapter.objects.filter(org=org, is_active=True).select_related("ig"):
+        if chapter.ig:
+            titles.add(RoleType.IG_CAMPUS_LEAD_ROLE(chapter.ig.code))
+            titles.add(RoleType.IG_CAMPUS_COLEAD_ROLE(chapter.ig.code))
+    return titles
+
+
+def match_ig_code_from_title(title):
+    """
+    If `title` exactly matches one of the IG-synthetic patterns for a REAL InterestGroup code
+    ("{code} CampusIGLead" / "{code} IGLead" / "{code} CampusIGCoLead"), return that code
+    (case-insensitive); else None. Used to keep campus_execom_role's global catalog free of
+    IG-scoped titles, which must stay campus-filtered rather than shown to every campus.
+    """
+    from db.task import InterestGroup
+
+    for suffix in ("CampusIGLead", "IGLead", "CampusIGCoLead"):
+        if title.lower().endswith(f" {suffix.lower()}"):
+            code = title[: -(len(suffix) + 1)].strip()
+            if InterestGroup.objects.filter(code__iexact=code).exists():
+                return code
+    return None
+
+
+def ensure_ig_execom_catalog_entries(ig_code, ig_name, acting_user_id):
+    """
+    Ensure this IG's execom-assignable titles (CampusIGLead, CampusIGCoLead — never the plain,
+    non-execom "{code} IGLead") exist in the global campus_execom_role directory (case-insensitive,
+    no duplicates). Called whenever an IG chapter is created or its lead is (re)assigned, so the
+    roles are immediately visible/reusable once relevant.
+    """
+    for title in (
+        RoleType.IG_CAMPUS_LEAD_ROLE(ig_code),
+        RoleType.IG_CAMPUS_COLEAD_ROLE(ig_code),
+    ):
+        if not CampusExecomRole.objects.filter(title__iexact=title).exists():
+            CampusExecomRole.objects.create(
+                id=str(uuid.uuid4()),
+                title=title,
+                description=f"{ig_name} Interest Group role",
+                created_by_id=acting_user_id,
+                updated_by_id=acting_user_id,
+            )
+
+
 def validate_campus_member(user_id, org_id):
     """Confirm that a user is an active member of the given campus (not alumni)."""
     return UserOrganizationLink.objects.filter(
@@ -138,6 +205,11 @@ def assign_ig_campus_lead(chapter, new_lead, acting_user_id):
             "is_execom_role": True,
         },
         {
+            "title": RoleType.IG_CAMPUS_COLEAD_ROLE(ig_code),
+            "description": f"{ig_name} Interest Group Campus Co-Lead",
+            "is_execom_role": True,
+        },
+        {
             "title": RoleType.IG_LEAD_ROLE(ig_code),
             "description": f"{ig_name} Interest Group Lead",
             "is_execom_role": False,
@@ -155,6 +227,9 @@ def assign_ig_campus_lead(chapter, new_lead, acting_user_id):
                 "is_execom_role": role_data["is_execom_role"],
             }
         )
+
+    # Keep the global role directory in sync with this IG's assignable titles.
+    ensure_ig_execom_catalog_entries(ig_code, ig_name, acting_user_id)
 
     role = Role.objects.get(title=RoleType.IG_CAMPUS_LEAD_ROLE(ig_code))
 

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -229,6 +229,14 @@ class CampusExecomAPI(APIView):
                 general_message="muid and role_title are required"
             ).get_failure_response()
 
+        # Canonical form used for every privileged-role comparison below. The `role`
+        # table uses a case-insensitive DB collation (utf8mb4_0900_ai_ci), so a plain
+        # Python `==`/`in` check against the raw, attacker-supplied casing can be
+        # bypassed (e.g. "campus lead") while the later DB lookup still resolves to
+        # the real, privileged row. Casefold once and compare against that everywhere
+        # — never against the raw `role_title`.
+        canonical_role_title = " ".join(role_title.strip().split()).casefold()
+
         # System roles that are highly privileged and cannot be assigned by campus leads
         BLACKLIST_ROLES = [
             RoleType.ADMIN.value, RoleType.FELLOW.value, RoleType.APPRAISER.value,
@@ -239,8 +247,9 @@ class CampusExecomAPI(APIView):
             RoleType.INTERN.value, RoleType.PRE_MEMBER.value, RoleType.SUSPEND.value,
             RoleType.MULEARNER.value
         ]
-        
-        if role_title in BLACKLIST_ROLES:
+        BLACKLIST_ROLES_CASEFOLD = {r.casefold() for r in BLACKLIST_ROLES}
+
+        if canonical_role_title in BLACKLIST_ROLES_CASEFOLD:
             return CustomResponse(
                 general_message=f"Cannot assign highly privileged system role: {role_title}"
             ).get_failure_response()
@@ -291,7 +300,7 @@ class CampusExecomAPI(APIView):
 
         # Campus Lead has exactly one holder per campus and is reassigned only via
         # transfer-lead-role — never through this generic roster/assign flow.
-        if role_title == RoleType.CAMPUS_LEAD.value:
+        if canonical_role_title == RoleType.CAMPUS_LEAD.value.casefold():
             return CustomResponse(
                 general_message="Campus Lead can't be assigned here. Use transfer-lead-role instead."
             ).get_failure_response()
@@ -515,7 +524,7 @@ class CampusExecomRoleAPI(APIView):
             RoleType.MULEARNER.value
         ]
 
-        if role_title in blacklist:
+        if role_title.casefold() in {r.casefold() for r in blacklist}:
             return CustomResponse(general_message=f"Cannot create highly privileged system role: {role_title}").get_failure_response()
 
         if match_ig_code_from_title(role_title) is not None:
@@ -523,25 +532,23 @@ class CampusExecomRoleAPI(APIView):
                 general_message=f"'{role_title}' is an Interest-Group-specific role — it's managed automatically per campus and can't be added to the shared role directory."
             ).get_failure_response()
 
-        with transaction.atomic():
-            # Global, case-insensitive reuse check — never create a duplicate title.
-            existing = CampusExecomRole.objects.filter(title__iexact=role_title).first()
-            if existing:
-                return CustomResponse(
-                    general_message="Role already exists",
-                    response={"id": existing.id, "title": existing.title},
-                ).get_success_response()
-
-            new_role = CampusExecomRole.objects.create(
-                id=str(uuid.uuid4()),
-                title=normalize_role_title(role_title),
-                created_by_id=user_id,
-                updated_by_id=user_id,
-            )
-            return CustomResponse(
-                general_message="Role created successfully",
-                response={"id": new_role.id, "title": new_role.title},
-            ).get_success_response()
+        # Atomic get-or-create: the title column has a case-insensitive unique
+        # constraint, so a plain "check, then create" is racy — two concurrent
+        # requests can both pass the check and then one hits an IntegrityError
+        # on insert. get_or_create retries the lookup if create() raises that
+        # IntegrityError, so the loser reuses the winner's row instead of 500ing.
+        role, created = CampusExecomRole.objects.get_or_create(
+            title=normalize_role_title(role_title),
+            defaults={
+                "id": str(uuid.uuid4()),
+                "created_by_id": user_id,
+                "updated_by_id": user_id,
+            },
+        )
+        return CustomResponse(
+            general_message="Role created successfully" if created else "Role already exists",
+            response={"id": role.id, "title": role.title},
+        ).get_success_response()
 
 
 class CampusUserSearchAPI(APIView):

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -20,6 +20,9 @@ from .dash_campus_helper import (
     get_campus_events_qs,
     validate_campus_member,
     campus_staff_required,
+    normalize_role_title,
+    ig_synthetic_titles_for_org,
+    match_ig_code_from_title,
 )
 from drf_spectacular.utils import extend_schema, inline_serializer, OpenApiResponse
 from rest_framework import serializers as s
@@ -268,7 +271,7 @@ class CampusExecomAPI(APIView):
         
         all_system_igs = InterestGroup.objects.all()
         for ig in all_system_igs:
-            if role_title.startswith(f"{ig.code} ") or role_title.startswith(f"{ig.name} ") or role_title.startswith(f"{ig.code}_") or role_title.startswith(f"{ig.name}_") or role_title == f"{ig.code} CampusLead" or role_title == f"{ig.code}CampusLead":
+            if role_title.startswith(f"{ig.code} ") or role_title.startswith(f"{ig.name} ") or role_title.startswith(f"{ig.code}_") or role_title.startswith(f"{ig.name}_") or role_title == f"{ig.code} CampusIGLead" or role_title == f"{ig.code}CampusIGLead":
                 ig_active_in_campus = active_igs.filter(ig=ig).exists()
                 if ig_active_in_campus:
                     matched_active_ig = True
@@ -286,9 +289,25 @@ class CampusExecomAPI(APIView):
                 general_message="User is not a member of your campus"
             ).get_failure_response()
 
+        # Campus Lead has exactly one holder per campus and is reassigned only via
+        # transfer-lead-role — never through this generic roster/assign flow.
+        if role_title == RoleType.CAMPUS_LEAD.value:
+            return CustomResponse(
+                general_message="Campus Lead can't be assigned here. Use transfer-lead-role instead."
+            ).get_failure_response()
+
+        # role_title must already be a recognized execom role: either present in the
+        # global campus_execom_role directory, or an active IG-chapter-derived synthetic
+        # title for this campus. No auto-create here — create it via the roles directory first.
+        if role_title not in ig_synthetic_titles_for_org(org) and not CampusExecomRole.objects.filter(title__iexact=role_title).exists():
+            return CustomResponse(
+                general_message=f"'{role_title}' is not a recognized execom role. Create it in the role directory first."
+            ).get_failure_response()
+
         # Wrap multi-table mutation in a single atomic transaction
         with transaction.atomic():
-            # Fetch role by title
+            # Fetch (or bridge-create) the matching system Role — UserRoleLink.role is a hard
+            # FK to `role`, independent of the campus_execom_role directory above.
             role = Role.objects.filter(title=role_title).first()
             if role is not None and not role.is_execom_role:
                 return CustomResponse(
@@ -302,12 +321,6 @@ class CampusExecomAPI(APIView):
                     updated_by_id=user_id,
                     is_execom_role=True,
                 )
-                # Link auto-created role to this campus
-                CampusExecomRole.objects.get_or_create(
-                    org=org,
-                    role=role,
-                    defaults={"created_by_id": user_id, "updated_by_id": user_id}
-                )
 
             # Assign new role — follows UserRoleLinkSerializer pattern
             serializer = campus_serializers.UserRoleLinkSerializer(
@@ -317,11 +330,21 @@ class CampusExecomAPI(APIView):
             if serializer.is_valid():
                 serializer.save()
 
-                if role_title.endswith("CampusLead") and role_title not in [RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value]:
-                    ig_code = role_title.replace("CampusLead", "").strip()
-                    chapter = CampusIGChapter.objects.filter(org=org, ig__code=ig_code, is_active=True).first()
+                ig_code_for_chapter_field = None
+                chapter_field = None
+                if role_title.endswith("CampusIGLead"):
+                    ig_code_for_chapter_field = role_title[: -len("CampusIGLead")].strip()
+                    chapter_field = "lead"
+                elif role_title.endswith("CampusIGCoLead"):
+                    ig_code_for_chapter_field = role_title[: -len("CampusIGCoLead")].strip()
+                    chapter_field = "co_lead"
+
+                if ig_code_for_chapter_field:
+                    chapter = CampusIGChapter.objects.filter(
+                        org=org, ig__code=ig_code_for_chapter_field, is_active=True
+                    ).first()
                     if chapter:
-                        chapter.lead = new_user
+                        setattr(chapter, chapter_field, new_user)
                         chapter.updated_by_id = user_id
                         chapter.save()
 
@@ -390,11 +413,21 @@ class CampusExecomAPI(APIView):
         user_id_of_role = role_link.user_id
         role_link.delete()
 
-        if role_title.endswith("CampusLead") and role_title not in [RoleType.CAMPUS_LEAD.value, RoleType.LEAD_ENABLER.value]:
-            ig_code = role_title.replace("CampusLead", "").strip()
-            chapter = CampusIGChapter.objects.filter(org=org, ig__code=ig_code, is_active=True).first()
-            if chapter and chapter.lead_id == user_id_of_role:
-                chapter.lead = None
+        ig_code_for_chapter_field = None
+        chapter_field = None
+        if role_title.endswith("CampusIGLead"):
+            ig_code_for_chapter_field = role_title[: -len("CampusIGLead")].strip()
+            chapter_field = "lead"
+        elif role_title.endswith("CampusIGCoLead"):
+            ig_code_for_chapter_field = role_title[: -len("CampusIGCoLead")].strip()
+            chapter_field = "co_lead"
+
+        if ig_code_for_chapter_field:
+            chapter = CampusIGChapter.objects.filter(
+                org=org, ig__code=ig_code_for_chapter_field, is_active=True
+            ).first()
+            if chapter and getattr(chapter, f"{chapter_field}_id") == user_id_of_role:
+                setattr(chapter, chapter_field, None)
                 chapter.updated_by_id = user_id
                 chapter.save()
 
@@ -437,38 +470,25 @@ class CampusExecomRoleAPI(APIView):
         if org is None:
             return CustomResponse(general_message="Campus lead has no college").get_failure_response()
 
+        # Per-campus IG-derived roles this org actually has active.
+        this_campus_ig_titles = ig_synthetic_titles_for_org(org)
+
+        # Global catalog, filtered so an IG-shaped title only shows for a campus that
+        # actually has that IG active — otherwise it silently leaks another campus's roles.
+        # "{code} IGLead" is never shown here at all — it's a plain, non-execom IG membership
+        # role, not an assignable execom role, regardless of whether a legacy row for it exists.
+        # "Campus Lead" is also never shown — it has exactly one holder per campus and must be
+        # assigned only through transfer-lead-role, never through this generic roster picker.
         roles = set()
-        roles.add(RoleType.CAMPUS_LEAD.value)
-        roles.add(RoleType.LEAD_ENABLER.value)
-        roles.add(RoleType.ENABLER.value)
-        roles.add(RoleType.IG_LEAD.value)
-        
+        for title in CampusExecomRole.objects.values_list("title", flat=True):
+            if title.lower().endswith(" iglead") or title == RoleType.CAMPUS_LEAD.value:
+                continue
+            if match_ig_code_from_title(title) is None or title in this_campus_ig_titles:
+                roles.add(title)
 
-        # Active IG roles for this campus
-        active_chapters = CampusIGChapter.objects.filter(org=org, is_active=True).select_related("ig")
-        for chapter in active_chapters:
-            if chapter.ig:
-                roles.add(f"{chapter.ig.code} CampusLead")
-                roles.add(f"{chapter.ig.code} IGLead")
+        roles.update(this_campus_ig_titles)
 
-
-        ig_campus_lead_titles = [
-            RoleType.IG_CAMPUS_LEAD_ROLE(code)
-            for code in InterestGroup.objects.values_list("code", flat=True)
-        ]
-        campus_role_ids = CampusExecomRole.objects.filter(
-            org=org, is_active=True
-        ).values_list("role_id", flat=True)
-
-        custom_execom_roles = Role.objects.filter(
-            id__in=campus_role_ids,
-            is_execom_role=True,
-        ).exclude(
-            title__in=ig_campus_lead_titles
-        ).values_list("title", flat=True)
-        roles.update(custom_execom_roles)
-
-        return CustomResponse(response={"data": sorted(list(roles))}).get_success_response()
+        return CustomResponse(response={"data": sorted(roles)}).get_success_response()
 
 
     @role_required([RoleType.CAMPUS_LEAD.value,RoleType.LEAD_ENABLER.value])
@@ -498,39 +518,30 @@ class CampusExecomRoleAPI(APIView):
         if role_title in blacklist:
             return CustomResponse(general_message=f"Cannot create highly privileged system role: {role_title}").get_failure_response()
 
-        # Resolve campus
-        if not (user_org_link := get_user_college_link(user_id)):
-            return CustomResponse(general_message="User has no organization").get_failure_response()
-        org = user_org_link.org
-        if org is None:
-            return CustomResponse(general_message="Campus lead has no college").get_failure_response()
+        if match_ig_code_from_title(role_title) is not None:
+            return CustomResponse(
+                general_message=f"'{role_title}' is an Interest-Group-specific role — it's managed automatically per campus and can't be added to the shared role directory."
+            ).get_failure_response()
 
         with transaction.atomic():
-            # Global case-insensitive lookup — reuse existing role if title matches
-            role = Role.objects.filter(title__iexact=role_title).first()
+            # Global, case-insensitive reuse check — never create a duplicate title.
+            existing = CampusExecomRole.objects.filter(title__iexact=role_title).first()
+            if existing:
+                return CustomResponse(
+                    general_message="Role already exists",
+                    response={"id": existing.id, "title": existing.title},
+                ).get_success_response()
 
-            if role:
-                if not role.is_execom_role:
-                    return CustomResponse(
-                        general_message=f"'{role_title}' is already in use by another feature and cannot be created as an execom role"
-                    ).get_failure_response()
-            else:
-                role = Role.objects.create(
-                    id=str(uuid.uuid4()),
-                    title=role_title,
-                    created_by_id=user_id,
-                    updated_by_id=user_id,
-                    is_execom_role=True,
-                )
-
-            # Link role to this campus (no-op if already linked)
-            _, created = CampusExecomRole.objects.get_or_create(
-                org=org,
-                role=role,
-                defaults={"created_by_id": user_id, "updated_by_id": user_id}
+            new_role = CampusExecomRole.objects.create(
+                id=str(uuid.uuid4()),
+                title=normalize_role_title(role_title),
+                created_by_id=user_id,
+                updated_by_id=user_id,
             )
-            message = "Role created successfully" if created else "Role already linked to this campus"
-            return CustomResponse(general_message=message).get_success_response()
+            return CustomResponse(
+                general_message="Role created successfully",
+                response={"id": new_role.id, "title": new_role.title},
+            ).get_success_response()
 
 
 class CampusUserSearchAPI(APIView):

--- a/api/dashboard/campus/events_views.py
+++ b/api/dashboard/campus/events_views.py
@@ -306,12 +306,40 @@ class CampusExecomAPI(APIView):
             ).get_failure_response()
 
         # role_title must already be a recognized execom role: either present in the
-        # global campus_execom_role directory, or an active IG-chapter-derived synthetic
-        # title for this campus. No auto-create here — create it via the roles directory first.
-        if role_title not in ig_synthetic_titles_for_org(org) and not CampusExecomRole.objects.filter(title__iexact=role_title).exists():
+        # global campus_execom_role directory, an active IG-chapter-derived synthetic
+        # title for this campus, or one of the always-assignable system roles below.
+        # No auto-create here — create it via the roles directory first.
+        #
+        # Both the synthetic-title check and the always-assignable check compare
+        # case-insensitively (via canonical_role_title), matching the catalog check's
+        # title__iexact and the DB's own case-insensitive collation — a differently-cased
+        # but otherwise valid title (e.g. "webdev campusiglead") must not be rejected while
+        # "WEBDEV CampusIGLead" is accepted.
+        ig_synthetic_titles_by_casefold = {
+            title.casefold(): title for title in ig_synthetic_titles_for_org(org)
+        }
+        # Enabler and Lead Enabler are core system roles a Campus Lead must always be able
+        # to grant from the campus dashboard, independent of whether the campus_execom_role
+        # catalog has been seeded with them.
+        ALWAYS_ASSIGNABLE_EXECOM_ROLES_BY_CASEFOLD = {
+            RoleType.ENABLER.value.casefold(): RoleType.ENABLER.value,
+            RoleType.LEAD_ENABLER.value.casefold(): RoleType.LEAD_ENABLER.value,
+        }
+        canonical_title_match = (
+            ig_synthetic_titles_by_casefold.get(canonical_role_title)
+            or ALWAYS_ASSIGNABLE_EXECOM_ROLES_BY_CASEFOLD.get(canonical_role_title)
+        )
+
+        if canonical_title_match is None and not CampusExecomRole.objects.filter(title__iexact=role_title).exists():
             return CustomResponse(
                 general_message=f"'{role_title}' is not a recognized execom role. Create it in the role directory first."
             ).get_failure_response()
+
+        # Normalize to the canonical casing so the chapter-field extraction below (which
+        # does an exact-case suffix match) and the Role row we resolve/create below stay
+        # consistent regardless of how the client cased the request.
+        if canonical_title_match is not None:
+            role_title = canonical_title_match
 
         # Wrap multi-table mutation in a single atomic transaction
         with transaction.atomic():
@@ -496,6 +524,12 @@ class CampusExecomRoleAPI(APIView):
                 roles.add(title)
 
         roles.update(this_campus_ig_titles)
+
+        # Enabler and Lead Enabler must always be offered as assignable roles from the
+        # campus dashboard, independent of whether the campus_execom_role catalog has
+        # been seeded with them — mirrors the always-assignable check in CampusExecomAPI.post.
+        roles.add(RoleType.ENABLER.value)
+        roles.add(RoleType.LEAD_ENABLER.value)
 
         return CustomResponse(response={"data": sorted(roles)}).get_success_response()
 

--- a/api/dashboard/campus/serializers.py
+++ b/api/dashboard/campus/serializers.py
@@ -12,7 +12,7 @@ from db.user import User, UserRoleLink
 from utils.types import OrganizationType
 from utils.types import RoleType, SocialPlatformType
 from utils.utils import DateTimeUtils
-from .dash_campus_helper import validate_campus_member, assign_ig_campus_lead
+from .dash_campus_helper import validate_campus_member, assign_ig_campus_lead, ensure_ig_execom_catalog_entries
 from db.events import Event
 from db.learning_circle import LearningCircle, UserCircleLink
 
@@ -562,13 +562,11 @@ class ExecomMemberSerializer(serializers.ModelSerializer):
 
     def get_ig_name(self, obj):
         title = obj.role.title
-        # IG campus lead roles use canonical format: "{ig_code} CampusLead"
-        if title not in (
-            RoleType.CAMPUS_LEAD.value,
-            RoleType.LEAD_ENABLER.value,
-        ) and title.endswith("CampusLead"):
-            ig_name = title.replace("CampusLead", "").strip()
-            return ig_name or None
+        # IG campus lead/co-lead roles use canonical format: "{ig_code} CampusIGLead" / "{ig_code} CampusIGCoLead"
+        for suffix in ("CampusIGLead", "CampusIGCoLead"):
+            if title.endswith(suffix):
+                ig_name = title[: -len(suffix)].strip()
+                return ig_name or None
         return None
 
         
@@ -700,14 +698,18 @@ class CampusIGChapterCreateSerializer(serializers.ModelSerializer):
         with transaction.atomic():
             chapter = CampusIGChapter.objects.create(**validated_data)
 
+            ig_name = chapter.ig.name
+            ig_code = chapter.ig.code
+
+            # Populate the global role directory with this IG's assignable titles
+            # immediately on chapter creation, regardless of whether a lead is set yet.
+            ensure_ig_execom_catalog_entries(ig_code, ig_name, user_id)
+
             if chapter.lead:
                 # assign_ig_campus_lead handles bootstrapping the roles internally
                 assign_ig_campus_lead(chapter, chapter.lead, user_id)
             else:
                 # Ensure IG roles exist in the database
-                ig_name = chapter.ig.name
-                ig_code = chapter.ig.code
-
                 roles_to_ensure = [
                     {
                         "title": ig_name,
@@ -716,6 +718,10 @@ class CampusIGChapterCreateSerializer(serializers.ModelSerializer):
                     {
                         "title": RoleType.IG_CAMPUS_LEAD_ROLE(ig_code),
                         "description": f"{ig_name} Interest Group Campus Lead",
+                    },
+                    {
+                        "title": RoleType.IG_CAMPUS_COLEAD_ROLE(ig_code),
+                        "description": f"{ig_name} Interest Group Campus Co-Lead",
                     },
                     {
                         "title": RoleType.IG_LEAD_ROLE(ig_code),

--- a/api/dashboard/events/manage_views.py
+++ b/api/dashboard/events/manage_views.py
@@ -62,8 +62,8 @@ def _can_create_event(roles):
     """True if user holds at least one event-creation role."""
     if MANAGEABLE_ROLES.intersection(set(roles)):
         return True
-    # Dynamic IG/campus roles: e.g. "WEBDEV IGLead", "WEBDEV CampusLead"
-    return any(r.endswith(' IGLead') or r.endswith(' CampusLead') for r in roles)
+    # Dynamic IG/campus roles: e.g. "WEBDEV IGLead", "WEBDEV CampusIGLead"
+    return any(r.endswith(' IGLead') or r.endswith(' CampusIGLead') for r in roles)
 
 
 def _get_manageable_events():
@@ -1142,7 +1142,7 @@ def _caller_can_respond(conn, user_id, roles):
         from db.task import InterestGroup
         ig = InterestGroup.objects.filter(id=conn.entity_id).first()
         if ig:
-            return f'{ig.code} CampusLead' in roles
+            return f'{ig.code} CampusIGLead' in roles
     return False
 
 
@@ -1475,7 +1475,7 @@ class MyEventInvitesAPI(APIView):
             if role.endswith(' IGLead'):
                 ig_code = role.replace(' IGLead', '')
                 auth_ig_codes.append(ig_code)
-            if role.endswith(' CampusLead') or role == RoleType.CAMPUS_LEAD.value:
+            if role.endswith(' CampusIGLead') or role == RoleType.CAMPUS_LEAD.value:
                 has_any_campus_lead_role = True
 
         from db.task import InterestGroup
@@ -1501,7 +1501,7 @@ class MyEventInvitesAPI(APIView):
             # Scope campus-IG invites to the specific IGs the user is a campus
             # lead for (entity_id on a campus_ig invite is the InterestGroup id).
             campus_ig_codes = [
-                r.replace(' CampusLead', '') for r in roles if r.endswith(' CampusLead')
+                r.replace(' CampusIGLead', '') for r in roles if r.endswith(' CampusIGLead')
             ]
             if campus_ig_codes:
                 ci_ig_ids = InterestGroup.objects.filter(

--- a/api/dashboard/events/meta_views.py
+++ b/api/dashboard/events/meta_views.py
@@ -145,10 +145,10 @@ class OrganizerOptionsAPI(APIView):
             )
             options['can_create_as_ig'] = list(igs)
 
-        # Campus IG leads: roles like "WEBDEV CampusLead"
+        # Campus IG leads: roles like "WEBDEV CampusIGLead"
         ci_lead_codes = [
-            r.replace(' CampusLead', '')
-            for r in roles if r.endswith(' CampusLead')
+            r.replace(' CampusIGLead', '')
+            for r in roles if r.endswith(' CampusIGLead')
         ]
         if ci_lead_codes:
             igs = InterestGroup.objects.filter(code__in=ci_lead_codes).values(

--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -427,7 +427,7 @@ class InterestGroupAPI(APIView):
             ).first()
 
             if ig_campus_lead_role:
-                ig_campus_lead_role.title = ig_new_code + " CampusLead"
+                ig_campus_lead_role.title = RoleType.IG_CAMPUS_LEAD_ROLE(ig_new_code)
                 ig_campus_lead_role.description = (
                     ig_new_name + " Interest Group Campus Lead"
                 )

--- a/api/dashboard/ig/dash_ig_view.py
+++ b/api/dashboard/ig/dash_ig_view.py
@@ -5,6 +5,7 @@ from rest_framework.views import APIView
 from django.db import transaction
 from db.task import InterestGroup
 from db.user import User, Role
+from db.campus import CampusExecomRole
 from utils.permission import CustomizePermission
 from utils.permission import JWTUtils, role_required
 from utils.response import CustomResponse
@@ -432,6 +433,42 @@ class InterestGroupAPI(APIView):
                     ig_new_name + " Interest Group Campus Lead"
                 )
                 ig_campus_lead_role.save()
+
+            # Co-Lead is a peer role to Campus Lead above and must be renamed the same way —
+            # otherwise its holder is silently orphaned under the old code (see PR history).
+            ig_campus_colead_role = Role.objects.filter(
+                title=RoleType.IG_CAMPUS_COLEAD_ROLE(ig_old_code)
+            ).first()
+
+            if ig_campus_colead_role:
+                ig_campus_colead_role.title = RoleType.IG_CAMPUS_COLEAD_ROLE(ig_new_code)
+                ig_campus_colead_role.description = (
+                    ig_new_name + " Interest Group Campus Co-Lead"
+                )
+                ig_campus_colead_role.save()
+
+            # The campus_execom_role catalog is a separate, decoupled directory (no FK to
+            # `Role`) that also stores these code-derived titles for the campus dashboard's
+            # role picker. Keep it in sync too, or the old-code titles linger there forever
+            # and leak into every campus's assignable-role list as if they were generic roles.
+            for old_title, new_title in (
+                (RoleType.IG_CAMPUS_LEAD_ROLE(ig_old_code), RoleType.IG_CAMPUS_LEAD_ROLE(ig_new_code)),
+                (RoleType.IG_CAMPUS_COLEAD_ROLE(ig_old_code), RoleType.IG_CAMPUS_COLEAD_ROLE(ig_new_code)),
+            ):
+                if old_title == new_title:
+                    continue
+                catalog_row = CampusExecomRole.objects.filter(title__iexact=old_title).first()
+                if catalog_row is None:
+                    continue
+                if CampusExecomRole.objects.filter(title__iexact=new_title).exclude(pk=catalog_row.pk).exists():
+                    # A row for the new-code title already exists (shouldn't normally
+                    # happen) — drop the stale old-code row instead of violating the
+                    # catalog's unique constraint on title.
+                    catalog_row.delete()
+                    continue
+                catalog_row.title = new_title
+                catalog_row.updated_by_id = user_id
+                catalog_row.save()
 
             ig_lead_role = Role.objects.filter(
                 title=RoleType.IG_LEAD_ROLE(ig_old_code)

--- a/db/campus.py
+++ b/db/campus.py
@@ -17,6 +17,8 @@ class CampusIGChapter(models.Model):
     ig = models.ForeignKey(InterestGroup, on_delete=models.CASCADE, related_name='campus_ig_chapter_ig')
     lead = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column='lead_id',
                              related_name='campus_ig_chapter_lead', blank=True, null=True)
+    co_lead = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID), db_column='co_lead_id',
+                                related_name='campus_ig_chapter_co_lead', blank=True, null=True)
     description = models.TextField(blank=True, null=True)
     icon_link = models.URLField(max_length=500, blank=True, null=True)
     is_active = models.BooleanField(default=True)
@@ -50,18 +52,22 @@ class CampusSocialLink(models.Model):
 
 
 class CampusExecomRole(models.Model):
-    id         = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
-    org        = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='campus_execom_roles')
-    role       = models.ForeignKey('db.Role', on_delete=models.CASCADE, related_name='campus_execom_role_links')
-    is_active  = models.BooleanField(default=True)
-    created_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
-                                   db_column='created_by', related_name='campus_execom_role_created_by')
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_by = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
-                                   db_column='updated_by', related_name='campus_execom_role_updated_by')
-    updated_at = models.DateTimeField(auto_now=True)
+    """Global, campus-agnostic catalog of execom role titles, reusable across all campuses.
+
+    Deliberately has no FK to Organization or the global Role table — a title here is just a
+    reusable name in the directory; the corresponding system Role (used by UserRoleLink) is
+    resolved/created independently at assignment time.
+    """
+    id          = models.CharField(primary_key=True, max_length=36, default=uuid.uuid4)
+    title       = models.CharField(max_length=75, unique=True)
+    description = models.CharField(max_length=300, blank=True, null=True)
+    created_by  = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+                                    db_column='created_by', related_name='campus_execom_role_created_by')
+    created_at  = models.DateTimeField(auto_now_add=True)
+    updated_by  = models.ForeignKey(User, on_delete=models.SET(settings.SYSTEM_ADMIN_ID),
+                                    db_column='updated_by', related_name='campus_execom_role_updated_by')
+    updated_at  = models.DateTimeField(auto_now=True)
 
     class Meta:
         managed = False
         db_table = 'campus_execom_role'
-        unique_together = [('org', 'role')]

--- a/utils/types.py
+++ b/utils/types.py
@@ -51,7 +51,11 @@ class RoleType(Enum):
 
     @classmethod
     def IG_CAMPUS_LEAD_ROLE(cls, ig_code: str):
-        return f"{ig_code} CampusLead"
+        return f"{ig_code} CampusIGLead"
+
+    @classmethod
+    def IG_CAMPUS_COLEAD_ROLE(cls, ig_code: str):
+        return f"{ig_code} CampusIGCoLead"
 
     @classmethod
     def IG_LEAD_ROLE(cls, ig_code: str):


### PR DESCRIPTION
## Summary
- Turns `campus_execom_role` from a per-campus join table into a global,
  reusable role directory (no more duplicate "Event Coordinator" per campus).
- Adds a Co-Lead role per Interest Group chapter (`CampusIGChapter.co_lead`),
  alongside the existing Lead, assigned through the same generic role flow.
- Renames the per-IG lead title from `"{code} CampusLead"` to
  `"{code} CampusIGLead"` to stop it being confused with the platform-wide
  `"{code} IGLead"` role, which grants edit rights on the Interest Group
  itself and must never be assignable from a campus's roster.
- Closes two leaks in the roles picker: another campus's IG-specific roles
  no longer show up, and neither does `"{code} IGLead"` or `"Campus Lead"`
  (both have their own dedicated, safer assignment paths).
- `alter-1.91.sql` handles both a fresh install and the existing dev DB's
  legacy shape idempotently, including a clearly-flagged destructive step
  that removes unused execom `Role` rows.

## Test plan
- [ ] `GET /api/v1/dashboard/campus/execom/roles/` for two campuses with
      different active IGs — confirm no cross-campus IG leakage, and that
      `Campus Lead` / `{code} IGLead` never appear.
- [ ] `POST .../execom/roles/` with the same title (different casing) from
      two different campuses — confirm the second call reuses the same row.
- [ ] `POST .../execom/` with an uncatalogued title, with `"Campus Lead"`,
      and with a valid `"{code} CampusIGCoLead"` — confirm reject / reject /
      success + `CampusIGChapter.co_lead` set respectively.
- [ ] Create a new IG chapter — confirm its `CampusIGLead`/`CampusIGCoLead`
      titles appear in the directory immediately.
